### PR TITLE
Makes UCX an optional dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,14 +66,21 @@ AC_ARG_ENABLE([urpc],
     [enable_urpc=$enableval],
     [enable_urpc=no]
 )
-AC_ARG_ENABLE([perfflow],
-    [AS_HELP_STRING([--enable-perfflow],
+AM_CONDITIONAL([URPC], [test "x$enable_urpc" = "xyes"])
+AC_ARG_WITH([perfflow],
+    [AS_HELP_STRING([--with-perfflow],
                     [enable performance measurement with PerfFlow Aspect])],
-    [enable_perfflow=$enableval],
-    [enable_perfflow=no]
+    [with_perfflow=$withval],
+    [with_perfflow=no]
 )
-# TODO Add support for libb64 back once base64 encoding/decoding is fully complete
-# AC_ARG_VAR([LIBB64_DIR], [root directory for libb64])
+AM_CONDITIONAL([PERFFLOW], [test "x$with_perfflow" = "xyes"])
+AC_ARG_WITH([ucx],
+    [AS_HELP_STRING([--with-ucx],
+                    [build the UCX-based data transport layer])],
+    [with_ucx=$withval],
+    [with_ucx=no]
+)
+AM_CONDITIONAL([UCX], [test "x$with_ucx" = "xyes"])
 
 #############################################
 # Define PKG_CHECK_VAR if it does not exist #
@@ -102,11 +109,29 @@ AS_VAR_IF([$1], [""], [$5], [$4])dnl
 ########################
 # Check for the dl library (specifically, the "dlsym" function)
 AC_CHECK_LIB([dl], [dlsym])
-# Check for UCX v1.6.0 or higher (Required)
-# TODO: make UCX optional based on a new AC_ARG_ENABLE flag
-PKG_CHECK_MODULES([UCX],
-    [ucx >= 1.6.0]
+# Find and get info for Flux-Core using pkg-config
+AX_FLUX_CORE
+# Check for Jansson 2.10 or higher (Required)
+PKG_CHECK_MODULES([JANSSON],
+    [jansson >= 2.10]
 )
+# Check for PerfFlow Aspect
+AX_PERFFLOW_ASPECT([PERFFLOW],
+    [pkg_check_perfflow_found=yes],
+    [pkg_check_perfflow_found=no]
+)
+if test "x$with_perfflow" = "xyes" && test "x$pkg_check_perfflow_found" = "xno"; then
+    AC_MSG_ERROR([requested PerfFlow Aspect support, but cannot find PerfFlow Aspect with pkg-config])
+fi
+# Check for UCX v1.6.0 or higher
+PKG_CHECK_MODULES([UCX],
+    [ucx >= 1.6.0],
+    [pkg_check_ucx_found=yes],
+    [pkg_check_ucx_found=no]
+)
+if test "x$with_ucx" = "xyes" && test "x$pkg_check_ucx_found" = "xno"; then
+    AC_MSG_ERROR([requested UCX support, but cannot find UCX with pkg-config])
+fi
 PKG_CHECK_VAR([UCX_LIBDIR],
     [ucx >= 1.6.0],
     [libdir],
@@ -116,25 +141,11 @@ PKG_CHECK_VAR([UCX_LIBDIR],
 AS_IF([test "x$UCX_LIBDIR" = "x"],
     [AC_MSG_FAILURE([check_var succeeded, but value is incorrect])]
 )
-# Find and get info for Flux-Core using pkg-config
-AX_FLUX_CORE
-PKG_CHECK_MODULES([JANSSON],
-    [jansson >= 2.10],
-    [pkg_check_jansson_found=yes],
-    [pkg_check_jansson_found=no]
+AS_IF([test "x$with_ucx" = "xyes"],
+    [DYAD_MOD_RPATH="-Wl,-rpath,$UCX_LIBDIR"],
+    [DYAD_MOD_RPATH=""]
 )
-if test "x$enable_urpc" = "xyes" && test "x$pkg_check_jansson_found" = "xno"; then
-    AC_MSG_ERROR([jansson cannot be located, but it is required when '--enable-urpc' is provided])
-fi
-AM_CONDITIONAL([URPC], [test "x$enable_urpc" = "xyes"])
-AX_PERFFLOW_ASPECT([PERFFLOW],
-    [pkg_check_perfflow_found=yes],
-    [pkg_check_perfflow_found=no]
-)
-if test "x$enable_perfflow" = "xyes" && test "x$pkg_check_perfflow_found" = "xno"; then
-    AC_MSG_ERROR([requested PerfFlow Aspect support, but cannot find PerfFlow Aspect with pkg-config])
-fi
-AM_CONDITIONAL([PERFFLOW], [test "x$enable_perfflow" = "xyes"])
+AC_SUBST([DYAD_MOD_RPATH])
 
 ###########################
 # Checks for header files #

--- a/configure.ac
+++ b/configure.ac
@@ -67,20 +67,20 @@ AC_ARG_ENABLE([urpc],
     [enable_urpc=no]
 )
 AM_CONDITIONAL([URPC], [test "x$enable_urpc" = "xyes"])
-AC_ARG_WITH([perfflow],
-    [AS_HELP_STRING([--with-perfflow],
+AC_ARG_ENABLE([perfflow],
+    [AS_HELP_STRING([--enable-perfflow],
                     [enable performance measurement with PerfFlow Aspect])],
-    [with_perfflow=$withval],
-    [with_perfflow=no]
+    [enable_perfflow=$withval],
+    [enable_perfflow=no]
 )
-AM_CONDITIONAL([PERFFLOW], [test "x$with_perfflow" = "xyes"])
-AC_ARG_WITH([ucx],
-    [AS_HELP_STRING([--with-ucx],
+AM_CONDITIONAL([PERFFLOW], [test "x$enable_perfflow" = "xyes"])
+AC_ARG_ENABLE([ucx],
+    [AS_HELP_STRING([--enable-ucx],
                     [build the UCX-based data transport layer])],
-    [with_ucx=$withval],
-    [with_ucx=no]
+    [enable_ucx=$withval],
+    [enable_ucx=no]
 )
-AM_CONDITIONAL([UCX], [test "x$with_ucx" = "xyes"])
+AM_CONDITIONAL([UCX], [test "x$enable_ucx" = "xyes"])
 
 #############################################
 # Define PKG_CHECK_VAR if it does not exist #
@@ -120,7 +120,7 @@ AX_PERFFLOW_ASPECT([PERFFLOW],
     [pkg_check_perfflow_found=yes],
     [pkg_check_perfflow_found=no]
 )
-if test "x$with_perfflow" = "xyes" && test "x$pkg_check_perfflow_found" = "xno"; then
+if test "x$enable_perfflow" = "xyes" && test "x$pkg_check_perfflow_found" = "xno"; then
     AC_MSG_ERROR([requested PerfFlow Aspect support, but cannot find PerfFlow Aspect with pkg-config])
 fi
 # Check for UCX v1.6.0 or higher
@@ -129,7 +129,7 @@ PKG_CHECK_MODULES([UCX],
     [pkg_check_ucx_found=yes],
     [pkg_check_ucx_found=no]
 )
-if test "x$with_ucx" = "xyes" && test "x$pkg_check_ucx_found" = "xno"; then
+if test "x$enable_ucx" = "xyes" && test "x$pkg_check_ucx_found" = "xno"; then
     AC_MSG_ERROR([requested UCX support, but cannot find UCX with pkg-config])
 fi
 PKG_CHECK_VAR([UCX_LIBDIR],
@@ -141,7 +141,7 @@ PKG_CHECK_VAR([UCX_LIBDIR],
 AS_IF([test "x$UCX_LIBDIR" = "x"],
     [AC_MSG_FAILURE([check_var succeeded, but value is incorrect])]
 )
-AS_IF([test "x$with_ucx" = "xyes"],
+AS_IF([test "x$enable_ucx" = "xyes"],
     [DYAD_MOD_RPATH="-Wl,-rpath,$UCX_LIBDIR"],
     [DYAD_MOD_RPATH=""]
 )

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -3,7 +3,6 @@ libdyad_core_la_SOURCES = \
 	dyad_core.c
 libdyad_core_la_LIBADD = \
 	$(top_builddir)/src/dtl/libdyad_dtl.la \
-	$(UCX_LIBS) \
 	$(JANSSON_LIBS) \
 	$(FLUX_CORE_LIBS)
 libdyad_core_la_CFLAGS = \
@@ -11,15 +10,15 @@ libdyad_core_la_CFLAGS = \
 	-I$(top_srcdir)/src/utils \
 	-I$(top_srcdir)/src/utils/base64 \
 	-I$(top_srcdir)/src/dtl \
-    $(UCX_CFLAGS) \
     $(JANSSON_CFLAGS) \
 	$(FLUX_CORE_CFLAGS) \
 	-DBUILDING_DYAD=1 \
 	-fvisibility=hidden
 libdyad_core_la_CPPFLAGS = 
-libdyad_core_la_LDFLAGS = \
-	-Wl,-rpath,'$(UCX_LIBDIR)' \
-	$(AM_LDFLAGS)
+if UCX
+libdyad_core_la_LIBADD += $(UCX_LIBS)
+libdyad_core_la_CFLAGS += $(UCX_CFLAGS)
+endif
 if PERFFLOW
 libdyad_core_la_LIBADD += $(PERFFLOW_LIBS)
 libdyad_core_la_CFLAGS += $(PERFFLOW_CFLAGS) -DDYAD_PERFFLOW=1

--- a/src/dtl/Makefile.am
+++ b/src/dtl/Makefile.am
@@ -4,22 +4,26 @@ libdyad_dtl_la_SOURCES = \
     dyad_dtl_impl.h \
     dyad_rc.h \
     flux_dtl.c \
-    flux_dtl.h \
-    ucx_dtl.c \
-    ucx_dtl.h
+    flux_dtl.h
 libdyad_dtl_la_LIBADD = \
     $(top_builddir)/src/utils/libutils.la \
     $(top_builddir)/src/utils/libmurmur3.la \
-    $(UCX_LIBS) \
     $(JANSSON_LIBS) \
     $(FLUX_CORE_LIBS)
 libdyad_dtl_la_CFLAGS = \
     $(AM_CFLAGS) \
     -I$(top_srcdir)/src/utils \
     -I$(top_srcdir)/src/utils/base64 \
-    $(UCX_CFLAGS) \
     $(JANSSON_CFLAGS) \
     $(FLUX_CORE_CLFAGS) \
     -fvisibility=hidden
+
+if UCX
+libdyad_dtl_la_SOURCES += \
+    ucx_dtl.c \
+    ucx_dtl.h
+libdyad_dtl_la_LIBADD += $(UCX_LIBS)
+libdyad_dtl_la_CFLAGS += $(UCX_CFLAGS)
+endif
 
 include_HEADERS = dyad_rc.h dyad_flux_log.h dyad_dtl.h

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -1,6 +1,7 @@
 lib_LTLIBRARIES = dyad.la
 dyad_la_SOURCES = \
 	dyad.c
+# Don't put a line break before DYAD_MOD_RPATH in case it evaluates to an empty string
 dyad_la_LDFLAGS = \
 	$(AM_LDFLAGS) \
 	-module \
@@ -8,11 +9,9 @@ dyad_la_LDFLAGS = \
 	-no-undefined \
 	--disable-static \
 	-shared \
-	-export-dynamic \
-    -Wl,-rpath,'$(UCX_LIBDIR)'
+	-export-dynamic $(DYAD_MOD_RPATH)
 dyad_la_LIBADD = \
 	$(top_builddir)/src/dtl/libdyad_dtl.la \
-    $(UCX_LIBS) \
 	$(JANSSON_LIBS) \
 	$(FLUX_CORE_LIBS)
 dyad_la_CFLAGS = \
@@ -20,12 +19,15 @@ dyad_la_CFLAGS = \
 	-I$(top_srcdir)/src/utils \
 	-I$(top_srcdir)/src/utils/base64 \
 	-I$(top_srcdir)/src/dtl \
-	$(UCX_CFLAGS) \
 	$(JANSSON_CFLAGS) \
 	$(FLUX_CORE_CFLAGS) \
 	-DBUILDING_DYAD \
 	-fvisibility=hidden
 dyad_la_CPPFLAGS =
+if UCX
+dyad_la_LIBADD += $(UCX_LIBS)
+dyad_la_CFLAGS += $(UCX_CFLAGS)
+endif
 if PERFFLOW
 dyad_la_LIBADD += $(PERFFLOW_LIBS)
 dyad_la_CFLAGS += $(PERFFLOW_CFLAGS) -DDYAD_PERFFLOW=1


### PR DESCRIPTION
This PR reworks `configure.ac` and all the relevant `Makefile.am`s to make UCX an optional dependency for DYAD.