### PR TITLE
Fixes the includes in the C++ demo code

### DIFF
--- a/docs/demos/ecp_feb_2023/cons.cpp
+++ b/docs/demos/ecp_feb_2023/cons.cpp
@@ -1,11 +1,10 @@
-#include <sys/stat.h>
+#include "generation.h"
 
 #include <dyad_stream_api.hpp>
 #include <fstream>
 #include <iostream>
 #include <string>
-
-#include "generation.h"
+#include <cstring> // For memset
 
 /**
  * Transfer the specified file with DYAD and read it

--- a/docs/demos/ecp_feb_2023/prod.cpp
+++ b/docs/demos/ecp_feb_2023/prod.cpp
@@ -1,11 +1,10 @@
-#include <sys/stat.h>
+#include "generation.h"
 
 #include <dyad_stream_api.hpp>
 #include <fstream>
 #include <iostream>
 #include <string>
-
-#include "generation.h"
+#include <cstring> // For memset
 
 /**
  * Write the spcified file and record it in for transfer with DYAD


### PR DESCRIPTION
There was a small mistake in the C++ demo code that would cause `memcpy` to not be found with some implementations of the C++ Standard Library. This PR fixes that by adding `#include <cstring>`