### PR TITLE
Hotfix: removes blank lines from end of .sym files because they break builds

### DIFF
--- a/src/core/dyad_core.sym
+++ b/src/core/dyad_core.sym
@@ -4,4 +4,3 @@ dyad_consume
 dyad_produce
 dyad_finalize
 dyad_ctx_default
-

--- a/src/wrapper/wrapper.sym
+++ b/src/wrapper/wrapper.sym
@@ -2,4 +2,3 @@ open
 fopen
 close
 fclose
-


### PR DESCRIPTION
During the review of #26, we noticed that GitHub didn't like the lack of a newline at the end of our `.sym` files, so we added those newlines. However, the addition of those newlines breaks Autotools builds. This PR adds those newlines back to the `.sym` files to fix DYAD's build process