### PR TITLE
Test: fix some issues with python API test

### DIFF
--- a/.github/workflows/compile_test.yaml
+++ b/.github/workflows/compile_test.yaml
@@ -292,9 +292,9 @@ jobs:
       - name: Test DYAD with separate FS python
         run: |
           mkdir -p $DYAD_PATH
-          #. ${SPACK_DIR}/share/spack/setup-env.sh
-          #export PATH=${PATH}:${DYAD_INSTALL_PREFIX}/bin:${DYAD_INSTALL_PREFIX}/sbin
-          #export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${DYAD_INSTALL_PREFIX}/lib
-          #echo "Starting flux brokers"
-          #flux start --test-size=2 /bin/bash ${GITHUB_WORKSPACE}/.github/prod-cons/dyad_prod_cons_test.sh "python"
+          . ${SPACK_DIR}/share/spack/setup-env.sh
+          export PATH=${PATH}:${DYAD_INSTALL_PREFIX}/bin:${DYAD_INSTALL_PREFIX}/sbin
+          export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${DYAD_INSTALL_PREFIX}/lib
+          echo "Starting flux brokers"
+          flux start --test-size=2 /bin/bash ${GITHUB_WORKSPACE}/.github/prod-cons/dyad_prod_cons_test.sh "python"
 

--- a/tests/pydyad_spsc/README.md
+++ b/tests/pydyad_spsc/README.md
@@ -21,3 +21,11 @@ $ python3 consumer.py <consumer_managed_directory> <num_files_to_transfer> <num_
 ```
 
 To run the test, you can either create your own script, or you can use `run.sh`. To use `run.sh`, first set the variables at the top of the file. Then, launch the job with `flux batch run.sh`.
+Define the following environment variables to execute run.sh
+
+```
+export DYAD_INSTALL_LIBDIR=<your dyad installation dir>
+export DYAD_PATH=/tmp/${USER}/dyad
+export DYAD_DTL_MODE=UCX
+export PYTHONPATH=${PYTHONPATH}:<dyad source location>/pydyad
+```

--- a/tests/pydyad_spsc/consumer.py
+++ b/tests/pydyad_spsc/consumer.py
@@ -26,7 +26,8 @@ def consume_data(i, num_ints_expected):
         raise RuntimeError("Could not read {}".format(fname))
     if int_buf.size != num_ints_expected:
         raise RuntimeError(
-            "Consumed data has incorrect size {}".format(num_ints_expected)
+            "Consumed data has incorrect size {n_read} != {expected}".format(
+             n_read = int_buf.size, expected = num_ints_expected)
         )
     if not np.array_equal(int_buf, verify_int_buf):
         raise RuntimeError("Consumed data is incorrect!")


### PR DESCRIPTION
tests/pydyad_spsc seems to have multiple issues.

- `KVS_NAMESPACE` variable is inconsistently used with `DYAD_KVS_NAMESPACE`
- DYAD managed directory is not created.
- In case that such a directory already exists, and the directory contains the files from the previous runs, the test is invalid
- module load uses producer's managed path which is misleading due to the variable name
- Depending on the DTL mode, it shows different errors                                                          