### PR TITLE
Wrapper: automatically detect if the file access sync need

### DIFF
--- a/src/wrapper/wrapper.c
+++ b/src/wrapper/wrapper.c
@@ -721,8 +721,9 @@ real_call:; // semicolon here to avoid the error
 
     int wronly = is_wronly (fd);
 
-    if (wronly == -1)
+    if (wronly == -1) {
         DPRINTF ("Failed to check the mode of the file with fcntl: %s\n", strerror (errno));
+    }
 
     if (to_sync && wronly == 1) {
         rc = func_ptr (fd);
@@ -797,8 +798,9 @@ real_call:;
 
     int wronly = is_wronly (fd);
 
-    if (wronly == -1)
+    if (wronly == -1) {
         DPRINTF ("Failed to check the mode of the file with fcntl: %s\n", strerror (errno));
+    }
 
 
     if (to_sync && wronly == 1) {

--- a/src/wrapper/wrapper.c
+++ b/src/wrapper/wrapper.c
@@ -90,6 +90,11 @@ int sync_directory (const char* path);
  *                                                                           *
  *****************************************************************************/
 
+static inline bool is_wronly (int fd)
+{
+  return (O_WRONLY == fcntl(fd, F_GETFL) & O_ACCMODE);
+}
+
 static inline bool is_dyad_producer ()
 {
     char *e = NULL;
@@ -390,11 +395,9 @@ static int dyad_open_sync (const char* __restrict__ path,
                            const char* __restrict__ user_path)
 {
     int rc = 0;
-    if (is_dyad_consumer ()) {
-        ctx->reenter = false;
-        rc = subscribe_via_flux (dyad_path, user_path);
-        ctx->reenter = true;
-    }
+    ctx->reenter = false;
+    rc = subscribe_via_flux (dyad_path, user_path);
+    ctx->reenter = true;
     return rc;
 }
 
@@ -403,11 +406,9 @@ static int dyad_close_sync (const char* __restrict__ path,
                             const char* __restrict__ user_path)
 {
     int rc = 0;
-    if (is_dyad_producer ()) {
-        ctx->reenter = false;
-        rc = publish_via_flux (dyad_path, user_path);
-        ctx->reenter = true;
-    }
+    ctx->reenter = false;
+    rc = publish_via_flux (dyad_path, user_path);
+    ctx->reenter = true;
     return rc;
 }
 
@@ -418,11 +419,7 @@ int open_sync (const char *path)
     char upath [PATH_MAX] = {'\0'}; // path with the dyad_path prefix removed
 
     if (!(dyad_path = getenv (DYAD_PATH_CONS_ENV))) {
-        if ((dyad_path = getenv (DYAD_PATH_PROD_ENV))) {
-            IPRINTF ("DYAD_SYNC OPEN: no need to sync producer open (\"%s\")\n", path);
-        } else {
-            IPRINTF ("DYAD_SYNC OPEN not enabled for \"%s\".\n", path);
-        }
+        IPRINTF ("DYAD_SYNC OPEN not enabled. Opening \"%s\".\n", path);
         goto done;
     }
 
@@ -431,7 +428,6 @@ int open_sync (const char *path)
     } else {
         IPRINTF ("DYAD_SYNC OPEN: %s is not a prefix of %s.\n", \
                  dyad_path, path);
-        rc = 0;
     }
 
 done:
@@ -442,17 +438,12 @@ done:
 
 int close_sync (const char *path)
 {
-    int rc = -1;
+    int rc = 0;
     const char *dyad_path = NULL;
     char upath [PATH_MAX] = {'\0'};
 
     if (!(dyad_path = getenv (DYAD_PATH_PROD_ENV))) {
-        rc = 0;
-        if ((dyad_path = getenv (DYAD_PATH_CONS_ENV))) {
-            IPRINTF ("DYAD_SYNC CLOSE: no need to sync consumer close (\"%s\")\n", path);
-        } else {
-            IPRINTF ("DYAD_SYNC CLOSE not enabled for \"%s\".\n", path);
-        }
+        IPRINTF ("DYAD_SYNC CLOSE not enabled. Closing \"%s\".\n", path);
         goto done;
     }
 
@@ -461,7 +452,6 @@ int close_sync (const char *path)
     } else {
         IPRINTF ("DYAD_SYNC CLOSE: %s is not a prefix of %s.\n", \
                  dyad_path, path);
-        rc = 0;
     }
 
 done:
@@ -592,6 +582,15 @@ int open (const char *path, int oflag, ...)
     char *error = NULL;
     typedef int (*open_ptr_t) (const char *, int, mode_t, ...);
     open_ptr_t func_ptr = NULL;
+    int mode = 0;
+
+    if (oflag & O_CREAT)
+    {
+        va_list arg;
+        va_start (arg, oflag);
+        mode = va_arg (arg, int);
+        va_end (arg);
+    }
 
     func_ptr = (open_ptr_t) dlsym (RTLD_NEXT, "open");
     if ((error = dlerror ())) {
@@ -599,7 +598,7 @@ int open (const char *path, int oflag, ...)
         return -1;
     }
 
-    if (is_path_dir (path)) {
+    if ((mode != O_RDONLY) || is_path_dir (path)) {
         // TODO: make sure if the directory mode is consistent
         goto real_call;
     }
@@ -617,15 +616,7 @@ int open (const char *path, int oflag, ...)
     IPRINTF ("DYAD_SYNC: exists open sync (\"%s\").\n", path);
 
 real_call:;
-    int mode = 0;
 
-    if (oflag & O_CREAT)
-    {
-        va_list arg;
-        va_start (arg, oflag);
-        mode = va_arg (arg, int);
-        va_end (arg);
-    }
     return (func_ptr (path, oflag, mode));
 }
 
@@ -641,7 +632,7 @@ FILE *fopen (const char *path, const char *mode)
         return NULL;
     }
 
-    if (is_path_dir (path)) {
+    if ((strcmp (mode, "r") != 0) || is_path_dir (path)) {
         // TODO: make sure if the directory mode is consistent
         goto real_call;
     }
@@ -715,9 +706,9 @@ real_call:; // semicolon here to avoid the error
     }
   #endif // DYAD_SYNC_DIR
 
-    rc = func_ptr (fd);
 
-    if (to_sync) {
+    if (to_sync && is_wronly (fd)) {
+        rc = func_ptr (fd);
         if (rc != 0) {
             DPRINTF ("Failed close (\"%s\").: %s\n", path, strerror (errno));
         }
@@ -726,6 +717,8 @@ real_call:; // semicolon here to avoid the error
             DPRINTF ("DYAD_SYNC: failed close sync (\"%s\").\n", path);
         }
         IPRINTF ("DYAD_SYNC: exits close sync (\"%s\").\n", path);
+    } else {
+        rc = func_ptr (fd);
     }
 
     return rc;
@@ -739,6 +732,7 @@ int fclose (FILE *fp)
     fclose_ptr_t func_ptr = NULL;
     char path [PATH_MAX+1] = {'\0'};
     int rc = 0;
+    int fd = 0;
 
     func_ptr = (fclose_ptr_t) dlsym (RTLD_NEXT, "fclose");
     if ((error = dlerror ())) {
@@ -775,7 +769,8 @@ int fclose (FILE *fp)
 
 real_call:;
     fflush (fp);
-    fsync (fileno (fp));
+    fd = fileno (fp);
+    fsync (fd);
 
   #if DYAD_SYNC_DIR
     if (to_sync) {
@@ -783,9 +778,9 @@ real_call:;
     }
   #endif // DYAD_SYNC_DIR
 
-    rc = func_ptr (fp);
 
-    if (to_sync) {
+    if (to_sync && is_wronly (fd)) {
+        rc = func_ptr (fp);
         if (rc != 0) {
             DPRINTF ("Failed fclose (\"%s\").\n", path);
         }
@@ -794,6 +789,8 @@ real_call:;
             DPRINTF ("DYAD_SYNC: failed fclose sync (\"%s\").\n", path);
         }
         IPRINTF ("DYAD_SYNC: exits fclose sync (\"%s\").\n", path);
+    } else {
+        rc = func_ptr (fp);
     }
 
     return rc;


### PR DESCRIPTION
DYAD currently detects the synchronization need by environment variable.
Users need to set appropriate variable to tell DYAD I/O interceptor which file access to synchronize. However, this has a limitation as a process can open multiple files with different modes. A consumer can be a producer at the same time, and vice versa. This PR removes the need for environment variable. For a file about to be closed, it utilizes the system call `fcntl()` to detect if a file has been open in the write mode. For a file about to be opened, the mode argument can be checked easily. This addresses issue #10 