### PR TITLE
Hotfix: various build system fixes to support CI

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,20 +132,22 @@ PKG_CHECK_MODULES([UCX],
 if test "x$enable_ucx" = "xyes" && test "x$pkg_check_ucx_found" = "xno"; then
     AC_MSG_ERROR([requested UCX support, but cannot find UCX with pkg-config])
 fi
-PKG_CHECK_VAR([UCX_LIBDIR],
-    [ucx >= 1.6.0],
-    [libdir],
-    [],
-    [AC_MSG_FAILURE([Could not find libdir for UCX])]
-)
-AS_IF([test "x$UCX_LIBDIR" = "x"],
-    [AC_MSG_FAILURE([check_var succeeded, but value is incorrect])]
-)
-AS_IF([test "x$enable_ucx" = "xyes"],
-    [DYAD_MOD_RPATH="-Wl,-rpath,$UCX_LIBDIR"],
-    [DYAD_MOD_RPATH=""]
-)
-AC_SUBST([DYAD_MOD_RPATH])
+if test "x$enable_ucx" = "xyes"; then
+    PKG_CHECK_VAR([UCX_LIBDIR],
+        [ucx >= 1.6.0],
+        [libdir],
+        [],
+        [AC_MSG_FAILURE([Could not find libdir for UCX])]
+    )
+    AS_IF([test "x$UCX_LIBDIR" = "x"],
+        [AC_MSG_FAILURE([check_var succeeded, but value is incorrect])]
+    )
+    AS_IF([test "x$enable_ucx" = "xyes"],
+        [DYAD_MOD_RPATH="-Wl,-rpath,$UCX_LIBDIR"],
+        [DYAD_MOD_RPATH=""]
+    )
+    AC_SUBST([DYAD_MOD_RPATH])
+fi
 
 ###########################
 # Checks for header files #

--- a/src/dtl/Makefile.am
+++ b/src/dtl/Makefile.am
@@ -23,7 +23,7 @@ libdyad_dtl_la_SOURCES += \
     ucx_dtl.c \
     ucx_dtl.h
 libdyad_dtl_la_LIBADD += $(UCX_LIBS)
-libdyad_dtl_la_CFLAGS += $(UCX_CFLAGS)
+libdyad_dtl_la_CFLAGS += $(UCX_CFLAGS) -DDYAD_ENABLE_UCX=1
 endif
 
 include_HEADERS = dyad_rc.h dyad_flux_log.h dyad_dtl.h

--- a/src/dtl/dyad_dtl_impl.c
+++ b/src/dtl/dyad_dtl_impl.c
@@ -1,7 +1,10 @@
 #include "dyad_dtl_impl.h"
 
 #include "flux_dtl.h"
+
+#if DYAD_ENABLE_UCX
 #include "ucx_dtl.h"
+#endif
 
 dyad_rc_t dyad_dtl_init (dyad_dtl_t **dtl_handle,
                          dyad_dtl_mode_t mode,

--- a/src/dtl/dyad_dtl_impl.c
+++ b/src/dtl/dyad_dtl_impl.c
@@ -14,44 +14,51 @@ dyad_rc_t dyad_dtl_init (dyad_dtl_t **dtl_handle,
     dyad_rc_t rc = DYAD_RC_OK;
     *dtl_handle = malloc (sizeof (struct dyad_dtl));
     if (*dtl_handle == NULL) {
-        return DYAD_RC_SYSFAIL;
+        rc = DYAD_RC_SYSFAIL;
+        goto dtl_init_done;
     }
     (*dtl_handle)->mode = mode;
 #if DYAD_ENABLE_UCX
     if (mode == DYAD_DTL_UCX) {
         rc = dyad_dtl_ucx_init (*dtl_handle, mode, h, debug);
         if (DYAD_IS_ERROR (rc)) {
-            return rc;
+            goto dtl_init_done;
         }
-        return DYAD_RC_OK;
     } else if (mode == DYAD_DTL_FLUX_RPC) {
 #else
     if (mode == DYAD_DTL_FLUX_RPC) {
 #endif
         rc = dyad_dtl_flux_init (*dtl_handle, mode, h, debug);
         if (DYAD_IS_ERROR (rc)) {
-            return rc;
+            goto dtl_init_done;
         }
-        return DYAD_RC_OK;
+    } else {
+        rc = DYAD_RC_BADDTLMODE;
+        goto dtl_init_done;
     }
-    return DYAD_RC_BADDTLMODE;
+    rc = DYAD_RC_OK;
+
+dtl_init_done:
+    return rc;
 }
 
 dyad_rc_t dyad_dtl_finalize (dyad_dtl_t **dtl_handle)
 {
     dyad_rc_t rc = DYAD_RC_OK;
-    if (dtl_handle == NULL || *dtl_handle == NULL)
+    if (dtl_handle == NULL || *dtl_handle == NULL) {
         // We should only reach this line if the user has passed
         // in an already-finalized DTL handle. In that case,
         // this function should be treated as a no-op, and we
         // should return DYAD_RC_OK to indicate no error has occured
-        return DYAD_RC_OK;
+        rc = DYAD_RC_OK;
+        goto dtl_finalize_done;
+    }
 #if DYAD_ENABLE_UCX
     if ((*dtl_handle)->mode == DYAD_DTL_UCX) {
         if ((*dtl_handle)->private.ucx_dtl_handle != NULL) {
             rc = dyad_dtl_ucx_finalize (dtl_handle);
             if (DYAD_IS_ERROR (rc)) {
-                return rc;
+                goto dtl_finalize_done;
             }
         }
     } else if ((*dtl_handle)->mode == DYAD_DTL_FLUX_RPC) {
@@ -61,13 +68,17 @@ dyad_rc_t dyad_dtl_finalize (dyad_dtl_t **dtl_handle)
         if ((*dtl_handle)->private.flux_dtl_handle != NULL) {
             rc = dyad_dtl_flux_finalize (dtl_handle);
             if (DYAD_IS_ERROR (rc)) {
-                return rc;
+                goto dtl_finalize_done;
             }
         }
     } else {
-        return DYAD_RC_BADDTLMODE;
+        rc = DYAD_RC_BADDTLMODE;
+        goto dtl_finalize_done;
     }
+    rc = DYAD_RC_OK;
+
+dtl_finalize_done:
     free (*dtl_handle);
     *dtl_handle = NULL;
-    return DYAD_RC_OK;
+    return rc;
 }

--- a/src/dtl/dyad_dtl_impl.c
+++ b/src/dtl/dyad_dtl_impl.c
@@ -14,6 +14,7 @@ dyad_rc_t dyad_dtl_init (dyad_dtl_t **dtl_handle,
         return DYAD_RC_SYSFAIL;
     }
     (*dtl_handle)->mode = mode;
+#if DYAD_ENABLE_UCX
     if (mode == DYAD_DTL_UCX) {
         rc = dyad_dtl_ucx_init (*dtl_handle, mode, h, debug);
         if (DYAD_IS_ERROR (rc)) {
@@ -21,6 +22,9 @@ dyad_rc_t dyad_dtl_init (dyad_dtl_t **dtl_handle,
         }
         return DYAD_RC_OK;
     } else if (mode == DYAD_DTL_FLUX_RPC) {
+#else
+    if (mode == DYAD_DTL_FLUX_RPC) {
+#endif
         rc = dyad_dtl_flux_init (*dtl_handle, mode, h, debug);
         if (DYAD_IS_ERROR (rc)) {
             return rc;
@@ -39,6 +43,7 @@ dyad_rc_t dyad_dtl_finalize (dyad_dtl_t **dtl_handle)
         // this function should be treated as a no-op, and we
         // should return DYAD_RC_OK to indicate no error has occured
         return DYAD_RC_OK;
+#if DYAD_ENABLE_UCX
     if ((*dtl_handle)->mode == DYAD_DTL_UCX) {
         if ((*dtl_handle)->private.ucx_dtl_handle != NULL) {
             rc = dyad_dtl_ucx_finalize (dtl_handle);
@@ -47,6 +52,9 @@ dyad_rc_t dyad_dtl_finalize (dyad_dtl_t **dtl_handle)
             }
         }
     } else if ((*dtl_handle)->mode == DYAD_DTL_FLUX_RPC) {
+#else
+    if ((*dtl_handle)->mode == DYAD_DTL_FLUX_RPC) {
+#endif
         if ((*dtl_handle)->private.flux_dtl_handle != NULL) {
             rc = dyad_dtl_flux_finalize (dtl_handle);
             if (DYAD_IS_ERROR (rc)) {

--- a/src/stream/Makefile.am
+++ b/src/stream/Makefile.am
@@ -2,7 +2,6 @@ lib_LTLIBRARIES = libdyad_fstream.la
 
 libdyad_fstream_la_SOURCES = dyad_stream_core.cpp
 libdyad_fstream_la_LDFLAGS = \
-    -Wl,-rpath,'$(UCX_LIBDIR)' \
     $(AM_LDFLAGS) \
     -avoid-version \
     -no-undefined

--- a/src/wrapper/Makefile.am
+++ b/src/wrapper/Makefile.am
@@ -1,7 +1,6 @@
 lib_LTLIBRARIES = dyad_wrapper.la
 dyad_wrapper_la_SOURCES = wrapper.c
 dyad_wrapper_la_LDFLAGS = \
-	-Wl,-rpath,'$(UCX_LIBDIR)' \
 	$(AM_LDFLAGS) \
 	-module \
 	-avoid-version \


### PR DESCRIPTION
#49 made UCX an optional dependency. However, it did not make the UCX-based code in `dyad_dtl_init` and `dyad_dtl_finalize` conditionally compiled. As a result, if a user built DYAD without `--enable-ucx` and then set the DTL mode to `UCX`, failures would occur due to `dyad_dtl_init` and `dyad_dtl_finalize` trying to call the corresponding UCX DTL functions, which would not have been built.

This hotfix PR fixes this small, but important, bug.