### PR TITLE
Consume after kvs pull

### DIFF
--- a/pydyad/pydyad/bindings.py
+++ b/pydyad/pydyad/bindings.py
@@ -302,6 +302,22 @@ class Dyad:
             raise RuntimeError("Cannot consume data with DYAD!")
 
     @dlio_log.log
+    def consume_w_metadata(self, fname, metadata_wrapper):
+        if self.dyad_consume is None:
+            warnings.warn(
+                "Trying to consunme with metadata  with DYAD when libdyad_core.so was not found",
+                RuntimeWarning
+            )
+            return
+        res = self.dyad_consume_w_metadata(
+            self.ctx,
+            fname.encode(),
+            metadata_wrapper
+        )
+        if int(res) != 0:
+            raise RuntimeError("Cannot consume data with metadata with DYAD!")
+
+    @dlio_log.log
     def finalize(self):
         if not self.initialized:
             return

--- a/pydyad/pydyad/bindings.py
+++ b/pydyad/pydyad/bindings.py
@@ -83,6 +83,7 @@ class Dyad:
         self.dyad_init_env = None
         self.dyad_produce = None
         self.dyad_consume = None
+        self.dyad_consume_w_metadata = None
         self.dyad_finalize = None
         dyad_core_lib_file = None
         self.cons_path = None
@@ -94,6 +95,7 @@ class Dyad:
         if self.dyad_core_lib is None:
             raise FileNotFoundError("Cannot find libdyad_core")
         self.ctx = ctypes.POINTER(DyadCtxWrapper)()
+
         self.dyad_init = self.dyad_core_lib.dyad_init
         self.dyad_init.argtypes = [
             ctypes.c_bool,                                   # debug
@@ -110,17 +112,20 @@ class Dyad:
             ctypes.POINTER(ctypes.POINTER(DyadCtxWrapper)),  # ctx
         ]
         self.dyad_init.restype = ctypes.c_int
+
         self.dyad_init_env = self.dyad_core_lib.dyad_init_env
         self.dyad_init_env.argtypes = [
             ctypes.POINTER(ctypes.POINTER(DyadCtxWrapper))
         ]
         self.dyad_init_env.restype = ctypes.c_int
+
         self.dyad_produce = self.dyad_core_lib.dyad_produce
         self.dyad_produce.argtypes = [
             ctypes.POINTER(DyadCtxWrapper),
             ctypes.c_char_p,
         ]
         self.dyad_produce.restype = ctypes.c_int
+
         self.dyad_get_metadata = self.dyad_core_lib.dyad_get_metadata
         self.dyad_get_metadata.argtypes = [
             ctypes.POINTER(DyadCtxWrapper),
@@ -129,22 +134,34 @@ class Dyad:
             ctypes.POINTER(ctypes.POINTER(DyadMetadataWrapper)),
         ]
         self.dyad_get_metadata.restype = ctypes.c_int
+
         self.dyad_free_metadata = self.dyad_core_lib.dyad_free_metadata
         self.dyad_free_metadata.argtypes = [
             ctypes.POINTER(ctypes.POINTER(DyadMetadataWrapper))
         ]
         self.dyad_free_metadata.restype = ctypes.c_int
+
         self.dyad_consume = self.dyad_core_lib.dyad_consume
         self.dyad_consume.argtypes = [
             ctypes.POINTER(DyadCtxWrapper),
             ctypes.c_char_p,
         ]
         self.dyad_consume.restype = ctypes.c_int
+
+        self.dyad_consume_w_metadata = self.dyad_core_lib.dyad_consume_w_metadata
+        self.dyad_consume_w_metadata.argtypes = [
+            ctypes.POINTER(DyadCtxWrapper),
+            ctypes.c_char_p,
+            ctypes.POINTER(DyadMetadataWrapper),
+        ]
+        self.dyad_consume_w_metadata.restype = ctypes.c_int
+
         self.dyad_finalize = self.dyad_core_lib.dyad_finalize
         self.dyad_finalize.argtypes = [
             ctypes.POINTER(ctypes.POINTER(DyadCtxWrapper)),
         ]
         self.dyad_finalize.restype = ctypes.c_int
+
         self.cons_path = None
         self.prod_path = None
         self.log_inst = None

--- a/pydyad/pydyad/context.py
+++ b/pydyad/pydyad/context.py
@@ -13,7 +13,7 @@ DYAD_IO = None
 # https://peps.python.org/pep-0343/
 @contextmanager
 @dlio_log.log
-def dyad_open(*args, dyad_ctx=None, register_dyad_ctx=False, **kwargs):
+def dyad_open(*args, dyad_ctx=None, metadata_wrapper=None, register_dyad_ctx=False, **kwargs):
     global DYAD_IO
     local_dyad_io = dyad_ctx
     if dyad_ctx is None:
@@ -38,7 +38,10 @@ def dyad_open(*args, dyad_ctx=None, register_dyad_ctx=False, **kwargs):
     if mode in ("r", "rb", "rt"):
         if (local_dyad_io.cons_path is not None and
                 local_dyad_io.cons_path in fname.parents):
-            local_dyad_io.consume(str(fname))
+            if metadata_wrapper:
+                local_dyad_io.consume_w_metadata(str(fname), metadata_wrapper)
+            else:
+                local_dyad_io.consume(str(fname))
     file_obj = io.open(*args, **kwargs)
     try:
         yield file_obj

--- a/src/dyad/common/dyad_structures.h
+++ b/src/dyad/common/dyad_structures.h
@@ -37,6 +37,8 @@ struct dyad_ctx {
     char* cons_managed_path;        // consumer path managed by DYAD
 };
 typedef struct dyad_ctx dyad_ctx_t;
+typedef void* ucx_ep_cache_h;
+
 
 #ifdef __cplusplus
 }

--- a/src/dyad/core/dyad_core.c
+++ b/src/dyad/core/dyad_core.c
@@ -861,7 +861,7 @@ dyad_rc_t dyad_get_metadata (dyad_ctx_t* ctx,
     DYAD_C_FUNCTION_UPDATE_STR ("upath", upath);
     DYAD_LOG_INFO (ctx, "Generating KVS key: %s", topic);
     gen_path_key (upath, topic, topic_len, ctx->key_depth, ctx->key_bins);
-    rc = dyad_kvs_read (ctx, topic, fname, should_wait, mdata);
+    rc = dyad_kvs_read (ctx, topic, upath, should_wait, mdata);
     if (DYAD_IS_ERROR (rc)) {
         DYAD_LOG_ERROR (ctx, "Could not read data from the KVS");
         goto get_metadata_done;

--- a/src/dyad/core/dyad_core.h
+++ b/src/dyad/core/dyad_core.h
@@ -139,6 +139,19 @@ DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED dyad_rc_t dyad_free_metadata (dyad_metadata_
 DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED dyad_rc_t dyad_consume (dyad_ctx_t* ctx, const char* fname);
 
 /**
+ * @brief Wrapper function that performs all the common tasks needed
+ *        of a consumer
+ * @param[in] ctx    the DYAD context for the operation
+ * @param[in] fname  the name of the file being "consumed"
+ * @param[in] mdata  a dyad_metadata_t object containing the metadata for the file
+ *                   User is responsible for deallocating this object
+ *
+ * @return An error code from dyad_rc.h
+ */
+DYAD_PFA_ANNOTATE DYAD_DLL_EXPORTED dyad_rc_t dyad_consume_w_metadata (dyad_ctx_t* ctx, const char* fname,
+                                                                       const dyad_metadata_t* mdata);
+
+/**
  * @brief Finalizes the DYAD instance and deallocates the context
  * @param[in] ctx  the DYAD context being finalized
  *

--- a/src/dyad/dtl/dyad_dtl_api.c
+++ b/src/dyad/dtl/dyad_dtl_api.c
@@ -69,7 +69,7 @@ dyad_rc_t dyad_dtl_finalize (dyad_ctx_t* ctx)
     }
 #if DYAD_ENABLE_UCX_DTL
     if ((ctx->dtl_handle)->mode == DYAD_DTL_UCX) {
-        if ((ctx->dtl_handle)->private.ucx_dtl_handle != NULL) {
+        if ((ctx->dtl_handle)->private_dtl.ucx_dtl_handle != NULL) {
             rc = dyad_dtl_ucx_finalize (ctx);
             if (DYAD_IS_ERROR (rc)) {
                 goto dtl_finalize_done;
@@ -79,7 +79,7 @@ dyad_rc_t dyad_dtl_finalize (dyad_ctx_t* ctx)
 #else
     if ((ctx->dtl_handle)->mode == DYAD_DTL_FLUX_RPC) {
 #endif
-        if ((ctx->dtl_handle)->private.flux_dtl_handle != NULL) {
+        if ((ctx->dtl_handle)->private_dtl.flux_dtl_handle != NULL) {
             rc = dyad_dtl_flux_finalize (ctx);
             if (DYAD_IS_ERROR (rc)) {
                 goto dtl_finalize_done;

--- a/src/dyad/dtl/dyad_dtl_api.c
+++ b/src/dyad/dtl/dyad_dtl_api.c
@@ -49,7 +49,7 @@ dyad_rc_t dyad_dtl_init (dyad_ctx_t* ctx,
         goto dtl_init_done;
     }
     rc = DYAD_RC_OK;
-    DYAD_LOG_DEBUG (ctx, "Finished dyad_dtl_init without error");
+    DYAD_LOG_DEBUG (ctx, "Finished dyad_dtl_init successfully");
 dtl_init_done:;
      DYAD_C_FUNCTION_END();
     return rc;

--- a/src/dyad/dtl/dyad_dtl_api.h
+++ b/src/dyad/dtl/dyad_dtl_api.h
@@ -42,12 +42,12 @@ enum dyad_dtl_comm_mode {
 typedef enum dyad_dtl_comm_mode dyad_dtl_comm_mode_t;
 
 struct dyad_dtl {
-    dyad_dtl_private_t private;
+    dyad_dtl_private_t private_dtl;
     dyad_dtl_mode_t mode;
     dyad_rc_t (*rpc_pack) (const dyad_ctx_t* ctx,
-                           const char* restrict upath,
+                           const char*  upath,
                            uint32_t producer_rank,
-                           json_t** restrict packed_obj);
+                           json_t**  packed_obj);
     dyad_rc_t (*rpc_unpack) (const dyad_ctx_t* ctx, const flux_msg_t* packed_obj, char** upath);
     dyad_rc_t (*rpc_respond) (const dyad_ctx_t* ctx, const flux_msg_t* orig_msg);
     dyad_rc_t (*rpc_recv_response) (const dyad_ctx_t* ctx, flux_future_t* f);

--- a/src/dyad/dtl/flux_dtl.c
+++ b/src/dyad/dtl/flux_dtl.c
@@ -15,17 +15,17 @@ dyad_rc_t dyad_dtl_flux_init (const dyad_ctx_t* ctx,
 {
     dyad_rc_t rc = DYAD_RC_OK;
     DYAD_C_FUNCTION_START();
-    ctx->dtl_handle->private.flux_dtl_handle = malloc (sizeof (struct dyad_dtl_flux));
-    if (ctx->dtl_handle->private.flux_dtl_handle == NULL) {
+    ctx->dtl_handle->private_dtl.flux_dtl_handle = malloc (sizeof (struct dyad_dtl_flux));
+    if (ctx->dtl_handle->private_dtl.flux_dtl_handle == NULL) {
         DYAD_LOG_ERROR (ctx, "Cannot allocate the Flux DTL handle");
         rc = DYAD_RC_SYSFAIL;
         goto dtl_flux_init_region_finish;
     }
-    ctx->dtl_handle->private.flux_dtl_handle->h = ctx->h;
-    ctx->dtl_handle->private.flux_dtl_handle->comm_mode = comm_mode;
-    ctx->dtl_handle->private.flux_dtl_handle->debug = debug;
-    ctx->dtl_handle->private.flux_dtl_handle->f = NULL;
-    ctx->dtl_handle->private.flux_dtl_handle->msg = NULL;
+    ctx->dtl_handle->private_dtl.flux_dtl_handle->h = ctx->h;
+    ctx->dtl_handle->private_dtl.flux_dtl_handle->comm_mode = comm_mode;
+    ctx->dtl_handle->private_dtl.flux_dtl_handle->debug = debug;
+    ctx->dtl_handle->private_dtl.flux_dtl_handle->f = NULL;
+    ctx->dtl_handle->private_dtl.flux_dtl_handle->msg = NULL;
 
     ctx->dtl_handle->rpc_pack = dyad_dtl_flux_rpc_pack;
     ctx->dtl_handle->rpc_unpack = dyad_dtl_flux_rpc_unpack;
@@ -76,7 +76,7 @@ dyad_rc_t dyad_dtl_flux_rpc_unpack (const dyad_ctx_t* ctx, const flux_msg_t* msg
         dyad_rc = DYAD_RC_BADUNPACK;
         goto dtl_flux_rpc_unpack_region_finish;
     }
-    ctx->dtl_handle->private.flux_dtl_handle->msg = (flux_msg_t*)msg;
+    ctx->dtl_handle->private_dtl.flux_dtl_handle->msg = (flux_msg_t*)msg;
     dyad_rc = DYAD_RC_OK;
     DYAD_C_FUNCTION_UPDATE_STR ("upath", *upath);
 dtl_flux_rpc_unpack_region_finish:
@@ -94,7 +94,7 @@ dyad_rc_t dyad_dtl_flux_rpc_respond (const dyad_ctx_t* ctx, const flux_msg_t* or
 dyad_rc_t dyad_dtl_flux_rpc_recv_response (const dyad_ctx_t* ctx, flux_future_t* f)
 {
     DYAD_C_FUNCTION_START();
-    ctx->dtl_handle->private.flux_dtl_handle->f = f;
+    ctx->dtl_handle->private_dtl.flux_dtl_handle->f = f;
     DYAD_C_FUNCTION_END();
     return DYAD_RC_OK;
 }
@@ -149,8 +149,8 @@ dyad_rc_t dyad_dtl_flux_send (const dyad_ctx_t* ctx, void* buf, size_t buflen)
     int rc = 0;
     DYAD_LOG_INFO (ctx,
                    "Send data to consumer using a Flux RPC response");
-    rc = flux_respond_raw (ctx->dtl_handle->private.flux_dtl_handle->h,
-                           ctx->dtl_handle->private.flux_dtl_handle->msg,
+    rc = flux_respond_raw (ctx->dtl_handle->private_dtl.flux_dtl_handle->h,
+                           ctx->dtl_handle->private_dtl.flux_dtl_handle->msg,
                            buf,
                            (int)buflen);
     if (FLUX_IS_ERROR (rc)) {
@@ -160,7 +160,7 @@ dyad_rc_t dyad_dtl_flux_send (const dyad_ctx_t* ctx, void* buf, size_t buflen)
         dyad_rc = DYAD_RC_FLUXFAIL;
         goto dtl_flux_send_region_finish;
     }
-    if (ctx->dtl_handle->private.flux_dtl_handle->debug) {
+    if (ctx->dtl_handle->private_dtl.flux_dtl_handle->debug) {
         DYAD_LOG_INFO (ctx,
                        "Successfully sent file contents to consumer");
     }
@@ -177,7 +177,7 @@ dyad_rc_t dyad_dtl_flux_recv (const dyad_ctx_t* ctx, void** buf, size_t* buflen)
     int rc = 0;
     dyad_rc_t dyad_rc = DYAD_RC_OK;
     errno = 0;
-    dyad_dtl_flux_t* dtl_handle = ctx->dtl_handle->private.flux_dtl_handle;
+    dyad_dtl_flux_t* dtl_handle = ctx->dtl_handle->private_dtl.flux_dtl_handle;
     DYAD_LOG_INFO (ctx, "Get file contents from module using Flux RPC");
     if (dtl_handle->f == NULL) {
         DYAD_LOG_ERROR (ctx, "Cannot get data using RPC without a Flux future");
@@ -216,10 +216,10 @@ finish_recv:
 dyad_rc_t dyad_dtl_flux_close_connection (const dyad_ctx_t* ctx)
 {
     DYAD_C_FUNCTION_START();
-    if (ctx->dtl_handle->private.flux_dtl_handle->f != NULL)
-        ctx->dtl_handle->private.flux_dtl_handle->f = NULL;
-    if (ctx->dtl_handle->private.flux_dtl_handle->msg != NULL)
-        ctx->dtl_handle->private.flux_dtl_handle->msg = NULL;
+    if (ctx->dtl_handle->private_dtl.flux_dtl_handle->f != NULL)
+        ctx->dtl_handle->private_dtl.flux_dtl_handle->f = NULL;
+    if (ctx->dtl_handle->private_dtl.flux_dtl_handle->msg != NULL)
+        ctx->dtl_handle->private_dtl.flux_dtl_handle->msg = NULL;
     DYAD_C_FUNCTION_END();
     return DYAD_RC_OK;
 }
@@ -231,11 +231,11 @@ dyad_rc_t dyad_dtl_flux_finalize (const dyad_ctx_t* ctx)
     if (ctx->dtl_handle == NULL) {
         goto dtl_flux_finalize_done;
     }
-    ctx->dtl_handle->private.flux_dtl_handle->h = NULL;
-    ctx->dtl_handle->private.flux_dtl_handle->f = NULL;
-    ctx->dtl_handle->private.flux_dtl_handle->msg = NULL;
-    free (ctx->dtl_handle->private.flux_dtl_handle);
-    ctx->dtl_handle->private.flux_dtl_handle = NULL;
+    ctx->dtl_handle->private_dtl.flux_dtl_handle->h = NULL;
+    ctx->dtl_handle->private_dtl.flux_dtl_handle->f = NULL;
+    ctx->dtl_handle->private_dtl.flux_dtl_handle->msg = NULL;
+    free (ctx->dtl_handle->private_dtl.flux_dtl_handle);
+    ctx->dtl_handle->private_dtl.flux_dtl_handle = NULL;
 dtl_flux_finalize_done:;
     DYAD_C_FUNCTION_END();
     return rc;

--- a/src/dyad/dtl/ucx_dtl.h
+++ b/src/dyad/dtl/ucx_dtl.h
@@ -28,6 +28,7 @@ struct dyad_dtl_ucx {
     ucp_ep_h ep;
     ucp_tag_t comm_tag;
     ucx_ep_cache_h ep_cache;
+    uint64_t consumer_conn_key;
 };
 
 typedef struct dyad_dtl_ucx dyad_dtl_ucx_t;
@@ -38,9 +39,9 @@ dyad_rc_t dyad_dtl_ucx_init (const dyad_ctx_t* ctx,
                              bool debug);
 
 dyad_rc_t dyad_dtl_ucx_rpc_pack (const dyad_ctx_t* ctx,
-                                 const char* restrict upath,
+                                 const char*  upath,
                                  uint32_t producer_rank,
-                                 json_t** restrict packed_obj);
+                                 json_t**  packed_obj);
 
 dyad_rc_t dyad_dtl_ucx_rpc_unpack (const dyad_ctx_t* ctx, const flux_msg_t* msg, char** upath);
 

--- a/src/dyad/dtl/ucx_ep_cache.h
+++ b/src/dyad/dtl/ucx_ep_cache.h
@@ -11,6 +11,7 @@
 #include <dyad/common/dyad_structures.h>
 #include <ucp/api/ucp.h>
 #include <flux/core.h>
+#include <dyad/dtl/ucx_dtl.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,7 +21,7 @@ extern "C" {
 // of UCX operations
 #define UCX_STATUS_FAIL(status) (status != UCS_OK)
 
-typedef void* ucx_ep_cache_h;
+
 
 dyad_rc_t ucx_connect (const dyad_ctx_t *ctx,
                        ucp_worker_h worker,

--- a/tests/integration/dlio_benchmark/configs/workload/dyad_unet3d.yaml
+++ b/tests/integration/dlio_benchmark/configs/workload/dyad_unet3d.yaml
@@ -19,7 +19,7 @@ dataset:
 reader: 
   data_loader: pytorch
   batch_size: 4
-  read_threads: 3
+  read_threads: 6
   file_shuffle: seed
   sample_shuffle: seed
   multiprocessing_context: spawn


### PR DESCRIPTION
1. Fixes a bug in `dyad_consume()` that returns the buffer that has never been assigned.
2. Adds an variant interface of `dyad_consume()` that relies on the metadata that has already been pulled from KVS 
3. Still need to add a python interface: note that the new interface `dyad_consume_w_mdata(..., mdata)` deallocates mdata internally. We can change this behavior depending on how we want to write python interface.