### PR TITLE
Adds a function to get DYAD file metadata

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,7 +11,7 @@ BinPackParameters: 'false'
 BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeBraces: Linux
 BreakBeforeTernaryOperators: 'true'
-ColumnLimit: '90'
+ColumnLimit: '100'
 ConstructorInitializerAllOnOneLineOrOnePerLine: 'true'
 IndentWidth: '4'
 PenaltyBreakBeforeFirstCallParameter: '10000000'

--- a/pydyad/pydyad/bindings.py
+++ b/pydyad/pydyad/bindings.py
@@ -1,8 +1,8 @@
 import ctypes
 from ctypes.util import find_library
-import os
 from pathlib import Path
 import warnings
+import weakref
 
 
 DYAD_LIB_DIR = None
@@ -33,6 +33,33 @@ class DyadCtxWrapper(ctypes.Structure):
         ("prod_managed_path", ctypes.c_char_p),
         ("cons_managed_path", ctypes.c_char_p),
     ]
+
+
+class DyadMetadataWrapper(ctypes.Structure):
+    _fields_ = [
+        ("fpath", ctypes.c_char_p),
+        ("owner_rank", ctypes.c_uint32),
+    ]
+
+
+class DyadMetadata:
+
+    def __init__(self, metadata_wrapper, dyad_obj):
+        self.mdata = metadata_wrapper
+        self.dyad_free_metadata = weakref.ref(dyad_obj.dyad_free_metadata)
+        self.mdata_attrs = [tup[0] for tup in metadata_wrapper._fields_]
+
+    def __getattr__(self, attr_name):
+        if self.mdata is not None:
+            if attr_name not in self.mdata_attrs:
+                raise AttributeError("{} is not an attribute of DYAD's metadata".format(attr_name))
+            return getattr(self.mdata.contents, attr_name)
+        raise AttributeError("Underlying metadata object has already been freed")
+
+    def __del__(self):
+        if self.mdata is not None:
+            self.dyad_free_metadata(self.mdata)
+            self.mdata = None
 
 
 class Dyad:
@@ -80,6 +107,19 @@ class Dyad:
             ctypes.c_char_p,
         ]
         self.dyad_produce.restype = ctypes.c_int
+        self.dyad_get_metadata = self.dyad_core_lib.dyad_get_metadata
+        self.dyad_get_metadata.argtypes = [
+            ctypes.POINTER(DyadCtxWrapper),
+            ctypes.c_char_p,
+            ctypes.c_bool,
+            ctypes.POINTER(ctypes.POINTER(DyadMetadataWrapper)),
+        ]
+        self.dyad_get_metadata.restype = ctypes.c_int
+        self.dyad_free_metadata = self.dyad_core_lib.dyad_free_metadata
+        self.dyad_free_metadata.argtypes = [
+            ctypes.POINTER(DyadMetadataWrapper)
+        ]
+        self.dyad_free_metadata.restype = ctypes.c_int
         self.dyad_consume = self.dyad_core_lib.dyad_consume
         self.dyad_consume.argtypes = [
             ctypes.POINTER(DyadCtxWrapper),
@@ -163,6 +203,36 @@ class Dyad:
         )
         if int(res) != 0:
             raise RuntimeError("Cannot produce data with DYAD!")
+        
+    def get_metadata(self, fname, should_wait=False, raw=False):
+        if self.dyad_get_metadata is None:
+            warnings.warn(
+                "Trying to get metadata for file with DYAD when libdyad_core.so was not found",
+                RuntimeWarning
+            )
+            return None
+        mdata = ctypes.POINTER(DyadMetadataWrapper)()
+        res = self.dyad_get_metadata(
+            self.ctx,
+            fname.encode(),
+            should_wait,
+            ctypes.byref(mdata)
+        )
+        if int(res) != 0:
+            return None
+        if not raw:
+            return DyadMetadata(mdata, self)
+        return mdata
+        
+    def free_metadata(self, metadata_wrapper):
+        if self.dyad_free_metadata is None:
+            warnings.warn("Trying to free DYAD metadata when libdyad_core.so was not found", RuntimeWarning)
+            return
+        res = self.dyad_free_metadata(
+            metadata_wrapper
+        )
+        if int(res) != 0:
+            raise RuntimeError("Could not free DYAD metadata")
     
     def consume(self, fname):
         if self.dyad_consume is None:

--- a/pydyad/pydyad/bindings.py
+++ b/pydyad/pydyad/bindings.py
@@ -58,7 +58,7 @@ class DyadMetadata:
 
     def __del__(self):
         if self.mdata is not None:
-            self.dyad_free_metadata(self.mdata)
+            self.dyad_free_metadata(ctypes.byref(self.mdata))
             self.mdata = None
 
 
@@ -117,7 +117,7 @@ class Dyad:
         self.dyad_get_metadata.restype = ctypes.c_int
         self.dyad_free_metadata = self.dyad_core_lib.dyad_free_metadata
         self.dyad_free_metadata.argtypes = [
-            ctypes.POINTER(DyadMetadataWrapper)
+            ctypes.POINTER(ctypes.POINTER(DyadMetadataWrapper))
         ]
         self.dyad_free_metadata.restype = ctypes.c_int
         self.dyad_consume = self.dyad_core_lib.dyad_consume
@@ -229,7 +229,7 @@ class Dyad:
             warnings.warn("Trying to free DYAD metadata when libdyad_core.so was not found", RuntimeWarning)
             return
         res = self.dyad_free_metadata(
-            metadata_wrapper
+            ctypes.byref(metadata_wrapper)
         )
         if int(res) != 0:
             raise RuntimeError("Could not free DYAD metadata")

--- a/src/core/dyad_core.c
+++ b/src/core/dyad_core.c
@@ -237,10 +237,7 @@ DYAD_CORE_FUNC_MODS dyad_rc_t dyad_kvs_read (const dyad_ctx_t* restrict ctx,
 
 kvs_read_end:
     if (DYAD_IS_ERROR (rc) && mdata != NULL && *mdata != NULL) {
-        if ((*mdata)->fpath != NULL)
-            free ((*mdata)->fpath);
-        free (*mdata);
-        *mdata = NULL;
+        dyad_free_metadata (mdata);
     }
     if (f != NULL) {
         flux_future_destroy (f);
@@ -294,10 +291,7 @@ DYAD_CORE_FUNC_MODS dyad_rc_t dyad_fetch (const dyad_ctx_t* restrict ctx,
                        "is the "
                        "same as the consumer rank\n");
         if (mdata != NULL && *mdata != NULL) {
-            if ((*mdata)->fpath != NULL)
-                free ((*mdata)->fpath);
-            free (*mdata);
-            *mdata = NULL;
+            dyad_free_metadata (mdata);
         }
         rc = DYAD_RC_OK;
         goto fetch_done;
@@ -776,22 +770,20 @@ dyad_rc_t dyad_get_metadata (dyad_ctx_t* ctx,
 
 get_metadata_done:
     if (DYAD_IS_ERROR (rc) && mdata != NULL && *mdata != NULL) {
-        if ((*mdata)->fpath != NULL)
-            free ((*mdata)->fpath);
-        free (*mdata);
-        *mdata = NULL;
+        dyad_free_metadata (mdata);
     }
     return rc;
 }
 
-dyad_rc_t dyad_free_metadata (dyad_metadata_t* mdata)
+dyad_rc_t dyad_free_metadata (dyad_metadata_t** mdata)
 {
-    if (mdata != NULL) {
-        if (mdata->fpath != NULL)
-            free (mdata->fpath);
-        free (mdata);
-        mdata = NULL;
+    if (mdata == NULL || *mdata == NULL) {
+        return DYAD_RC_OK;
     }
+    if ((*mdata)->fpath != NULL)
+        free ((*mdata)->fpath);
+    free (*mdata);
+    *mdata = NULL;
     return DYAD_RC_OK;
 }
 
@@ -836,10 +828,7 @@ dyad_rc_t dyad_consume (dyad_ctx_t* ctx, const char* fname)
     // Regardless if there was an error in dyad_pull,
     // free the KVS response object
     if (mdata != NULL) {
-        if (mdata->fpath != NULL)
-            free (mdata->fpath);
-        free (mdata);
-        mdata = NULL;
+        dyad_free_metadata (&mdata);
     }
     // If an error occured in dyad_pull, log it
     // and return the corresponding DYAD return code

--- a/src/core/dyad_core.h
+++ b/src/core/dyad_core.h
@@ -65,9 +65,8 @@ typedef struct dyad_metadata dyad_metadata_t;
     } while (0)
 #endif  // DPRINTF
 
-#define TIME_DIFF(Tstart, Tend)                                                \
-    ((double)(1000000000L * ((Tend).tv_sec - (Tstart).tv_sec) + (Tend).tv_nsec \
-              - (Tstart).tv_nsec)                                              \
+#define TIME_DIFF(Tstart, Tend)                                                                    \
+    ((double)(1000000000L * ((Tend).tv_sec - (Tstart).tv_sec) + (Tend).tv_nsec - (Tstart).tv_nsec) \
      / 1000000000L)
 
 // Detailed information message that can be omitted
@@ -119,8 +118,7 @@ DYAD_DLL_EXPORTED dyad_rc_t dyad_init_env (dyad_ctx_t** ctx);
  *
  * @return An error code from dyad_rc.h
  */
-DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED dyad_rc_t dyad_produce (dyad_ctx_t* ctx,
-                                                            const char* fname);
+DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED dyad_rc_t dyad_produce (dyad_ctx_t* ctx, const char* fname);
 
 /**
  * @brief Obtain DYAD metadata for a file in the consumer-managed directory
@@ -136,8 +134,7 @@ DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED dyad_rc_t dyad_get_metadata (dyad_ctx_t* ctx
                                                                  bool should_wait,
                                                                  dyad_metadata_t** mdata);
 
-DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED dyad_rc_t
-dyad_free_metadata (dyad_metadata_t** mdata);
+DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED dyad_rc_t dyad_free_metadata (dyad_metadata_t** mdata);
 
 /**
  * @brief Wrapper function that performs all the common tasks needed
@@ -147,8 +144,7 @@ dyad_free_metadata (dyad_metadata_t** mdata);
  *
  * @return An error code from dyad_rc.h
  */
-DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED dyad_rc_t dyad_consume (dyad_ctx_t* ctx,
-                                                            const char* fname);
+DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED dyad_rc_t dyad_consume (dyad_ctx_t* ctx, const char* fname);
 
 /**
  * @brief Finalizes the DYAD instance and deallocates the context
@@ -159,8 +155,7 @@ DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED dyad_rc_t dyad_consume (dyad_ctx_t* ctx,
 DYAD_DLL_EXPORTED dyad_rc_t dyad_finalize (dyad_ctx_t** ctx);
 
 #if DYAD_SYNC_DIR
-DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED int dyad_sync_directory (dyad_ctx_t* ctx,
-                                                             const char* path);
+DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED int dyad_sync_directory (dyad_ctx_t* ctx, const char* path);
 #endif
 
 #ifdef __cplusplus

--- a/src/core/dyad_core.h
+++ b/src/core/dyad_core.h
@@ -50,6 +50,12 @@ struct dyad_ctx {
 DYAD_DLL_EXPORTED extern const struct dyad_ctx dyad_ctx_default;
 typedef struct dyad_ctx dyad_ctx_t;
 
+struct dyad_metadata {
+    char* fpath;
+    uint32_t owner_rank;
+};
+typedef struct dyad_metadata dyad_metadata_t;
+
 // Debug message
 #ifndef DPRINTF
 #define DPRINTF(curr_dyad_ctx, fmt, ...)           \
@@ -84,7 +90,7 @@ typedef struct dyad_ctx dyad_ctx_t;
  *                            instance of DYAD
  * @param[out] ctx            the newly initialized context
  *
- * @return An integer error code (values TBD)
+ * @return An error code from dyad_rc.h
  */
 DYAD_DLL_EXPORTED dyad_rc_t dyad_init (bool debug,
                                        bool check,
@@ -100,7 +106,8 @@ DYAD_DLL_EXPORTED dyad_rc_t dyad_init (bool debug,
 /**
  * @brief Intialize the DYAD context using environment variables
  * @param[out] ctx the newly initialized context
- * @return An error code
+ *
+ * @return An error code from dyad_rc.h
  */
 DYAD_DLL_EXPORTED dyad_rc_t dyad_init_env (dyad_ctx_t** ctx);
 
@@ -110,10 +117,26 @@ DYAD_DLL_EXPORTED dyad_rc_t dyad_init_env (dyad_ctx_t** ctx);
  * @param[in] ctx    the DYAD context for the operation
  * @param[in] fname  the name of the file being "produced"
  *
- * @return An integer error code (values TBD)
+ * @return An error code from dyad_rc.h
  */
 DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED dyad_rc_t dyad_produce (dyad_ctx_t* ctx,
                                                             const char* fname);
+
+/**
+ * @brief Obtain DYAD metadata for a file in the consumer-managed directory
+ * @param[in]  ctx         the DYAD context for the operation
+ * @param[in]  fname       the name of the file for which metadata is obtained
+ * @param[in]  should_wait if true, wait for the file to be produced before returning
+ * @param[out] mdata       a dyad_metadata_t object containing the metadata for the file
+ *
+ * @return An error code from dyad_rc.h
+ */
+DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED dyad_rc_t dyad_get_metadata (dyad_ctx_t* ctx,
+                                                                 const char* fname,
+                                                                 bool should_wait,
+                                                                 dyad_metadata_t** mdata);
+
+DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED dyad_rc_t dyad_free_metadata (dyad_metadata_t* mdata);
 
 /**
  * @brief Wrapper function that performs all the common tasks needed
@@ -121,7 +144,7 @@ DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED dyad_rc_t dyad_produce (dyad_ctx_t* ctx,
  * @param[in] ctx    the DYAD context for the operation
  * @param[in] fname  the name of the file being "consumed"
  *
- * @return An integer error code (values TBD)
+ * @return An error code from dyad_rc.h
  */
 DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED dyad_rc_t dyad_consume (dyad_ctx_t* ctx,
                                                             const char* fname);
@@ -130,7 +153,7 @@ DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED dyad_rc_t dyad_consume (dyad_ctx_t* ctx,
  * @brief Finalizes the DYAD instance and deallocates the context
  * @param[in] ctx  the DYAD context being finalized
  *
- * @return An integer error code (values TBD)
+ * @return An error code from dyad_rc.h
  */
 DYAD_DLL_EXPORTED dyad_rc_t dyad_finalize (dyad_ctx_t** ctx);
 

--- a/src/core/dyad_core.h
+++ b/src/core/dyad_core.h
@@ -136,7 +136,8 @@ DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED dyad_rc_t dyad_get_metadata (dyad_ctx_t* ctx
                                                                  bool should_wait,
                                                                  dyad_metadata_t** mdata);
 
-DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED dyad_rc_t dyad_free_metadata (dyad_metadata_t* mdata);
+DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED dyad_rc_t
+dyad_free_metadata (dyad_metadata_t** mdata);
 
 /**
  * @brief Wrapper function that performs all the common tasks needed

--- a/src/dtl/dyad_rc.h
+++ b/src/dtl/dyad_rc.h
@@ -24,9 +24,9 @@ enum dyad_core_return_codes {
     DYAD_RC_NOCTX = -2,            // No DYAD Context found
     DYAD_RC_FLUXFAIL = -3,         // Some Flux function failed
     DYAD_RC_BADCOMMIT = -4,        // Flux KVS commit didn't work
-    DYAD_RC_BADLOOKUP = -5,        // Flux KVS lookup didn't work
+    DYAD_RC_NOTFOUND = -5,         // Flux KVS lookup didn't work
     DYAD_RC_BADFETCH = -6,         // Flux KVS commit didn't work
-    DYAD_RC_BADRESPONSE = -7,      // Cannot create/populate a DYAD response
+    DYAD_RC_BADMETADATA = -7,      // Cannot create/populate a DYAD response
     DYAD_RC_BADRPC = -8,           // Flux RPC pack or get didn't work
     DYAD_RC_BADFIO = -9,           // File I/O failed
     DYAD_RC_BADMANAGEDPATH = -10,  // Cons or Prod Manged Path is bad
@@ -41,6 +41,7 @@ enum dyad_core_return_codes {
                                    // end of stream) sooner than expected
     DYAD_RC_BAD_B64DECODE = -18,   // Decoding of data w/ base64 failed
     DYAD_RC_BAD_COMM_MODE = -19,   // Invalid comm mode provided to DTL
+    DYAD_RC_UNTRACKED = -20,       // Provided path is not tracked by DYAD
 };
 
 typedef enum dyad_core_return_codes dyad_rc_t;


### PR DESCRIPTION
This PR adds a new function to the Core library: `dyad_get_metadata`. This function accepts a file path as input, and, if metadata about that file is found in the Flux KVS, it will return that metadata to the user.

Additionally, this PR adds Python bindings to the new `dyad_get_metadata` function.

Due to the Python binding, this PR depends on #27 