### PR TITLE
Wrapper name change

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -110,7 +110,7 @@ simply adding the following before the shell command that launches their applica
 
 .. code-block:: shell
 
-   $ LD_PRELOAD=path/to/libdyad_sync.so
+   $ LD_PRELOAD=path/to/dyad_wrapper.so
 
 Once preloaded, DYAD's C API will intercept the :code:`open` and :code:`fopen` functions when consuming
 files and the :code:`close` and :code:`fclose` functions when producing files. As a result,

--- a/dyadrun.in
+++ b/dyadrun.in
@@ -166,12 +166,12 @@ fi
 if test $should_preload -ne 0; then
     lib_dir_opts=""
     if test ! -z $DYAD_ROOT; then
-        lib_dir_opts="$lib_dir_opts $DYAD_ROOT/lib/libdyad_sync.so"
+        lib_dir_opts="$lib_dir_opts $DYAD_ROOT/lib/dyad_wrapper.so"
     fi
     if test ! -z $DYAD_LIBRARYDIR; then
-        lib_dir_opts="$lib_dir_opts $DYAD_LIBRARYDIR/libdyad_sync.so"
+        lib_dir_opts="$lib_dir_opts $DYAD_LIBRARYDIR/dyad_wrapper.so"
     fi
-    lib_dir_opts="$lib_dir_opts $DYAD_INSTALL_LIB/libdyad_sync.so"
+    lib_dir_opts="$lib_dir_opts $DYAD_INSTALL_LIB/dyad_wrapper.so"
     preload_found=0
     for ldir in $lib_dir_opts; do
         if test -f $ldir; then
@@ -181,7 +181,7 @@ if test $should_preload -ne 0; then
         fi
     done
     if test $preload_found -ne 1; then
-        echo "ERROR: Could not find libdyad_sync.so!"
+        echo "ERROR: Could not find dyad_wrapper.so!"
         echo "       Checked the following locations: $lib_dir_opts"
         exit -1
     fi

--- a/run/flux/gen.sh
+++ b/run/flux/gen.sh
@@ -90,7 +90,7 @@ do
       cp -RP ${DYAD_MOD_PATH} .
       pushd $(basename ${DYAD_MOD_PATH}) > /dev/null
       ln -sfn ${DYAD_INSTALL_PATH}/src/modules/dyad.so dyad.so
-      ln -sfn ${DYAD_INSTALL_PATH}/src/wrapper/libdyad_sync.so
+      ln -sfn ${DYAD_INSTALL_PATH}/src/wrapper/dyad_wrapper.so
       popd > /dev/null
 
       cp -RP ${DYAD_APP_PATH} .

--- a/run/flux/separate_steps.template.sh
+++ b/run/flux/separate_steps.template.sh
@@ -52,7 +52,7 @@ do
     export DYAD_ARGS_PARSER_PATH=${SPECROOT}/user_apps/args.sh
     ${LAUNCHER} ${SPECROOT}/user_apps/step_prod${ext_barrier}.sh \
                 --workspace ${WORKSPACE} --specroot ${SPECROOT} \
-                --wpath ${DYAD_INSTALL_PATH}/src/wrapper/libdyad_sync.so \
+                --wpath ${DYAD_INSTALL_PATH}/src/wrapper/dyad_wrapper.so \
                 --kvs_namespace ${KVS_NS} --context ${CONTEXT} \
                 --depth ${DYAD_KVS_DEPTH} --bins ${DYAD_KVS_BINS} \
                 --sync ${SYNC} ${SHARED_FS} --iter ${ITER} \
@@ -67,7 +67,7 @@ do
     export DYAD_ARGS_PARSER_PATH=${SPECROOT}/user_apps/args.sh
     ${LAUNCHER} ${SPECROOT}/user_apps/step_cons${ext_barrier}.sh \
                 --workspace ${WORKSPACE} --specroot ${SPECROOT} \
-                --wpath ${DYAD_INSTALL_PATH}/src/wrapper/libdyad_sync.so \
+                --wpath ${DYAD_INSTALL_PATH}/src/wrapper/dyad_wrapper.so \
                 --kvs_namespace ${KVS_NS} --context ${CONTEXT} \
                 --depth ${DYAD_KVS_DEPTH} --bins ${DYAD_KVS_BINS} \
                 --sync ${SYNC} ${SHARED_FS} --iter ${ITER} \

--- a/run/merlin/separate_steps.yaml
+++ b/run/merlin/separate_steps.yaml
@@ -55,7 +55,7 @@ study:
       date +"%T.%3N" >> $(WORKSPACE)/time.$(CONTEXT).txt
       $(LAUNCHER) $(SPECROOT)/user_apps/step_prod.sh \
                   --workspace $(WORKSPACE) --specroot $(SPECROOT) \
-                  --wpath $(DYAD_INSTALL_PATH)/src/wrapper/libdyad_sync.so \
+                  --wpath $(DYAD_INSTALL_PATH)/src/wrapper/dyad_wrapper.so \
                   --kvs_namespace $(KVS_NS) --context $(CONTEXT) \
                   --depth $(DYAD_KVS_DEPTH) --bins $(DYAD_KVS_BINS) \
                   --sync $(SYNC) --iter $(ITER) \
@@ -86,7 +86,7 @@ study:
       date +"%T.%3N" >> $(WORKSPACE)/time.$(CONTEXT).txt
       $(LAUNCHER) $(SPECROOT)/user_apps/step_cons.sh \
                   --workspace $(WORKSPACE) --specroot $(SPECROOT) \
-                  --wpath $(DYAD_INSTALL_PATH)/src/wrapper/libdyad_sync.so \
+                  --wpath $(DYAD_INSTALL_PATH)/src/wrapper/dyad_wrapper.so \
                   --kvs_namespace $(KVS_NS) --context $(CONTEXT) \
                   --depth $(DYAD_KVS_DEPTH) --bins $(DYAD_KVS_BINS) \
                   --sync $(SYNC) --iter $(ITER) \

--- a/run/merlin/single_step.yaml
+++ b/run/merlin/single_step.yaml
@@ -56,7 +56,7 @@ study:
       date +"%T.%3N" >> $(WORKSPACE)/time.$(CONTEXT).txt
       $(LAUNCHER) $(SPECROOT)/user_apps/single_step.sh \
                   --workspace $(WORKSPACE) --specroot $(SPECROOT) \
-                  --wpath $(DYAD_INSTALL_PATH)/src/wrapper/libdyad_sync.so \
+                  --wpath $(DYAD_INSTALL_PATH)/src/wrapper/dyad_wrapper.so \
                   --kvs_namespace $(KVS_NS) --context $(CONTEXT) \
                   --depth $(DYAD_KVS_DEPTH) --bins $(DYAD_KVS_BINS) \
                   --sync $(SYNC) --iter $(ITER) \

--- a/run/merlin/templates/gen.sh
+++ b/run/merlin/templates/gen.sh
@@ -82,7 +82,7 @@ do
       cp -RP ${DYAD_MOD_PATH} .
       pushd $(basename ${DYAD_MOD_PATH}) > /dev/null
       ln -sfn ${DYAD_INSTALL_PATH}/src/modules/dyad.so dyad.so
-      ln -sfn ${DYAD_INSTALL_PATH}/src/wrapper/libdyad_sync.so libdyad_sync.so
+      ln -sfn ${DYAD_INSTALL_PATH}/src/wrapper/dyad_wrapper.so dyad_wrapper.so
       popd > /dev/null
 
       cp -RP ${DYAD_APP_PATH} .
@@ -126,7 +126,7 @@ do
       cp -RP ${DYAD_MOD_PATH} .
       pushd $(basename ${DYAD_MOD_PATH}) > /dev/null
       ln -sfn ${DYAD_INSTALL_PATH}/src/modules/dyad.so dyad.so
-      ln -sfn ${DYAD_INSTALL_PATH}/src/wrapper/libdyad_sync.so
+      ln -sfn ${DYAD_INSTALL_PATH}/src/wrapper/dyad_wrapper.so
       popd > /dev/null
 
       cp -RP ${DYAD_APP_PATH} .

--- a/run/merlin/templates/separate_steps.template.yaml
+++ b/run/merlin/templates/separate_steps.template.yaml
@@ -65,7 +65,7 @@ study:
       date +"%T.%3N" >> $(WORKSPACE)/time.$(CONTEXT).txt
       $(LAUNCHER) $(SPECROOT)/user_apps/step_prod.sh \
                   --workspace $(WORKSPACE) --specroot $(SPECROOT) \
-                  --wpath $(DYAD_INSTALL_PATH)/src/wrapper/libdyad_sync.so \
+                  --wpath $(DYAD_INSTALL_PATH)/src/wrapper/dyad_wrapper.so \
                   --kvs_namespace $(KVS_NS) --context $(CONTEXT) \
                   --depth $(DYAD_KVS_DEPTH) --bins $(DYAD_KVS_BINS) \
                   --sync $(SYNC) $(SHARED_FS) --iter $(ITER) \
@@ -97,7 +97,7 @@ study:
       date +"%T.%3N" >> $(WORKSPACE)/time.$(CONTEXT).txt
       $(LAUNCHER) $(SPECROOT)/user_apps/step_cons.sh \
                   --workspace $(WORKSPACE) --specroot $(SPECROOT) \
-                  --wpath $(DYAD_INSTALL_PATH)/src/wrapper/libdyad_sync.so \
+                  --wpath $(DYAD_INSTALL_PATH)/src/wrapper/dyad_wrapper.so \
                   --kvs_namespace $(KVS_NS) --context $(CONTEXT) \
                   --depth $(DYAD_KVS_DEPTH) --bins $(DYAD_KVS_BINS) \
                   --sync $(SYNC) $(SHARED_FS) --iter $(ITER) \

--- a/run/user_apps/args.sh
+++ b/run/user_apps/args.sh
@@ -361,7 +361,7 @@ fi
 
 # Set dyad wrapper path
 if [ "${DYAD_WRAPPER}" == "" ] ; then
-    DYAD_WRAPPER=${SPECROOT}/dyad/libdyad_sync.so
+    DYAD_WRAPPER=${SPECROOT}/dyad/dyad_wrapper.so
 fi
 
 # Set dyad module path

--- a/src/stream/test/args.sh
+++ b/src/stream/test/args.sh
@@ -268,7 +268,7 @@ done
 
 # Set dyad wrapper path
 #if [ "${DYAD_WRAPPER}" == "" ] ; then
-#    DYAD_WRAPPER=../libdyad_sync.so
+#    DYAD_WRAPPER=../dyad_wrapper.so
 #fi
 
 # Set dyad module path

--- a/src/wrapper/Makefile.am
+++ b/src/wrapper/Makefile.am
@@ -1,15 +1,15 @@
-lib_LTLIBRARIES = libdyad_sync.la
-libdyad_sync_la_SOURCES = wrapper.c
-libdyad_sync_la_LDFLAGS = $(AM_LDFLAGS) -avoid-version -no-undefined -shared
-libdyad_sync_la_LIBADD = $(top_builddir)/src/core/libdyad_core.la
-libdyad_sync_la_CPPFLAGS = -I$(top_builddir)/src/utils -I$(top_builddir)/src/core $(FLUX_CORE_CFLAGS)
+lib_LTLIBRARIES = dyad_wrapper.la
+dyad_wrapper_la_SOURCES = wrapper.c
+dyad_wrapper_la_LDFLAGS = $(AM_LDFLAGS) -module -avoid-version -no-undefined -shared
+dyad_wrapper_la_LIBADD = $(top_builddir)/src/core/libdyad_core.la
+dyad_wrapper_la_CPPFLAGS = -I$(top_builddir)/src/utils -I$(top_builddir)/src/core $(FLUX_CORE_CFLAGS)
 
 install-exec-hook:
-	@(cd $(DESTDIR)$(libdir) && $(RM) libdyad_sync.la)
+	@(cd $(DESTDIR)$(libdir) && $(RM) dyad_wrapper.la)
 
 # if PERFFLOW
-# libdyad_sync_la_LIBADD += $(PERFFLOW_LIBS)
-# libdyad_sync_la_CPPFLAGS += $(PERFFLOW_PLUGIN_CPPFLAGS) $(PERFFLOW_CFLAGS) -DDYAD_PERFFLOW=1
+# dyad_wrapper_la_LIBADD += $(PERFFLOW_LIBS)
+# dyad_wrapper_la_CPPFLAGS += $(PERFFLOW_PLUGIN_CPPFLAGS) $(PERFFLOW_CFLAGS) -DDYAD_PERFFLOW=1
 # endif
 
 bin_PROGRAMS = flux_barrier

--- a/src/wrapper/README.md
+++ b/src/wrapper/README.md
@@ -6,7 +6,7 @@ DYAD component to intercept file open/close calls and synchronize producers and 
 Build and install flux-core. Please see https://github.com/flux-framework/flux-core.
  
 
-#### To build `libdyad_sync.so`:
+#### To build `dyad_wrapper.so`:
 
 ```
 export PKG_CONFIG_PATH=<FLUX_INSTALL_ROOT>/lib/pkgconfig
@@ -40,8 +40,8 @@ This will create a new shell in which you can communicate with the instance.
 
 
 ```
-LD_PRELOAD=<path to libdyad_sync.so> DYAD_SYNC_CHECK=1 consumer_test &
-LD_PRELOAD=<path to libdyad_sync.so> DYAD_SYNC_CHECK=1 producer_test
+LD_PRELOAD=<path to dyad_wrapper.so> DYAD_SYNC_CHECK=1 consumer_test &
+LD_PRELOAD=<path to dyad_wrapper.so> DYAD_SYNC_CHECK=1 producer_test
 ```
 
 To enable debug trace for DYAD synchronizer, set the `DYAD_SYNC_DEBUG` environment variable to 1 as well.

--- a/src/wrapper/test/args.sh
+++ b/src/wrapper/test/args.sh
@@ -316,7 +316,7 @@ done
 
 # Set dyad wrapper path
 if [ "${DYAD_WRAPPER}" == "" ] ; then
-    DYAD_WRAPPER=../libdyad_sync.so
+    DYAD_WRAPPER=../dyad_wrapper.so
 fi
 
 # Set dyad module path


### PR DESCRIPTION
Changing `libdyad_sync.so` to `dyad_wrapper.so`
This is basedon PR #22. Once it is merged, I will rebase this. That will leave only the change relevant to this visible.
TODO: Make sure the ECP tutorial uses the version it was created with using git tag