### PR TITLE
exp: add the barrier in the producer-consumer experiment script generation

### DIFF
--- a/run/flux/gen.sh
+++ b/run/flux/gen.sh
@@ -4,6 +4,7 @@
 tasks_per_node=1
 max_iters_per_node=4
 num_files_per_iter=16
+barrier=barrier
 
 
 . ./absolute_path.sh
@@ -70,6 +71,7 @@ do
               | sed -e 's/@NODES@/'$n'/g' \
               | sed -e 's/@TOTAL_TASKS@/'${total_tasks}'/g' \
               | sed -e 's/@DYAD_INSTALL_PATH@/'${DYAD_PATH_STRING}'/g' \
+              | sed -e 's/@EXT_BARRIER@/'${barrier}'/g' \
               > ${odir}/separate_steps.${n}.sh
 
 


### PR DESCRIPTION
In the script that generates job scripts for experimenting producer-consumer patterns, a barrier is used before starting any of producer and consumer such that they all can start at the same time regardless of the scheduler delay. This is to help obtain better measurements.