### PR TITLE
Adds a dedicated Python API

### DIFF
--- a/.github/prod-cons/dyad_consumer.sh
+++ b/.github/prod-cons/dyad_consumer.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 
+this_script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+source $this_script_dir/prod_cons_argparse.sh
+
 export DYAD_PATH_CONSUMER=${DYAD_PATH}_consumer
 mkdir -p ${DYAD_PATH_CONSUMER}
 
-echo "Loading DYAD module"
-
-#flux module load ${DYAD_INSTALL_PREFIX}/lib/dyad.so  $DYAD_PATH_CONSUMER $DYAD_DTL_MODE
-${GITHUB_WORKSPACE}/docs/demos/ecp_feb_2023/cpp_cons 10 $DYAD_PATH_CONSUMER
+if [[ "$mode" == "${valid_modes[0]}" ]]; then
+    LD_PRELOAD=${DYAD_INSTALL_PREFIX}/lib/dyad_wrapper.so ${GITHUB_WORKSPACE}/docs/demos/ecp_feb_2023/c_cons 10 $DYAD_PATH_CONSUMER
+elif [[ "$mode" == "${valid_modes[1]}" ]]; then
+    ${GITHUB_WORKSPACE}/docs/demos/ecp_feb_2023/cpp_cons 10 $DYAD_PATH_CONSUMER
+elif [[ "$mode" == "${valid_modes[2]}" ]]; then
+    python3 ${GITHUB_WORKSPACE}/tests/pydyad_spsc/consumer.py $DYAD_PATH_CONSUMER 10 50
+else
+    echo "Invalid test mode: $mode"
+    exit 1
+fi

--- a/.github/prod-cons/dyad_prod_cons_test.sh
+++ b/.github/prod-cons/dyad_prod_cons_test.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
+
+this_script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+source $this_script_dir/prod_cons_argparse.sh
+
 echo "Creating namespace for DYAD"
 flux kvs namespace create ${DYAD_KVS_NAMESPACE}
 
 flux resource list
 
 echo "Running Consumer job"
-flux submit --nodes 1 --exclusive --env=DYAD_KVS_NAMESPACE=${DYAD_KVS_NAMESPACE} --env=DYAD_DTL_MODE=${DYAD_DTL_MODE} --env=DYAD_PATH_CONSUMER=$DYAD_PATH_CONSUMER ${GITHUB_WORKSPACE}/.github/prod-cons/dyad_consumer.sh
+# flux submit --nodes 1 --exclusive --env=DYAD_KVS_NAMESPACE=${DYAD_KVS_NAMESPACE} --env=DYAD_DTL_MODE=${DYAD_DTL_MODE} --env=DYAD_PATH_CONSUMER=$DYAD_PATH_CONSUMER ${GITHUB_WORKSPACE}/.github/prod-cons/dyad_consumer.sh $mode
+flux submit --nodes 1 --exclusive -t 10 --env=DYAD_KVS_NAMESPACE=${DYAD_KVS_NAMESPACE} --env=DYAD_DTL_MODE=${DYAD_DTL_MODE} ${GITHUB_WORKSPACE}/.github/prod-cons/dyad_consumer.sh $mode
 CONS_PID=$(flux job last)
 # Will block terminal until done
 echo "Running Producer job"
-flux submit --nodes 1 --exclusive --env=DYAD_KVS_NAMESPACE=${DYAD_KVS_NAMESPACE} --env=DYAD_DTL_MODE=${DYAD_DTL_MODE} --env=DYAD_PATH_PRODUCER=$DYAD_PATH_PRODUCER ${GITHUB_WORKSPACE}/.github/prod-cons/dyad_producer.sh
+# flux submit --nodes 1 --exclusive --env=DYAD_KVS_NAMESPACE=${DYAD_KVS_NAMESPACE} --env=DYAD_DTL_MODE=${DYAD_DTL_MODE} --env=DYAD_PATH_PRODUCER=$DYAD_PATH_PRODUCER ${GITHUB_WORKSPACE}/.github/prod-cons/dyad_producer.sh $mode
+flux submit --nodes 1 --exclusive -t 10 --env=DYAD_KVS_NAMESPACE=${DYAD_KVS_NAMESPACE} --env=DYAD_DTL_MODE=${DYAD_DTL_MODE} ${GITHUB_WORKSPACE}/.github/prod-cons/dyad_producer.sh $mode
 PROD_PID=$(flux job last)
 flux jobs -a
 flux job attach $PROD_PID

--- a/.github/prod-cons/dyad_producer.sh
+++ b/.github/prod-cons/dyad_producer.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+this_script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+source $this_script_dir/prod_cons_argparse.sh
+
 export DYAD_PATH_PRODUCER=${DYAD_PATH}_producer
 mkdir -p ${DYAD_PATH_PRODUCER}
 echo "Loading DYAD module"
@@ -7,5 +11,16 @@ echo "Loading DYAD module"
 echo flux module load ${DYAD_INSTALL_PREFIX}/lib/dyad.so  $DYAD_PATH_PRODUCER $DYAD_DTL_MODE
 flux module load ${DYAD_INSTALL_PREFIX}/lib/dyad.so  $DYAD_PATH_PRODUCER $DYAD_DTL_MODE
 
-echo ${GITHUB_WORKSPACE}/docs/demos/ecp_feb_2023/cpp_prod 10 $DYAD_PATH_PRODUCER
-${GITHUB_WORKSPACE}/docs/demos/ecp_feb_2023/cpp_prod 10 $DYAD_PATH_PRODUCER
+if [[ "$mode" == "${valid_modes[0]}" ]]; then
+    echo ${GITHUB_WORKSPACE}/docs/demos/ecp_feb_2023/c_prod 10 $DYAD_PATH_PRODUCER
+    LD_PRELOAD=${DYAD_INSTALL_PREFIX}/lib/dyad_wrapper.so ${GITHUB_WORKSPACE}/docs/demos/ecp_feb_2023/c_prod 10 $DYAD_PATH_PRODUCER
+elif [[ "$mode" == "${test_modes[1]}" ]]; then
+    echo ${GITHUB_WORKSPACE}/docs/demos/ecp_feb_2023/cpp_prod 10 $DYAD_PATH_PRODUCER
+    ${GITHUB_WORKSPACE}/docs/demos/ecp_feb_2023/cpp_prod 10 $DYAD_PATH_PRODUCER
+elif [[ "$mode" == "${test_modes[2]}" ]]; then
+    echo python3 ${GITHUB_WORKSPACE}/tests/pydyad_spsc/consumer.py $DYAD_PATH_PRODUCER 10 50
+    python3 ${GITHUB_WORKSPACE}/tests/pydyad_spsc/consumer.py $DYAD_PATH_PRODUCER 10 50
+else
+    echo "Invalid test mode: $mode"
+    exit 1
+fi

--- a/.github/prod-cons/prod_cons_argparse.sh
+++ b/.github/prod-cons/prod_cons_argparse.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+script_name="$0"
+
+if test "$#" -ne 1; then
+    echo "Invalid number of arguments to $script_name"
+    exit 1
+fi
+
+mode="$1"
+
+valid_modes=("c" "cpp" "python")
+mode_is_valid=0
+for vm in "${valid_modes[@]}"; do
+    if [[ $mode_is_valid -eq 1 ]] || [[ "$mode" == "$vm" ]]; then
+        mode_is_valid=1
+    else
+        mode_is_valid=0
+    fi
+done
+
+if [[ $mode_is_valid -eq 0 ]]; then
+    echo "Invalid mode: $mode"
+    exit 2
+fi

--- a/.github/workflows/compile_test.yaml
+++ b/.github/workflows/compile_test.yaml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         flux: [ 0.52.0, 0.49.0]
         mode: ["FLUX_RPC", "UCX"]
+        test_mode: ["c", "cpp", "python"]
     runs-on: ubuntu-20.04 # Docker-based jobs must run on Ubuntu
     env:
       FLUX_VERSION: ${{ matrix.flux }}
@@ -21,6 +22,7 @@ jobs:
       DYAD_KVS_NAMESPACE: "test"
       DYAD_DTL_MODE: ${{ matrix.mode }}
       DYAD_PATH: "/home/runner/work/dyad/temp"
+      DYAD_TEST_MODE: ${{ matrix.test_mode }}
     steps:
       - name: Push checkout
         if: github.event_name == 'push'
@@ -178,7 +180,7 @@ jobs:
                   prefix: /usr
           EOF
           spack external find
-          spack spec flux-core@${FLUX_VERSION} 
+          spack spec flux-core@${FLUX_VERSION}
           if [[ $DYAD_DTL_MODE == 'UCX' ]]; then
             spack spec ucx@1.13.1
           fi
@@ -190,7 +192,7 @@ jobs:
             spack install -j4 ucx@1.13.1
           fi
           mkdir -p ${DYAD_INSTALL_PREFIX}
-          spack view --verbose symlink ${DYAD_INSTALL_PREFIX} flux-core@${FLUX_VERSION} 
+          spack view --verbose symlink ${DYAD_INSTALL_PREFIX} flux-core@${FLUX_VERSION}
           if [[ $DYAD_DTL_MODE == 'UCX' ]]; then
             spack view --verbose symlink ${DYAD_INSTALL_PREFIX} ucx@1.13.1
           fi
@@ -213,7 +215,14 @@ jobs:
                       CXXFLAGS="-I${DYAD_INSTALL_PREFIX}/include" \
                       LDFLAGS="-L${DYAD_INSTALL_PREFIX}/lib"
           make install -j
+      - name: Install PyDYAD
+        if: ${{ matrix.test_mode == 'python' }}
+        run: |
+          cd ${GITHUB_WORKSPACE}/pydyad
+          python3 -m pip install -e .
+          cd ${GITHUB_WORKSPACE}
       - name: Install Test
+        if: ${{ matrix.test_mode == 'c' || matrix.test_mode == 'cpp' }}
         run: |
           . ${SPACK_DIR}/share/spack/setup-env.sh
           export CFLAGS="-I${DYAD_INSTALL_PREFIX}/include"
@@ -228,5 +237,5 @@ jobs:
           export PATH=${PATH}:${DYAD_INSTALL_PREFIX}/bin:${DYAD_INSTALL_PREFIX}/sbin
           export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${DYAD_INSTALL_PREFIX}/lib
           echo "Starting flux brokers"
-          flux start --test-size=2 /bin/bash ${GITHUB_WORKSPACE}/.github/prod-cons/dyad_prod_cons_test.sh
-          
+          flux start --test-size=2 /bin/bash ${GITHUB_WORKSPACE}/.github/prod-cons/dyad_prod_cons_test.sh ${DYAD_TEST_MODE}
+

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,8 @@ flux_barrier
 **/_build/
 
 **/bib/*.rst
+
+# Python stuff
+**/__pycache__/
+**/build
+**/*.egg-info

--- a/pydyad/pydyad/__init__.py
+++ b/pydyad/pydyad/__init__.py
@@ -1,0 +1,2 @@
+from pydyad.context import dyad_open
+from pydyad.bindings import Dyad

--- a/pydyad/pydyad/bindings.py
+++ b/pydyad/pydyad/bindings.py
@@ -1,0 +1,207 @@
+import ctypes
+import os
+from pathlib import Path
+import warnings
+
+from numpy.ctypeslib import load_library
+
+
+DYAD_LIB_DIR = None
+
+
+class FluxHandle(ctypes.Structure):
+    pass
+
+
+class DyadDTLHandle(ctypes.Structure):
+    pass
+
+
+class DyadCtxWrapper(ctypes.Structure):
+    _fields_ = [
+        ("h", ctypes.POINTER(FluxHandle)),
+        ("dtl_handle", ctypes.POINTER(DyadDTLHandle)),
+        ("debug", ctypes.c_bool),
+        ("check", ctypes.c_bool),
+        ("reenter", ctypes.c_bool),
+        ("initialized", ctypes.c_bool),
+        ("shared_storage", ctypes.c_bool),
+        ("sync_started", ctypes.c_bool),
+        ("key_depth", ctypes.c_uint),
+        ("key_bins", ctypes.c_uint),
+        ("rank", ctypes.c_uint32),
+        ("kvs_namespace", ctypes.c_char_p),
+        ("prod_managed_path", ctypes.c_char_p),
+        ("cons_managed_path", ctypes.c_char_p),
+    ]
+
+
+class Dyad:
+
+    def __init__(self):
+        self.dyad_core_lib = None
+        self.ctx = None
+        self.dyad_init = None
+        self.dyad_init_env = None
+        self.dyad_produce = None
+        self.dyad_consume = None
+        self.dyad_finalize = None
+        dyad_core_libpath = None
+        self.cons_path = None
+        self.prod_path = None
+        if DYAD_LIB_DIR is None:
+            if "LD_LIBRARY_PATH" not in os.environ:
+                raise EnvironmentError("Cannot find LD_LIBRARY_PATH in environment!")
+            for p in os.environ["LD_LIBRARY_PATH"].split(":"):
+                lib_path = Path(p).expanduser().resolve()
+                if len(list(lib_path.glob("libdyad_core.*"))) != 0:
+                    dyad_core_libpath = lib_path
+                    break
+            if dyad_core_libpath is None:
+                raise FileNotFoundError("Cannot find libdyad_core.so!")
+        else:
+            dyad_core_libpath = DYAD_LIB_DIR
+            if not isinstance(DYAD_LIB_DIR, Path):
+                dyad_core_libpath = Path(DYAD_LIB_DIR)
+            dyad_core_libpath = dyad_core_libpath.expanduser().resolve()
+            if not dyad_core_libpath.is_dir():
+                raise FileNotFoundError("Value of DYAD_LIB_DIR either doesn't exist or is not a directory")
+            if len(list(lib_path.glob("libdyad_core.*"))) == 0:
+                raise FileNotFoundError("Cannot find libdyad_core.so in value of DYAD_LIB_DIR")
+        self.dyad_core_lib = load_library("libdyad_core", dyad_core_libpath)
+        if self.dyad_core_lib is None:
+            raise FileNotFoundError("Cannot find libdyad_core")
+        self.ctx = ctypes.POINTER(DyadCtxWrapper)()
+        self.dyad_init = self.dyad_core_lib.dyad_init
+        self.dyad_init.argtypes = [
+            ctypes.c_bool,                                   # debug
+            ctypes.c_bool,                                   # check
+            ctypes.c_bool,                                   # shared_storage
+            ctypes.c_uint,                                   # key_depth
+            ctypes.c_uint,                                   # key_bins
+            ctypes.c_char_p,                                 # kvs_namespace
+            ctypes.c_char_p,                                 # prod_managed_path
+            ctypes.c_char_p,                                 # cons_managed_path
+            ctypes.POINTER(ctypes.POINTER(DyadCtxWrapper)),  # ctx
+        ]
+        self.dyad_init.restype = ctypes.c_int
+        self.dyad_init_env = self.dyad_core_lib.dyad_init_env
+        self.dyad_init_env.argtypes = [
+            ctypes.POINTER(ctypes.POINTER(DyadCtxWrapper))
+        ]
+        self.dyad_init_env.restype = ctypes.c_int
+        self.dyad_produce = self.dyad_core_lib.dyad_produce
+        self.dyad_produce.argtypes = [
+            ctypes.POINTER(DyadCtxWrapper),
+            ctypes.c_char_p,
+        ]
+        self.dyad_produce.restype = ctypes.c_int
+        self.dyad_consume = self.dyad_core_lib.dyad_consume
+        self.dyad_consume.argtypes = [
+            ctypes.POINTER(DyadCtxWrapper),
+            ctypes.c_char_p,
+        ]
+        self.dyad_consume.restype = ctypes.c_int
+        self.dyad_finalize = self.dyad_core_lib.dyad_finalize
+        self.dyad_finalize.argtypes = [
+            ctypes.POINTER(ctypes.POINTER(DyadCtxWrapper)),
+        ]
+        self.dyad_finalize.restype = ctypes.c_int
+        self.cons_path = None
+        self.prod_path = None
+        
+    def init(self, debug, check, shared_storage, key_depth,
+             key_bins, kvs_namespace, prod_managed_path,
+             cons_managed_path):
+        if self.dyad_init is None:
+            warnings.warn(
+                "Trying to initialize DYAD when libdyad_core.so was not found",
+                RuntimeWarning
+            )
+            return
+        res = self.dyad_init(
+            ctypes.c_bool(debug),
+            ctypes.c_bool(check),
+            ctypes.c_bool(shared_storage),
+            ctypes.c_uint(key_depth),
+            ctypes.c_uint(key_bins),
+            kvs_namespace.encode() if kvs_namespace is not None else None,
+            prod_managed_path.encode() if prod_managed_path is not None else None,
+            cons_managed_path.encode() if cons_managed_path is not None else None,
+            ctypes.byref(self.ctx),
+        )
+        if int(res) != 0:
+            raise RuntimeError("Could not initialize DYAD!")
+        if self.ctx.contents.prod_managed_path is None:
+            self.prod_path = None
+        else:
+            self.prod_path = Path(self.ctx.contents.prod_managed_path.decode("utf-8")).expanduser().resolve()
+        if self.ctx.contents.cons_managed_path is None:
+            self.cons_path = None
+        else:
+            self.cons_path = Path(self.ctx.contents.cons_managed_path.decode("utf-8")).expanduser().resolve()
+        
+    def init_env(self):
+        if self.dyad_init_env is None:
+            warnings.warn(
+                "Trying to initialize DYAD when libdyad_core.so was not found",
+                RuntimeWarning
+            )
+            return
+        res = self.dyad_init_env(
+            ctypes.byref(self.ctx)
+        )
+        if int(res) != 0:
+            raise RuntimeError("Could not initialize DYAD with environment variables")
+        if self.ctx.contents.prod_managed_path is None:
+            self.prod_path = None
+        else:
+            self.prod_path = Path(self.ctx.contents.prod_managed_path.decode("utf-8")).expanduser().resolve()
+        if self.ctx.contents.cons_managed_path is None:
+            self.cons_path = None
+        else:
+            self.cons_path = Path(self.ctx.contents.cons_managed_path.decode("utf-8")).expanduser().resolve()
+        
+    def __del__(self):
+        self.finalize()
+    
+    def produce(self, fname):
+        if self.dyad_produce is None:
+            warnings.warn(
+                "Trying to produce with DYAD when libdyad_core.so was not found",
+                RuntimeWarning
+            )
+            return
+        res = self.dyad_produce(
+            self.ctx,
+            fname.encode(),
+        )
+        if int(res) != 0:
+            raise RuntimeError("Cannot produce data with DYAD!")
+    
+    def consume(self, fname):
+        if self.dyad_consume is None:
+            warnings.warn(
+                "Trying to consunme with DYAD when libdyad_core.so was not found",
+                RuntimeWarning
+            )
+            return
+        res = self.dyad_consume(
+            self.ctx,
+            fname.encode(),
+        )
+        if int(res) != 0:
+            raise RuntimeError("Cannot consume data with DYAD!")
+    
+    def finalize(self):
+        if self.dyad_finalize is None:
+            warnings.warn(
+                "Trying to finalize DYAD when libdyad_core.so was not found",
+                RuntimeWarning
+            )
+            return
+        res = self.dyad_finalize(
+            ctypes.byref(self.ctx)
+        )
+        if int(res) != 0:
+            raise RuntimeError("Cannot finalize DYAD!")

--- a/pydyad/pydyad/context.py
+++ b/pydyad/pydyad/context.py
@@ -1,0 +1,48 @@
+from pydyad.bindings import Dyad
+
+from contextlib import contextmanager
+import io
+from pathlib import Path
+
+
+DYAD_IO = None
+
+
+# The design of dyad_open is based on the PEP for Python's 'with' syntax:
+# https://peps.python.org/pep-0343/
+@contextmanager
+def dyad_open(*args, dyad_ctx=None, register_dyad_ctx=False, **kwargs):
+    global DYAD_IO
+    local_dyad_io = dyad_ctx
+    if dyad_ctx is None:
+        if DYAD_IO is None:
+            DYAD_IO = Dyad()
+            DYAD_IO.init_env()
+        local_dyad_io = DYAD_IO
+    else:
+        if register_dyad_ctx:
+            DYAD_IO = dyad_ctx
+    fname = args[0]
+    if not isinstance(args[0], Path):
+        fname = Path(args[0])
+    fname = fname.expanduser().resolve()
+    mode = None
+    if "mode" in kwargs:
+        mode = kwargs["mode"]
+    elif len(args) > 1:
+        mode = args[1]
+    else:
+        raise NameError("'mode' argument not provided to dyad_open")
+    if mode in ("r", "rb", "rt"):
+        if (local_dyad_io.cons_path is not None and
+                local_dyad_io.cons_path in fname.parents):
+            local_dyad_io.consume(str(fname))
+    file_obj = io.open(*args, **kwargs)
+    try:
+        yield file_obj
+    finally:
+        file_obj.close()
+        if mode in ("w", "wb", "wt"):
+            if (local_dyad_io.prod_path is not None and
+                    local_dyad_io.prod_path in fname.parents):
+                local_dyad_io.produce(str(fname))

--- a/pydyad/pyproject.toml
+++ b/pydyad/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/pydyad/setup.cfg
+++ b/pydyad/setup.cfg
@@ -1,0 +1,10 @@
+[metadata]
+name = pydyad
+version = 0.1.0
+classifier =
+    License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)
+
+[options]
+python_requires = >=3.7
+install_requires =
+    numpy

--- a/pydyad/setup.py
+++ b/pydyad/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()

--- a/tests/pydyad_spsc/README.md
+++ b/tests/pydyad_spsc/README.md
@@ -1,0 +1,23 @@
+# PyDYAD Single Producer-Single Consumer Test
+
+This directory contains a very simple test pipeline to ensure PyDYAD is working. It consists of two tasks: a producer and a consumer. Both tasks run for a fixed number of iterations. In each iteration, the producer creates a NumPy array consisting of consecutive 64-bit integers starting from the product of the iteration ID and number of integers per iteration. Similarly, in each iteration, the consumer creates a NumPy array in the same way as the producer. Then, the consumer reads the file created by the producer and verifies that the file's contents.
+
+## Usage
+
+The usage of these tasks is below. The parameters for these tasks is as follows:
+* `producer_managed_directory`: the directory where the producer will write data. Can also be considered as DYAD's producer managed directory
+* `consumer_managed_directory`: the directory from which the consumer will read data. Can also be considered as DYAD's consumer managed directory
+* `num_files_to_transfer`: the number of files that they producer will write and that the consumer will read. Can also be considered the number of iterations
+* `num_ints_expected`: the number of randomly generated integers that will be stored in each file
+
+__Producer Task:__
+```bash
+$ python3 producer.py <producer_managed_directory> <num_files_to_transfer> <num_ints_expected>
+```
+
+__Consumer Task:__
+```bash
+$ python3 consumer.py <consumer_managed_directory> <num_files_to_transfer> <num_ints_expected>
+```
+
+To run the test, you can either create your own script, or you can use `run.sh`. To use `run.sh`, first set the variables at the top of the file. Then, launch the job with `flux batch run.sh`.

--- a/tests/pydyad_spsc/consumer.py
+++ b/tests/pydyad_spsc/consumer.py
@@ -1,0 +1,53 @@
+from pydyad import dyad_open
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+
+CONS_DIR = None
+
+
+def consume_data(i, num_ints_expected):
+    global CONS_DIR
+    fname = "file{}.npy".format(i)
+    fname = CONS_DIR / fname
+    start_val = i * num_ints_expected
+    verify_int_buf = np.arange(
+        start_val,
+        start_val+num_ints_expected,
+        dtype=np.uint64
+    )
+    int_buf = None
+    with dyad_open(fname, "rb") as f:
+        int_buf = np.load(f)
+    if int_buf is None:
+        raise RuntimeError("Could not read {}".format(fname))
+    if int_buf.size != num_ints_expected:
+        raise RuntimeError(
+            "Consumed data has incorrect size {}".format(num_ints_expected)
+        )
+    if not np.array_equal(int_buf, verify_int_buf):
+        raise RuntimeError("Consumed data is incorrect!")
+    print("Correctly consumed data (iter {})".format(i), flush=True)
+
+
+def main():
+    parser = argparse.ArgumentParser("Consumes data for pydyad test")
+    parser.add_argument("cons_managed_dir", type=Path,
+                        help="DYAD's consumer managed path")
+    parser.add_argument("num_files", type=int,
+                        help="Number of files to consume")
+    parser.add_argument("num_ints_expected", type=int,
+                        help="Number of ints expected in each consumed file")
+    args = parser.parse_args()
+    global CONS_DIR
+    CONS_DIR = args.cons_managed_dir.expanduser().resolve()
+    for i in range(args.num_files):
+        print("Trying to consume data (iter {})".format(i), flush=True)
+        consume_data(i, args.num_ints_expected)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/pydyad_spsc/producer.py
+++ b/tests/pydyad_spsc/producer.py
@@ -1,0 +1,40 @@
+from pydyad import dyad_open
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+
+PROD_DIR = None
+
+
+def produce_data(i, num_ints):
+    global PROD_DIR
+    fname = "file{}.npy".format(i)
+    fname = PROD_DIR / fname
+    start_val = i * num_ints
+    int_buf = np.arange(start_val, start_val+num_ints, dtype=np.uint64)
+    with dyad_open(fname, "wb") as f:
+        np.save(f, int_buf)
+    print("Successfully produced data (iter {})".format(i), flush=True)
+
+
+def main():
+    parser = argparse.ArgumentParser("Generates data for pydyad test")
+    parser.add_argument("prod_managed_dir", type=Path,
+                        help="DYAD's producer managed path")
+    parser.add_argument("num_files", type=int,
+                        help="Number of files to produce")
+    parser.add_argument("num_ints", type=int,
+                        help="Number of ints in each produced file")
+    args = parser.parse_args()
+    global PROD_DIR
+    PROD_DIR = args.prod_managed_dir.expanduser().resolve()
+    for i in range(args.num_files):
+        print("Trying to produce data (iter {})".format(i), flush=True)
+        produce_data(i, args.num_ints)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/pydyad_spsc/run.sh
+++ b/tests/pydyad_spsc/run.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# FLUX: -N 2
+# FLUX: --output=pydyad_spsc_test.out
+# FLUX: --error=pydyad_spsc_test.err
+
+DYAD_INSTALL_LIBDIR="/g/g90/lumsden1/ws/insitu_benchmark/dyad/_test_install/lib"
+KVS_NAMESPACE="pydyad_test"
+CONS_MANAGED_PATH="/l/ssd/lumsden1/pydyad_test"
+PROD_MANAGED_PATH="/l/ssd/lumsden1/pydyad_test"
+NUM_FILES=50
+NUM_INTS=500
+
+export LD_LIBRARY_PATH="$DYAD_INSTALL_LIBDIR:$LD_LIBRARY_PATH"
+
+if [ ! -d "$CONS_MANAGED_PATH" ]; then
+    mkdir -p $CONS_MANAGED_PATH
+fi
+if [ ! -d "$PROD_MANAGED_PATH" ]; then
+    mkdir -p $PROD_MANAGED_PATH
+fi
+
+cat > ./env_file.cons << EOM
+DYAD_PATH_CONSUMER=$CONS_MANAGED_PATH
+DYAD_KVS_NAMESPACE=$KVS_NAMESPACE
+DYAD_DTL_MODE=UCX
+EOM
+
+cat > ./env_file.prod << EOM
+DYAD_PATH_PRODUCER=$PROD_MANAGED_PATH
+DYAD_KVS_NAMESPACE=$KVS_NAMESPACE
+DYAD_DTL_MODE=UCX
+EOM
+
+flux kvs namespace create $KVS_NAMESPACE
+flux exec -r all flux module load $DYAD_INSTALL_LIBDIR/dyad.so \
+    $PROD_MANAGED_PATH UCX
+
+flux submit -N 1 --tasks-per-node=1 --exclusive \
+    --output="pydyad_cons.out" --error="pydyad_cons.err" \
+    --env-file=./env_file.cons \
+    --flags=waitable \
+    python3 consumer.py $CONS_MANAGED_PATH $NUM_FILES $NUM_INTS
+flux submit -N 1 --tasks-per-node=1 --exclusive \
+    --output="pydyad_prod.out" --error="pydyad_prod.err" \
+    --env-file=./env_file.prod \
+    --flags=waitable \
+    python3 producer.py $PROD_MANAGED_PATH $NUM_FILES $NUM_INTS
+    
+flux job wait --all
+
+flux exec -r all flux module unload dyad
+flux kvs namespace remove $KVS_NAMESPACE
+
+if [ -d "$CONS_MANAGED_PATH" ]; then
+    rm -r $CONS_MANAGED_PATH
+fi
+if [ -d "$PROD_MANAGED_PATH" ]; then
+    rm -r $PROD_MANAGED_PATH
+fi
+
+if [ $? -ne 0 ]; then
+    echo "ERROR: a job crashed with an error"
+    exit 1
+fi

--- a/tests/pydyad_spsc/run.sh
+++ b/tests/pydyad_spsc/run.sh
@@ -3,59 +3,74 @@
 # FLUX: --output=pydyad_spsc_test.out
 # FLUX: --error=pydyad_spsc_test.err
 
-DYAD_INSTALL_LIBDIR="/g/g90/lumsden1/ws/insitu_benchmark/dyad/_test_install/lib"
-KVS_NAMESPACE="pydyad_test"
-CONS_MANAGED_PATH="/l/ssd/lumsden1/pydyad_test"
-PROD_MANAGED_PATH="/l/ssd/lumsden1/pydyad_test"
-NUM_FILES=50
-NUM_INTS=500
+if [ -z "${DYAD_INSTALL_LIBDIR}" ]; then
+    echo "DYAD_INSTALL_LIBDIR must be defined"
+    exit 1
+fi
+if [ ! -d "${DYAD_INSTALL_LIBDIR}" ]; then
+    echo "DYAD_INSTALL_LIBDIR ($DYAD_INSTALL_LIBDIR) does not exist"
+    exit 1
+fi
+if [ ! -f "${DYAD_INSTALL_LIBDIR}/dyad.so" ]; then
+    echo "Invalid contents in DYAD_INSTALL_LIBDIR ($DYAD_INSTALL_LIBDIR)"
+    exit 1
+fi
+if [ -z "${DYAD_PATH_CONSUMER}" ]; then
+    if [ -z "${DYAD_PATH}" ]; then
+        echo "Either DYAD_PATH_CONSUMER or DYAD_PATH must be defined"
+        exit 1
+    else
+        DYAD_PATH_CONSUMER="${DYAD_PATH}"
+    fi
+fi
+if [ -z "${DYAD_PATH_PRODUCER}" ]; then
+    if [ -z "${DYAD_PATH}" ]; then
+        echo "Either DYAD_PATH_PRODUCER or DYAD_PATH must be defined"
+        exit 1
+    else
+        DYAD_PATH_PRODUCER="${DYAD_PATH}"
+    fi
+fi
+if [ -z "${DYAD_DTL_MODE}" ]; then
+    DYAD_DTL_MODE="FLUX_RPC"
+fi
+if [ -z "${DYAD_KVS_NAMESPACE}" ]; then
+    DYAD_KVS_NAMESPACE="pydyad_test"
+fi
+if [ -z "${NUM_FILES}" ]; then
+    NUM_FILES=50
+fi
+if [ -z "${NUM_INTS}" ]; then
+    NUM_INTS=50
+fi
 
 export LD_LIBRARY_PATH="$DYAD_INSTALL_LIBDIR:$LD_LIBRARY_PATH"
 
-if [ ! -d "$CONS_MANAGED_PATH" ]; then
-    mkdir -p $CONS_MANAGED_PATH
-fi
-if [ ! -d "$PROD_MANAGED_PATH" ]; then
-    mkdir -p $PROD_MANAGED_PATH
-fi
-
-cat > ./env_file.cons << EOM
-DYAD_PATH_CONSUMER=$CONS_MANAGED_PATH
-DYAD_KVS_NAMESPACE=$KVS_NAMESPACE
-DYAD_DTL_MODE=UCX
-EOM
-
-cat > ./env_file.prod << EOM
-DYAD_PATH_PRODUCER=$PROD_MANAGED_PATH
-DYAD_KVS_NAMESPACE=$KVS_NAMESPACE
-DYAD_DTL_MODE=UCX
-EOM
-
 flux kvs namespace create $KVS_NAMESPACE
 flux exec -r all flux module load $DYAD_INSTALL_LIBDIR/dyad.so \
-    $PROD_MANAGED_PATH UCX
+    $DYAD_PATH_PRODUCER $DYAD_DTL_MODE
 
 flux submit -N 1 --tasks-per-node=1 --exclusive \
     --output="pydyad_cons.out" --error="pydyad_cons.err" \
-    --env-file=./env_file.cons \
+    --env=DYAD_PATH_CONSUMER=$DYAD_PATH_CONSUMER --env=DYAD_DTL_MODE=$DYAD_DTL_MODE --env=DYAD_KVS_NAMESPACE=$KVS_NAMESPACE \
     --flags=waitable \
-    python3 consumer.py $CONS_MANAGED_PATH $NUM_FILES $NUM_INTS
+    python3 consumer.py $DYAD_PATH_CONSUMER $NUM_FILES $NUM_INTS
 flux submit -N 1 --tasks-per-node=1 --exclusive \
     --output="pydyad_prod.out" --error="pydyad_prod.err" \
-    --env-file=./env_file.prod \
+    --env=DYAD_PATH_PRODUCER=$DYAD_PATH_PRODUCER --env=DYAD_DTL_MODE=$DYAD_DTL_MODE --env=DYAD_KVS_NAMESPACE=$KVS_NAMESPACE \
     --flags=waitable \
-    python3 producer.py $PROD_MANAGED_PATH $NUM_FILES $NUM_INTS
+    python3 producer.py $DYAD_PATH_PRODUCER $NUM_FILES $NUM_INTS
     
 flux job wait --all
 
-flux exec -r all flux module unload dyad
+flux exec -r all flux module remove dyad
 flux kvs namespace remove $KVS_NAMESPACE
 
-if [ -d "$CONS_MANAGED_PATH" ]; then
-    rm -r $CONS_MANAGED_PATH
+if [ -d "$DYAD_PATH_CONSUMER" ]; then
+    rm -r $DYAD_PATH_CONSUMER
 fi
-if [ -d "$PROD_MANAGED_PATH" ]; then
-    rm -r $PROD_MANAGED_PATH
+if [ -d "$DYAD_PATH_PRODUCER" ]; then
+    rm -r $DYAD_PATH_PRODUCER
 fi
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
This PR adds a dedicated Python API to DYAD. This API will not be built/installed by Autotools. Instead, it will use setuptools/pip for its build/install process. This will allow us to host the Python API on PyPI if desired.

In terms of the interface, there are only 3 things a user may have to interact with:
1. The `dyad_open` function
2. The `dyad_open_local` function
3. The `Dyad` class

Most users will only use `dyad_open`. This function is a drop-in replacement for the built-in `open` function. Internally, this function is a "context manager" (see [this page](https://docs.python.org/3/library/contextlib.html) for more info). It creates a global `Dyad` object (if not created previously) and uses the `Dyad` object and built-in `open` function to carry out data production/consumption. When using `dyad_open`, DYAD will always be configured with environment variables.

The `dyad_open_local` function is provided to allow users to programmatically configure DYAD. When using `dyad_open_local`, users will first manually create a `Dyad` object and initialize it with the `init` or `init_env` methods. Then, users will invoke `dyad_open_local`. This function takes the same arguments as the built-in `open` plus an additional positional argument called `dyad_ctx`. This argument is the last required positional (i.e., it comes after all positionals from the built-in `open` function), and it accepts a pre-initialized `Dyad` object.

This PR is currently work-in-progress. The API is mostly complete, but packaging (i.e., setuptools stuff) and basic testing are still required.