### PR TITLE
Hotfix: updates build system to prevent excessive symbol exports

### DIFF
--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -2,6 +2,7 @@ lib_LTLIBRARIES = libdyad_core.la
 libdyad_core_la_SOURCES = dyad_core.c
 libdyad_core_la_LIBADD = $(top_builddir)/src/utils/libutils.la $(top_builddir)/src/utils/libmurmur3.la $(FLUX_CORE_LIBS)
 libdyad_core_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_builddir)/src/utils $(FLUX_CORE_CFLAGS)
+libdyad_core_la_LDFLAGS = -export-symbols dyad_core.sym $(AM_LDFLAGS)
 if PERFFLOW
 libdyad_core_la_LIBADD += $(PERFFLOW_LIBS)
 libdyad_core_la_CPPFLAGS += $(PERFFLOW_PLUGIN_CPPFLAGS) $(PERFFLOW_CFLAGS) -DDYAD_PERFFLOW=1

--- a/src/core/dyad_core.sym
+++ b/src/core/dyad_core.sym
@@ -1,0 +1,7 @@
+dyad_init
+dyad_init_env
+dyad_consume
+dyad_produce
+dyad_finalize
+dyad_ctx_default
+

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -1,6 +1,11 @@
 lib_LTLIBRARIES = dyad.la
 dyad_la_SOURCES = dyad.c read_all.c dyad_ctx.h read_all.h
-dyad_la_LDFLAGS = $(AM_LDFLAGS) -module -avoid-version -no-undefined
+dyad_la_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	-module \
+	-avoid-version \
+	-no-undefined \
+	-export-symbols-regex '^mod_(name|main)$$'
 dyad_la_LIBADD = $(top_builddir)/src/utils/libutils.la $(FLUX_CORE_LIBS)
 dyad_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_builddir)/src/utils $(FLUX_CORE_CFLAGS)
 if PERFFLOW

--- a/src/wrapper/Makefile.am
+++ b/src/wrapper/Makefile.am
@@ -1,7 +1,16 @@
 lib_LTLIBRARIES = dyad_wrapper.la
 dyad_wrapper_la_SOURCES = wrapper.c
-dyad_wrapper_la_LDFLAGS = $(AM_LDFLAGS) -module -avoid-version -no-undefined -shared
-dyad_wrapper_la_LIBADD = $(top_builddir)/src/core/libdyad_core.la
+dyad_wrapper_la_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	-module \
+	-avoid-version \
+	-no-undefined \
+	-shared \
+	-export-symbols wrapper.sym
+dyad_wrapper_la_LIBADD = \
+	$(top_builddir)/src/core/libdyad_core.la \
+	# Need to add libutils.la now that libdyad_core is not exporting utils' symbols
+	$(top_builddir)/src/utils/libutils.la
 dyad_wrapper_la_CPPFLAGS = -I$(top_builddir)/src/utils -I$(top_builddir)/src/core $(FLUX_CORE_CFLAGS)
 
 install-exec-hook:

--- a/src/wrapper/wrapper.c
+++ b/src/wrapper/wrapper.c
@@ -46,7 +46,7 @@ using namespace std;  // std::clock ()
 extern "C" {
 #endif
 
-__thread dyad_ctx_t *ctx = NULL;
+static __thread dyad_ctx_t *ctx = NULL;
 // static void dyad_wrapper_init (void) __attribute__((constructor));
 static void dyad_wrapper_fini (void) __attribute__ ((destructor));
 

--- a/src/wrapper/wrapper.sym
+++ b/src/wrapper/wrapper.sym
@@ -1,0 +1,5 @@
+open
+fopen
+close
+fclose
+


### PR DESCRIPTION
DYAD's various libraries were previously exporting a lot of symbols that were not supposed to be exported. This PR fixes this using libtool's `-export-symbols` and `-export-symbols-regex` flags.