### PR TITLE
Bug Fix for shared storage 

### DIFF
--- a/pydyad/pydyad/bindings.py
+++ b/pydyad/pydyad/bindings.py
@@ -22,6 +22,7 @@ class DyadCtxWrapper(ctypes.Structure):
         ("h", ctypes.POINTER(FluxHandle)),
         ("dtl_handle", ctypes.POINTER(DyadDTLHandle)),
         ("fname", ctypes.c_char_p),
+        ("use_fs_locks", ctypes.c_bool),
         ("debug", ctypes.c_bool),
         ("check", ctypes.c_bool),
         ("reenter", ctypes.c_bool),

--- a/src/dyad/common/dyad_structures.h
+++ b/src/dyad/common/dyad_structures.h
@@ -20,6 +20,7 @@ struct dyad_ctx {
     flux_t* h;                      // the Flux handle for DYAD
     struct dyad_dtl* dtl_handle;    // Opaque handle to DTL info
     const char* fname;              // Used to track which file is getting processed.
+    bool use_fs_locks;              // Used to track if fs locks should be used.
     // User Facing
     bool debug;                     // if true, perform debug logging
     bool check;                     // if true, perform some check logging

--- a/src/dyad/core/dyad_core.c
+++ b/src/dyad/core/dyad_core.c
@@ -35,6 +35,7 @@ const struct dyad_ctx dyad_ctx_default = {
     NULL,   // h
     NULL,   // dtl_handle
     NULL,   // fname
+    false,  // use_fs_locks
     false,  // debug
     false,  // check
     false,  // reenter
@@ -303,10 +304,6 @@ DYAD_CORE_FUNC_MODS dyad_rc_t dyad_fetch (const dyad_ctx_t* restrict ctx,
     char upath[PATH_MAX] = {'\0'};
     const size_t topic_len = PATH_MAX;
     char topic[PATH_MAX + 1] = {'\0'};
-    if (ctx->shared_storage) {
-        rc = DYAD_RC_OK;
-        goto fetch_done;
-    }
     memset (upath, 0, PATH_MAX);
     memset (topic, 0, topic_len + 1);
     // Extract the path to the file specified by fname relative to the
@@ -674,6 +671,7 @@ dyad_rc_t dyad_init (bool debug,
     // Set reenter and initialized to indicate this.
     (*ctx)->reenter = true;
     (*ctx)->initialized = true;
+    (*ctx)->use_fs_locks = true; // This is default value except for streams which dont have a fp.
     // TODO Print logging info
     rc = DYAD_RC_OK;
     // TODO: Add folder option here.
@@ -934,58 +932,72 @@ dyad_rc_t dyad_consume (dyad_ctx_t* ctx, const char* fname)
         dyad_release_flock (ctx, fd, &exclusive_lock);
         goto consume_close;
     }
-    if ((file_size = get_file_size (fd)) <= 0) {
-        DYAD_LOG_INFO (ctx, "[node %u rank %u pid %d] File (%s with fd %d) is not fetched yet", \
+    file_size = get_file_size (fd);
+    if (ctx->shared_storage) {
+        dyad_release_flock (ctx, fd, &exclusive_lock);
+        if (!ctx->use_fs_locks || file_size <= 0) {
+            // as file size was zero that means consumer won the lock first so has to wait for kvs.
+            // or we cannot use file lock based synchronization as it does not work with the
+            // files managed by c++ fstream.
+            dyad_fetch(ctx, fname, &mdata);
+        }
+    } else {
+        if (file_size <= 0) {
+            DYAD_LOG_INFO (ctx, "[node %u rank %u pid %d] File (%s with fd %d) is not fetched yet", \
                        ctx->node_idx, ctx->rank, ctx->pid, fname, fd);
-        // Call dyad_fetch to get (and possibly wait on)
-        // data from the Flux KVS
-        rc = dyad_fetch (ctx, fname, &mdata);
-        // If an error occured in dyad_fetch, log an error
-        // and return the corresponding DYAD return code
-        if (DYAD_IS_ERROR (rc)) {
-            DYAD_LOG_ERROR (ctx, "dyad_fetch failed!\n");
-            dyad_release_flock (ctx, fd, &exclusive_lock);
-            goto consume_close;
-        }
-        // If dyad_fetch was successful, but resp is still NULL,
-        // then we need to skip data transfer.
-        // This will most likely happend because shared_storage
-        // is enabled
-        if (mdata == NULL) {
-            DYAD_LOG_INFO (ctx, "File '%s' is local!\n", fname);
-            rc = DYAD_RC_OK;
-            dyad_release_flock (ctx, fd, &exclusive_lock);
-            goto consume_close;
-        }
+            // Call dyad_fetch to get (and possibly wait on)
+            // data from the Flux KVS
+            rc = dyad_fetch (ctx, fname, &mdata);
+            // If an error occured in dyad_fetch, log an error
+            // and return the corresponding DYAD return code
+            if (DYAD_IS_ERROR (rc)) {
+                DYAD_LOG_ERROR (ctx, "dyad_fetch failed!\n");
+                dyad_release_flock (ctx, fd, &exclusive_lock);
+                goto consume_close;
+            }
+            // If dyad_fetch was successful, but resp is still NULL,
+            // then we need to skip data transfer.
+            // This will most likely happend because shared_storage
+            // is enabled
+            if (mdata == NULL) {
+                DYAD_LOG_INFO (ctx, "File '%s' is local!\n", fname);
+                rc = DYAD_RC_OK;
+                dyad_release_flock (ctx, fd, &exclusive_lock);
+                goto consume_close;
+            }
 
-        // Call dyad_get_data to dispatch a RPC to the producer's Flux broker
-        // and retrieve the data associated with the file
-        rc = dyad_get_data (ctx, mdata, &file_data, &data_len);
-        if (DYAD_IS_ERROR (rc)) {
-            DYAD_LOG_ERROR (ctx, "dyad_get_data failed!\n");
-            dyad_release_flock (ctx, fd, &exclusive_lock);
-            goto consume_done;
-        }
-        DYAD_C_FUNCTION_UPDATE_INT ("data_len", data_len);
+            // Call dyad_get_data to dispatch a RPC to the producer's Flux broker
+            // and retrieve the data associated with the file
+            rc = dyad_get_data (ctx, mdata, &file_data, &data_len);
+            if (DYAD_IS_ERROR (rc)) {
+                DYAD_LOG_ERROR (ctx, "dyad_get_data failed!\n");
+                dyad_release_flock (ctx, fd, &exclusive_lock);
+                goto consume_done;
+            }
+            DYAD_C_FUNCTION_UPDATE_INT ("data_len", data_len);
 
-        // Call dyad_pull to fetch the data from the producer's
-        // Flux broker
-        rc = dyad_cons_store (ctx, mdata, fd, data_len, file_data);
-        // Regardless if there was an error in dyad_pull,
-        // free the KVS response object
-        if (mdata != NULL) {
-            dyad_free_metadata (&mdata);
+            // Call dyad_pull to fetch the data from the producer's
+            // Flux broker
+            rc = dyad_cons_store (ctx, mdata, fd, data_len, file_data);
+            // Regardless if there was an error in dyad_pull,
+            // free the KVS response object
+            if (mdata != NULL) {
+                dyad_free_metadata (&mdata);
+            }
+            // If an error occured in dyad_pull, log it
+            // and return the corresponding DYAD return code
+            if (DYAD_IS_ERROR (rc)) {
+                DYAD_LOG_ERROR (ctx, "dyad_cons_store failed!\n");
+                dyad_release_flock (ctx, fd, &exclusive_lock);
+                goto consume_done;
+            };
+            fsync (fd);
         }
-        // If an error occured in dyad_pull, log it
-        // and return the corresponding DYAD return code
-        if (DYAD_IS_ERROR (rc)) {
-            DYAD_LOG_ERROR (ctx, "dyad_cons_store failed!\n");
-            dyad_release_flock (ctx, fd, &exclusive_lock);
-            goto consume_done;
-        };
-        fsync (fd);
+        dyad_release_flock (ctx, fd, &exclusive_lock);
     }
-    dyad_release_flock (ctx, fd, &exclusive_lock);
+
+
+
     DYAD_C_FUNCTION_UPDATE_INT ("file_size", file_size);
 
     if (close (fd) != 0) {

--- a/src/dyad/modules/dyad.c
+++ b/src/dyad/modules/dyad.c
@@ -69,6 +69,9 @@ void dyad_mod_fini (void)
 
     if (h != NULL) {
     }
+#ifdef DYAD_PROFILER_DLIO_PROFILER
+    DLIO_PROFILER_C_FINI ();
+#endif
 }
 
 static void freectx (void *arg)
@@ -428,7 +431,7 @@ DYAD_DLL_EXPORTED int mod_main (flux_t *h, int argc, char **argv)
         DYAD_LOG_DEBUG (mod_ctx->ctx, "flux_reactor_run: %s", strerror (errno));
         goto mod_error;
     }
-
+    DYAD_LOG_DEBUG (mod_ctx->ctx, "DYAD Module finished");
     goto mod_done;
 
 mod_error:;

--- a/src/dyad/stream/dyad_stream_core.cpp
+++ b/src/dyad/stream/dyad_stream_core.cpp
@@ -122,6 +122,8 @@ void dyad_stream_core::init (const dyad_params &p)
                               p.m_cons_managed_path.c_str (),
                               static_cast<dyad_dtl_mode_t> (p.m_dtl_mode),
                               &m_ctx);
+    // TODO:  implement a lock file based synchronization scheme.
+    m_ctx->use_fs_locks = false; // this is to disable checking for fs lock based logic.
     (void) rc;
     // TODO figure out if we want to error if init fails
     m_initialized = true;

--- a/tests/integration/dlio_benchmark/configs/workload/dyad_unet3d.yaml
+++ b/tests/integration/dlio_benchmark/configs/workload/dyad_unet3d.yaml
@@ -28,7 +28,7 @@ reader:
 
 train:
   epochs: 10
-  computation_time: 0 #1.3604
+  computation_time: 1.3604
 
 checkpoint:
   checkpoint_folder: checkpoints/unet3d

--- a/tests/integration/dlio_benchmark/perf_analysis/dlp_analyzer-checkpoint.ipynb
+++ b/tests/integration/dlio_benchmark/perf_analysis/dlp_analyzer-checkpoint.ipynb
@@ -6,8 +6,8 @@
    "id": "86ed50dc-d4d6-4e78-be69-1d55b8362a46",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:21.882558Z",
-     "start_time": "2024-01-28T06:05:21.838181Z"
+     "end_time": "2024-01-29T07:14:45.521145Z",
+     "start_time": "2024-01-29T07:14:45.495862Z"
     },
     "scrolled": true
    },
@@ -22,8 +22,8 @@
    "id": "93bc48a5-30a9-4108-88a6-59861bddd0ce",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:21.895263Z",
-     "start_time": "2024-01-28T06:05:21.888559Z"
+     "end_time": "2024-01-29T07:14:45.528354Z",
+     "start_time": "2024-01-29T07:14:45.524654Z"
     }
    },
    "outputs": [],
@@ -37,8 +37,8 @@
    "id": "4a47492d-40d0-4dea-b1a2-aa1f083239e3",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:22.504400Z",
-     "start_time": "2024-01-28T06:05:21.898712Z"
+     "end_time": "2024-01-29T07:14:46.371271Z",
+     "start_time": "2024-01-29T07:14:45.530925Z"
     }
    },
    "outputs": [
@@ -66,8 +66,8 @@
    "id": "7c006011",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:22.532069Z",
-     "start_time": "2024-01-28T06:05:22.508824Z"
+     "end_time": "2024-01-29T07:14:46.397739Z",
+     "start_time": "2024-01-29T07:14:46.375363Z"
     }
    },
    "outputs": [],
@@ -81,8 +81,8 @@
    "id": "ef1dcd21-7001-47d4-b0e0-b9460b86556d",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:22.559152Z",
-     "start_time": "2024-01-28T06:05:22.535547Z"
+     "end_time": "2024-01-29T07:14:46.423805Z",
+     "start_time": "2024-01-29T07:14:46.400214Z"
     }
    },
    "outputs": [],
@@ -101,8 +101,8 @@
    "id": "c310a43c-006c-4c36-9d54-d7056e9c0519",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:22.591442Z",
-     "start_time": "2024-01-28T06:05:22.562613Z"
+     "end_time": "2024-01-29T07:14:46.454843Z",
+     "start_time": "2024-01-29T07:14:46.426548Z"
     }
    },
    "outputs": [
@@ -136,8 +136,8 @@
    "id": "89d58cc4-dd7a-47f8-82a6-6ef2ea9a2bc0",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:24.159702Z",
-     "start_time": "2024-01-28T06:05:22.594801Z"
+     "end_time": "2024-01-29T07:14:48.044731Z",
+     "start_time": "2024-01-29T07:14:46.457547Z"
     }
    },
    "outputs": [
@@ -161,8 +161,8 @@
    "id": "91b2872f",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:24.196047Z",
-     "start_time": "2024-01-28T06:05:24.163742Z"
+     "end_time": "2024-01-29T07:14:48.079887Z",
+     "start_time": "2024-01-29T07:14:48.048032Z"
     }
    },
    "outputs": [],
@@ -181,8 +181,8 @@
    "id": "1b330315-f487-409a-b2c6-d6eab2894b87",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:24.230333Z",
-     "start_time": "2024-01-28T06:05:24.199492Z"
+     "end_time": "2024-01-29T07:14:48.113271Z",
+     "start_time": "2024-01-29T07:14:48.082813Z"
     }
    },
    "outputs": [],
@@ -196,8 +196,8 @@
    "id": "6fe1d34c-f607-4c29-ad3e-e199276fd30c",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:24.273508Z",
-     "start_time": "2024-01-28T06:05:24.236621Z"
+     "end_time": "2024-01-29T07:14:48.156013Z",
+     "start_time": "2024-01-29T07:14:48.119577Z"
     }
    },
    "outputs": [],
@@ -238,8 +238,8 @@
    "id": "face72a1-485a-4168-b87a-2171aad37691",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:24.311538Z",
-     "start_time": "2024-01-28T06:05:24.276922Z"
+     "end_time": "2024-01-29T07:14:48.192932Z",
+     "start_time": "2024-01-29T07:14:48.158769Z"
     }
    },
    "outputs": [],
@@ -269,6 +269,7 @@
     "    filename = \"/usr/workspace/ice4hpc/dlio/dyad_logs/01-27/n2_p8_br1/*.pfw\"\n",
     "    filename = \"/usr/WS2/haridev/dyad/tests/integration/dlio_benchmark/hydra_log/unet3d/2024-01-27-20-06-06/*.pfw\"\n",
     "    #filename = \"/usr/WS2/haridev/dyad/tests/integration/dlio_benchmark/hydra_log/unet3d/2024-01-27-20-16-14/*.pfw\"\n",
+    "    filename = \"/usr/WS2/haridev/dyad/tests/integration/dlio_benchmark/hydra_log/unet3d/2024-01-28-23-08-42/*.pfw\" # shm\n",
     "    condition_fn = get_conditions_dyad_dlio_unet3d\n",
     "else:\n",
     "    raise Exception(\"Unknown App name\")"
@@ -280,8 +281,8 @@
    "id": "d7d8637e",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:24.355962Z",
-     "start_time": "2024-01-28T06:05:24.314597Z"
+     "end_time": "2024-01-29T07:14:48.228347Z",
+     "start_time": "2024-01-29T07:14:48.195682Z"
     }
    },
    "outputs": [],
@@ -304,8 +305,8 @@
    "id": "025a3289",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:24.391880Z",
-     "start_time": "2024-01-28T06:05:24.359776Z"
+     "end_time": "2024-01-29T07:14:48.261377Z",
+     "start_time": "2024-01-29T07:14:48.231206Z"
     }
    },
    "outputs": [],
@@ -321,8 +322,8 @@
    "id": "5f41509f",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:24.426342Z",
-     "start_time": "2024-01-28T06:05:24.395342Z"
+     "end_time": "2024-01-29T07:14:48.294466Z",
+     "start_time": "2024-01-29T07:14:48.264161Z"
     }
    },
    "outputs": [],
@@ -339,8 +340,8 @@
    "id": "d3a7cf5b-fbbc-4eee-9ed5-ce869f4541e6",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:24.466527Z",
-     "start_time": "2024-01-28T06:05:24.429111Z"
+     "end_time": "2024-01-29T07:14:48.328475Z",
+     "start_time": "2024-01-29T07:14:48.297308Z"
     }
    },
    "outputs": [],
@@ -356,8 +357,8 @@
    "id": "9ae31f27-a26a-463a-b2e9-3adba8de7246",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:24.509811Z",
-     "start_time": "2024-01-28T06:05:24.469732Z"
+     "end_time": "2024-01-29T07:14:48.362983Z",
+     "start_time": "2024-01-29T07:14:48.330761Z"
     },
     "scrolled": true
    },
@@ -384,8 +385,8 @@
    "id": "04428959-820f-4466-8ceb-778bcce93bf0",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:24.562067Z",
-     "start_time": "2024-01-28T06:05:24.512780Z"
+     "end_time": "2024-01-29T07:14:48.396383Z",
+     "start_time": "2024-01-29T07:14:48.365244Z"
     }
    },
    "outputs": [],
@@ -399,8 +400,8 @@
    "id": "68e813b7-6b95-4f31-b223-1fb50774db50",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:28.324395Z",
-     "start_time": "2024-01-28T06:05:24.565286Z"
+     "end_time": "2024-01-29T07:14:52.499403Z",
+     "start_time": "2024-01-29T07:14:48.399205Z"
     }
    },
    "outputs": [
@@ -408,23 +409,23 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO] [22:05:28] Initialized Client with 16 workers and link http://127.0.0.1:8787/status [/usr/WS2/haridev/dyad/env/python/lib/python3.9/site-packages/dlp_analyzer/main.py:670]\n",
-      "2024-01-27 22:05:28,614 - distributed.nanny - WARNING - Restarting worker\n",
-      "2024-01-27 22:05:28,663 - distributed.nanny - WARNING - Restarting worker\n",
-      "2024-01-27 22:05:28,693 - distributed.nanny - WARNING - Restarting worker\n",
-      "2024-01-27 22:05:28,733 - distributed.nanny - WARNING - Restarting worker\n",
-      "2024-01-27 22:05:28,774 - distributed.nanny - WARNING - Restarting worker\n",
-      "2024-01-27 22:05:28,778 - distributed.nanny - WARNING - Restarting worker\n",
-      "2024-01-27 22:05:28,794 - distributed.nanny - WARNING - Restarting worker\n",
-      "2024-01-27 22:05:28,844 - distributed.nanny - WARNING - Restarting worker\n",
-      "2024-01-27 22:05:28,861 - distributed.nanny - WARNING - Restarting worker\n",
-      "2024-01-27 22:05:28,867 - distributed.nanny - WARNING - Restarting worker\n",
-      "2024-01-27 22:05:28,883 - distributed.nanny - WARNING - Restarting worker\n",
-      "2024-01-27 22:05:28,920 - distributed.nanny - WARNING - Restarting worker\n",
-      "2024-01-27 22:05:28,925 - distributed.nanny - WARNING - Restarting worker\n",
-      "2024-01-27 22:05:28,964 - distributed.nanny - WARNING - Restarting worker\n",
-      "2024-01-27 22:05:28,969 - distributed.nanny - WARNING - Restarting worker\n",
-      "2024-01-27 22:05:28,988 - distributed.nanny - WARNING - Restarting worker\n"
+      "[INFO] [23:14:52] Initialized Client with 16 workers and link http://127.0.0.1:8787/status [/usr/WS2/haridev/dyad/env/python/lib/python3.9/site-packages/dlp_analyzer/main.py:670]\n",
+      "2024-01-28 23:14:52,736 - distributed.nanny - WARNING - Restarting worker\n",
+      "2024-01-28 23:14:52,759 - distributed.nanny - WARNING - Restarting worker\n",
+      "2024-01-28 23:14:52,785 - distributed.nanny - WARNING - Restarting worker\n",
+      "2024-01-28 23:14:52,809 - distributed.nanny - WARNING - Restarting worker\n",
+      "2024-01-28 23:14:52,841 - distributed.nanny - WARNING - Restarting worker\n",
+      "2024-01-28 23:14:52,857 - distributed.nanny - WARNING - Restarting worker\n",
+      "2024-01-28 23:14:52,861 - distributed.nanny - WARNING - Restarting worker\n",
+      "2024-01-28 23:14:52,902 - distributed.nanny - WARNING - Restarting worker\n",
+      "2024-01-28 23:14:52,919 - distributed.nanny - WARNING - Restarting worker\n",
+      "2024-01-28 23:14:52,956 - distributed.nanny - WARNING - Restarting worker\n",
+      "2024-01-28 23:14:52,959 - distributed.nanny - WARNING - Restarting worker\n",
+      "2024-01-28 23:14:52,999 - distributed.nanny - WARNING - Restarting worker\n",
+      "2024-01-28 23:14:53,003 - distributed.nanny - WARNING - Restarting worker\n",
+      "2024-01-28 23:14:53,019 - distributed.nanny - WARNING - Restarting worker\n",
+      "2024-01-28 23:14:53,037 - distributed.nanny - WARNING - Restarting worker\n",
+      "2024-01-28 23:14:53,058 - distributed.nanny - WARNING - Restarting worker\n"
      ]
     }
    ],
@@ -438,8 +439,8 @@
    "id": "236e50a4-03b6-4895-a0a5-d473f5e391b5",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:31.851066Z",
-     "start_time": "2024-01-28T06:05:28.328736Z"
+     "end_time": "2024-01-29T07:14:54.911151Z",
+     "start_time": "2024-01-29T07:14:52.502644Z"
     },
     "scrolled": true
    },
@@ -448,7 +449,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO] [22:05:31] Restarting all workers [/usr/WS2/haridev/dyad/env/python/lib/python3.9/site-packages/dlp_analyzer/main.py:658]\n"
+      "[INFO] [23:14:54] Restarting all workers [/usr/WS2/haridev/dyad/env/python/lib/python3.9/site-packages/dlp_analyzer/main.py:658]\n"
      ]
     }
    ],
@@ -462,8 +463,8 @@
    "id": "b37727ee-a221-43ab-81e1-cdf98c2cf314",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:35.639057Z",
-     "start_time": "2024-01-28T06:05:31.855492Z"
+     "end_time": "2024-01-29T07:14:58.567889Z",
+     "start_time": "2024-01-29T07:14:54.913380Z"
     },
     "scrolled": true
    },
@@ -472,10 +473,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO] [22:05:31] Created index for 0 files [/usr/WS2/haridev/dyad/env/python/lib/python3.9/site-packages/dlp_analyzer/main.py:367]\n",
-      "[INFO] [22:05:31] Total size of all files are <dask.bag.core.Item object at 0x1555197ec430> bytes [/usr/WS2/haridev/dyad/env/python/lib/python3.9/site-packages/dlp_analyzer/main.py:369]\n",
-      "[INFO] [22:05:35] Loaded events [/usr/WS2/haridev/dyad/env/python/lib/python3.9/site-packages/dlp_analyzer/main.py:424]\n",
-      "[INFO] [22:05:35] Loaded plots with slope threshold: 45 [/usr/WS2/haridev/dyad/env/python/lib/python3.9/site-packages/dlp_analyzer/main.py:430]\n"
+      "[INFO] [23:14:55] Created index for 0 files [/usr/WS2/haridev/dyad/env/python/lib/python3.9/site-packages/dlp_analyzer/main.py:367]\n",
+      "[INFO] [23:14:55] Total size of all files are <dask.bag.core.Item object at 0x155519a3c790> bytes [/usr/WS2/haridev/dyad/env/python/lib/python3.9/site-packages/dlp_analyzer/main.py:369]\n",
+      "[INFO] [23:14:58] Loaded events [/usr/WS2/haridev/dyad/env/python/lib/python3.9/site-packages/dlp_analyzer/main.py:424]\n",
+      "[INFO] [23:14:58] Loaded plots with slope threshold: 45 [/usr/WS2/haridev/dyad/env/python/lib/python3.9/site-packages/dlp_analyzer/main.py:430]\n"
      ]
     }
    ],
@@ -489,8 +490,8 @@
    "id": "c8c4b2d0-76c4-46df-9a35-068c98aaa7f8",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:35.760068Z",
-     "start_time": "2024-01-28T06:05:35.642411Z"
+     "end_time": "2024-01-29T07:14:58.881840Z",
+     "start_time": "2024-01-29T07:14:58.571943Z"
     }
    },
    "outputs": [
@@ -542,12 +543,12 @@
        "      <td>DLIOBenchmark.__init__</td>\n",
        "      <td>dlio_benchmark</td>\n",
        "      <td>1</td>\n",
-       "      <td>1846469</td>\n",
-       "      <td>28812083</td>\n",
-       "      <td>28812114</td>\n",
-       "      <td>31</td>\n",
+       "      <td>4158662</td>\n",
+       "      <td>159</td>\n",
+       "      <td>195</td>\n",
+       "      <td>36</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>28.0</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>corona171</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -564,12 +565,12 @@
        "      <td>FileStorage.get_uri</td>\n",
        "      <td>storage</td>\n",
        "      <td>1</td>\n",
-       "      <td>1846469</td>\n",
-       "      <td>28813871</td>\n",
-       "      <td>28813880</td>\n",
+       "      <td>4158662</td>\n",
+       "      <td>3339</td>\n",
+       "      <td>3348</td>\n",
        "      <td>9</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>28.0</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>corona171</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -586,17 +587,17 @@
        "      <td>opendir</td>\n",
        "      <td>POSIX</td>\n",
        "      <td>1</td>\n",
-       "      <td>1846469</td>\n",
-       "      <td>28813967</td>\n",
-       "      <td>28818878</td>\n",
-       "      <td>4911</td>\n",
+       "      <td>4158662</td>\n",
+       "      <td>3432</td>\n",
+       "      <td>9060</td>\n",
+       "      <td>5628</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>28.0</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>corona171</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>4911</td>\n",
+       "      <td>5628</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>4911</td>\n",
+       "      <td>5628</td>\n",
        "      <td>/p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...</td>\n",
        "      <td>2</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -608,12 +609,12 @@
        "      <td>FileStorage.walk_node</td>\n",
        "      <td>storage</td>\n",
        "      <td>1</td>\n",
-       "      <td>1846469</td>\n",
-       "      <td>28813860</td>\n",
-       "      <td>28820225</td>\n",
-       "      <td>6365</td>\n",
+       "      <td>4158662</td>\n",
+       "      <td>3328</td>\n",
+       "      <td>10635</td>\n",
+       "      <td>7307</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>28.0</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>corona171</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -630,12 +631,12 @@
        "      <td>FileStorage.get_uri</td>\n",
        "      <td>storage</td>\n",
        "      <td>1</td>\n",
-       "      <td>1846469</td>\n",
-       "      <td>28820298</td>\n",
-       "      <td>28820305</td>\n",
-       "      <td>7</td>\n",
+       "      <td>4158662</td>\n",
+       "      <td>10710</td>\n",
+       "      <td>10718</td>\n",
+       "      <td>8</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>28.0</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>corona171</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -652,24 +653,24 @@
        "</div>"
       ],
       "text/plain": [
-       "                     name             cat  pid      tid        ts        te  \\\n",
-       "0  DLIOBenchmark.__init__  dlio_benchmark    1  1846469  28812083  28812114   \n",
-       "1     FileStorage.get_uri         storage    1  1846469  28813871  28813880   \n",
-       "2                 opendir           POSIX    1  1846469  28813967  28818878   \n",
-       "3   FileStorage.walk_node         storage    1  1846469  28813860  28820225   \n",
-       "4     FileStorage.get_uri         storage    1  1846469  28820298  28820305   \n",
+       "                     name             cat  pid      tid     ts     te   dur  \\\n",
+       "0  DLIOBenchmark.__init__  dlio_benchmark    1  4158662    159    195    36   \n",
+       "1     FileStorage.get_uri         storage    1  4158662   3339   3348     9   \n",
+       "2                 opendir           POSIX    1  4158662   3432   9060  5628   \n",
+       "3   FileStorage.walk_node         storage    1  4158662   3328  10635  7307   \n",
+       "4     FileStorage.get_uri         storage    1  4158662  10710  10718     8   \n",
        "\n",
-       "    dur  tinterval  trange   hostname  compute_time  io_time  app_io_time  \\\n",
-       "0    31       <NA>    28.0  corona171          <NA>     <NA>         <NA>   \n",
-       "1     9       <NA>    28.0  corona171          <NA>     <NA>         <NA>   \n",
-       "2  4911       <NA>    28.0  corona171          <NA>     4911         <NA>   \n",
-       "3  6365       <NA>    28.0  corona171          <NA>     <NA>         <NA>   \n",
-       "4     7       <NA>    28.0  corona171          <NA>     <NA>         <NA>   \n",
+       "   tinterval  trange   hostname  compute_time  io_time  app_io_time  \\\n",
+       "0       <NA>     0.0  corona171          <NA>     <NA>         <NA>   \n",
+       "1       <NA>     0.0  corona171          <NA>     <NA>         <NA>   \n",
+       "2       <NA>     0.0  corona171          <NA>     5628         <NA>   \n",
+       "3       <NA>     0.0  corona171          <NA>     <NA>         <NA>   \n",
+       "4       <NA>     0.0  corona171          <NA>     <NA>         <NA>   \n",
        "\n",
        "   total_time                                           filename  phase  size  \\\n",
        "0           0                                               <NA>      0  <NA>   \n",
        "1           0                                               <NA>      0  <NA>   \n",
-       "2        4911  /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      2  <NA>   \n",
+       "2        5628  /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      2  <NA>   \n",
        "3           0                                               <NA>      0  <NA>   \n",
        "4           0                                               <NA>      0  <NA>   \n",
        "\n",
@@ -696,8 +697,8 @@
    "id": "34c6fa12-ce7f-4bc9-b24e-c3b59b739147",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:35.812767Z",
-     "start_time": "2024-01-28T06:05:35.763293Z"
+     "end_time": "2024-01-29T07:14:58.936066Z",
+     "start_time": "2024-01-29T07:14:58.886020Z"
     },
     "scrolled": true
    },
@@ -712,8 +713,8 @@
    "id": "f057a7a8-e3b3-4ed6-b1b9-769d52c7be4d",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:36.789654Z",
-     "start_time": "2024-01-28T06:05:35.815552Z"
+     "end_time": "2024-01-29T07:14:59.695536Z",
+     "start_time": "2024-01-29T07:14:58.939616Z"
     },
     "scrolled": true
    },
@@ -722,8 +723,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO] [22:05:35] Total number of events in the workload are 290165 [/usr/WS2/haridev/dyad/env/python/lib/python3.9/site-packages/dlp_analyzer/main.py:522]\n",
-      "[INFO] [22:05:36] Approximate True 70204908, 6515391.0, 0.0, 0.0,                6515391.0, 0.0, 0.0, 0.0 [/usr/WS2/haridev/dyad/env/python/lib/python3.9/site-packages/dlp_analyzer/main.py:476]\n"
+      "[INFO] [23:14:59] Total number of events in the workload are 249708 [/usr/WS2/haridev/dyad/env/python/lib/python3.9/site-packages/dlp_analyzer/main.py:522]\n",
+      "[INFO] [23:14:59] Approximate True 65742275, 7176790.0, 35406265.0, 0.0,                1609109.0, 29838584.0, 0.0, 35406265.0 [/usr/WS2/haridev/dyad/env/python/lib/python3.9/site-packages/dlp_analyzer/main.py:476]\n"
      ]
     },
     {
@@ -731,18 +732,22 @@
       "text/html": [
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">╭──────────────────────────────────────────────────── Summary ────────────────────────────────────────────────────╮\n",
        "│ <span style=\"color: #008080; text-decoration-color: #008080\"> Allocation   </span> Scheduler Allocation Details                                                                     │\n",
-       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> ├── Nodes: 2                                                                                     │\n",
-       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> ├── Processes: 56                                                                                │\n",
+       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> ├── Nodes: 1                                                                                     │\n",
+       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> ├── Processes: 8                                                                                 │\n",
        "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> ├── Thread allocations across nodes (includes dynamically created threads)                       │\n",
-       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> │   ├── Compute: 0                                                                               │\n",
-       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> │   └── I/O: 32                                                                                  │\n",
-       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> └── Events Recorded: 290K                                                                        │\n",
+       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> │   ├── Compute: 8                                                                               │\n",
+       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> │   └── I/O: 28                                                                                  │\n",
+       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> └── Events Recorded: 250K                                                                        │\n",
        "│ <span style=\"color: #008080; text-decoration-color: #008080\"> Dataset      </span> Description of Dataset Used                                                                      │\n",
        "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> └── Files: 347                                                                                   │\n",
        "│ <span style=\"color: #008080; text-decoration-color: #008080\"> I/O Behavior </span> Behavior of Application                                                                          │\n",
        "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> ├── Split of Time in application                                                                 │\n",
-       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> │   ├── Total Time: 70.205 sec                                                                   │\n",
-       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> │   └── Overall I/O: 6.515 sec                                                                   │\n",
+       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> │   ├── Total Time: 65.742 sec                                                                   │\n",
+       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> │   ├── Unoverlapped App Compute: 35.406 sec                                                     │\n",
+       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> │   ├── Compute: 35.406 sec                                                                      │\n",
+       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> │   ├── Overall I/O: 7.177 sec                                                                   │\n",
+       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> │   ├── Unoverlapped I/O: 1.609 sec                                                              │\n",
+       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> │   └── Unoverlapped Compute: 29.839 sec                                                         │\n",
        "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span> └── Metrics by function                                                                          │\n",
        "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span>     ├── Function       |count |                  size                   |                        │\n",
        "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span>     ├──                |      |min   |25    |mean  |median|75    |max   |                        │\n",
@@ -752,33 +757,37 @@
        "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span>     ├── open64         |3K    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
        "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span>     ├── __fxstat64     |5K    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
        "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span>     ├── lseek64        |136K  |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
-       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span>     ├── write          |583   |55    |73    |3MB   |183   |2MB   |476MB |                        │\n",
+       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span>     ├── write          |568   |55    |73    |3MB   |183   |2MB   |476MB |                        │\n",
        "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span>     ├── close          |5K    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
        "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span>     ├── readlink       |5K    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
-       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span>     ├── read           |66K   |NA    |4KB   |368KB |4KB   |252KB |4MB   |                        │\n",
-       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span>     ├── open           |3K    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
+       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span>     ├── read           |66K   |NA    |4KB   |363KB |4KB   |252KB |4MB   |                        │\n",
+       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span>     ├── open           |2K    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
        "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span>     ├── fcntl          |5K    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
        "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span>     ├── lseek          |5K    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
-       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span>     ├── __xstat        |71    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
-       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span>     └── fsync          |69    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
+       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span>     ├── __xstat        |70    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
+       "│ <span style=\"color: #008080; text-decoration-color: #008080\">              </span>     └── fsync          |70    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
        "╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\n",
        "</pre>\n"
       ],
       "text/plain": [
        "╭──────────────────────────────────────────────────── Summary ────────────────────────────────────────────────────╮\n",
        "│ \u001b[36m \u001b[0m\u001b[36mAllocation  \u001b[0m\u001b[36m \u001b[0m Scheduler Allocation Details                                                                     │\n",
-       "│ \u001b[36m              \u001b[0m ├── Nodes: 2                                                                                     │\n",
-       "│ \u001b[36m              \u001b[0m ├── Processes: 56                                                                                │\n",
+       "│ \u001b[36m              \u001b[0m ├── Nodes: 1                                                                                     │\n",
+       "│ \u001b[36m              \u001b[0m ├── Processes: 8                                                                                 │\n",
        "│ \u001b[36m              \u001b[0m ├── Thread allocations across nodes (includes dynamically created threads)                       │\n",
-       "│ \u001b[36m              \u001b[0m │   ├── Compute: 0                                                                               │\n",
-       "│ \u001b[36m              \u001b[0m │   └── I/O: 32                                                                                  │\n",
-       "│ \u001b[36m              \u001b[0m └── Events Recorded: 290K                                                                        │\n",
+       "│ \u001b[36m              \u001b[0m │   ├── Compute: 8                                                                               │\n",
+       "│ \u001b[36m              \u001b[0m │   └── I/O: 28                                                                                  │\n",
+       "│ \u001b[36m              \u001b[0m └── Events Recorded: 250K                                                                        │\n",
        "│ \u001b[36m \u001b[0m\u001b[36mDataset     \u001b[0m\u001b[36m \u001b[0m Description of Dataset Used                                                                      │\n",
        "│ \u001b[36m              \u001b[0m └── Files: 347                                                                                   │\n",
        "│ \u001b[36m \u001b[0m\u001b[36mI/O Behavior\u001b[0m\u001b[36m \u001b[0m Behavior of Application                                                                          │\n",
        "│ \u001b[36m              \u001b[0m ├── Split of Time in application                                                                 │\n",
-       "│ \u001b[36m              \u001b[0m │   ├── Total Time: 70.205 sec                                                                   │\n",
-       "│ \u001b[36m              \u001b[0m │   └── Overall I/O: 6.515 sec                                                                   │\n",
+       "│ \u001b[36m              \u001b[0m │   ├── Total Time: 65.742 sec                                                                   │\n",
+       "│ \u001b[36m              \u001b[0m │   ├── Unoverlapped App Compute: 35.406 sec                                                     │\n",
+       "│ \u001b[36m              \u001b[0m │   ├── Compute: 35.406 sec                                                                      │\n",
+       "│ \u001b[36m              \u001b[0m │   ├── Overall I/O: 7.177 sec                                                                   │\n",
+       "│ \u001b[36m              \u001b[0m │   ├── Unoverlapped I/O: 1.609 sec                                                              │\n",
+       "│ \u001b[36m              \u001b[0m │   └── Unoverlapped Compute: 29.839 sec                                                         │\n",
        "│ \u001b[36m              \u001b[0m └── Metrics by function                                                                          │\n",
        "│ \u001b[36m              \u001b[0m     ├── Function       |count |                  size                   |                        │\n",
        "│ \u001b[36m              \u001b[0m     ├──                |      |min   |25    |mean  |median|75    |max   |                        │\n",
@@ -788,15 +797,15 @@
        "│ \u001b[36m              \u001b[0m     ├── open64         |3K    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
        "│ \u001b[36m              \u001b[0m     ├── __fxstat64     |5K    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
        "│ \u001b[36m              \u001b[0m     ├── lseek64        |136K  |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
-       "│ \u001b[36m              \u001b[0m     ├── write          |583   |55    |73    |3MB   |183   |2MB   |476MB |                        │\n",
+       "│ \u001b[36m              \u001b[0m     ├── write          |568   |55    |73    |3MB   |183   |2MB   |476MB |                        │\n",
        "│ \u001b[36m              \u001b[0m     ├── close          |5K    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
        "│ \u001b[36m              \u001b[0m     ├── readlink       |5K    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
-       "│ \u001b[36m              \u001b[0m     ├── read           |66K   |NA    |4KB   |368KB |4KB   |252KB |4MB   |                        │\n",
-       "│ \u001b[36m              \u001b[0m     ├── open           |3K    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
+       "│ \u001b[36m              \u001b[0m     ├── read           |66K   |NA    |4KB   |363KB |4KB   |252KB |4MB   |                        │\n",
+       "│ \u001b[36m              \u001b[0m     ├── open           |2K    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
        "│ \u001b[36m              \u001b[0m     ├── fcntl          |5K    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
        "│ \u001b[36m              \u001b[0m     ├── lseek          |5K    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
-       "│ \u001b[36m              \u001b[0m     ├── __xstat        |71    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
-       "│ \u001b[36m              \u001b[0m     └── fsync          |69    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
+       "│ \u001b[36m              \u001b[0m     ├── __xstat        |70    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
+       "│ \u001b[36m              \u001b[0m     └── fsync          |70    |NA    |nan   |nan   |NA    |nan   |NA    |                        │\n",
        "╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\n"
       ]
      },
@@ -816,8 +825,8 @@
    "id": "c22acd72",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:36.984041Z",
-     "start_time": "2024-01-28T06:05:36.792635Z"
+     "end_time": "2024-01-29T07:14:59.819180Z",
+     "start_time": "2024-01-29T07:14:59.698596Z"
     }
    },
    "outputs": [
@@ -889,8 +898,8 @@
    "id": "f645f8ac",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:37.031778Z",
-     "start_time": "2024-01-28T06:05:36.986700Z"
+     "end_time": "2024-01-29T07:14:59.867877Z",
+     "start_time": "2024-01-29T07:14:59.821297Z"
     }
    },
    "outputs": [],
@@ -905,8 +914,8 @@
    "id": "4d772781",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:37.281689Z",
-     "start_time": "2024-01-28T06:05:37.034756Z"
+     "end_time": "2024-01-29T07:15:00.095054Z",
+     "start_time": "2024-01-29T07:14:59.870910Z"
     }
    },
    "outputs": [
@@ -973,8 +982,8 @@
    "id": "fd5798d3",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T06:05:37.578043Z",
-     "start_time": "2024-01-28T06:05:37.284102Z"
+     "end_time": "2024-01-29T07:15:00.454514Z",
+     "start_time": "2024-01-29T07:15:00.098181Z"
     }
    },
    "outputs": [
@@ -1013,183 +1022,183 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>8969676</td>\n",
+       "      <td>7771342</td>\n",
        "      <td>201283584</td>\n",
-       "      <td>21.400883</td>\n",
+       "      <td>24.700880</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>4938643</td>\n",
+       "      <td>5561607</td>\n",
        "      <td>201283584</td>\n",
-       "      <td>38.868771</td>\n",
+       "      <td>34.515021</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>3436547</td>\n",
+       "      <td>3799894</td>\n",
        "      <td>201283584</td>\n",
-       "      <td>55.858100</td>\n",
+       "      <td>50.516931</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>2582914</td>\n",
+       "      <td>702792</td>\n",
        "      <td>201283584</td>\n",
-       "      <td>74.318767</td>\n",
+       "      <td>273.137691</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>540996</td>\n",
+       "      <td>125441</td>\n",
        "      <td>201283584</td>\n",
-       "      <td>354.825145</td>\n",
+       "      <td>1530.273072</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td>515565</td>\n",
+       "      <td>133285</td>\n",
        "      <td>201283584</td>\n",
-       "      <td>372.327416</td>\n",
+       "      <td>1440.214461</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
-       "      <td>125295</td>\n",
+       "      <td>117639</td>\n",
        "      <td>201283584</td>\n",
-       "      <td>1532.056222</td>\n",
+       "      <td>1631.763143</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
-       "      <td>163435</td>\n",
+       "      <td>107326</td>\n",
        "      <td>201283584</td>\n",
-       "      <td>1174.528004</td>\n",
+       "      <td>1788.559942</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
-       "      <td>55500</td>\n",
+       "      <td>110120</td>\n",
        "      <td>201283584</td>\n",
-       "      <td>3458.720439</td>\n",
+       "      <td>1743.180025</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>10</th>\n",
-       "      <td>81733</td>\n",
+       "      <td>126935</td>\n",
        "      <td>201283584</td>\n",
-       "      <td>2348.610529</td>\n",
+       "      <td>1512.262058</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>11</th>\n",
-       "      <td>129335</td>\n",
+       "      <td>163528</td>\n",
        "      <td>201283584</td>\n",
-       "      <td>1484.199825</td>\n",
+       "      <td>1173.860038</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>12</th>\n",
-       "      <td>151079</td>\n",
+       "      <td>169468</td>\n",
        "      <td>201283584</td>\n",
-       "      <td>1270.586808</td>\n",
+       "      <td>1132.715229</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>13</th>\n",
-       "      <td>116262</td>\n",
+       "      <td>117409</td>\n",
        "      <td>201283584</td>\n",
-       "      <td>1651.089646</td>\n",
+       "      <td>1634.959708</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>14</th>\n",
-       "      <td>166410</td>\n",
+       "      <td>117613</td>\n",
        "      <td>201283584</td>\n",
-       "      <td>1153.530343</td>\n",
+       "      <td>1632.123867</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>15</th>\n",
-       "      <td>167225</td>\n",
+       "      <td>164210</td>\n",
        "      <td>201283584</td>\n",
-       "      <td>1147.908413</td>\n",
+       "      <td>1168.984741</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>16</th>\n",
-       "      <td>291999</td>\n",
+       "      <td>221632</td>\n",
        "      <td>201283584</td>\n",
-       "      <td>657.396033</td>\n",
+       "      <td>866.115833</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>17</th>\n",
-       "      <td>200940</td>\n",
+       "      <td>172387</td>\n",
        "      <td>201283584</td>\n",
-       "      <td>955.304988</td>\n",
+       "      <td>1113.535153</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>18</th>\n",
-       "      <td>186395</td>\n",
+       "      <td>139189</td>\n",
        "      <td>201283584</td>\n",
-       "      <td>1029.850502</td>\n",
+       "      <td>1379.124675</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>19</th>\n",
-       "      <td>186498</td>\n",
+       "      <td>147919</td>\n",
        "      <td>201283584</td>\n",
-       "      <td>1029.281732</td>\n",
+       "      <td>1297.730409</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>20</th>\n",
-       "      <td>245686</td>\n",
+       "      <td>163072</td>\n",
        "      <td>201283584</td>\n",
-       "      <td>781.318367</td>\n",
+       "      <td>1177.142516</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>21</th>\n",
-       "      <td>116016</td>\n",
+       "      <td>59622</td>\n",
        "      <td>134189056</td>\n",
-       "      <td>1103.060408</td>\n",
+       "      <td>2146.399924</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>22</th>\n",
-       "      <td>137272</td>\n",
+       "      <td>125650</td>\n",
        "      <td>134189056</td>\n",
-       "      <td>932.256077</td>\n",
+       "      <td>1018.485127</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>23</th>\n",
-       "      <td>160872</td>\n",
+       "      <td>104923</td>\n",
        "      <td>134189056</td>\n",
-       "      <td>795.493661</td>\n",
+       "      <td>1219.681636</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>24</th>\n",
-       "      <td>87935</td>\n",
+       "      <td>83222</td>\n",
        "      <td>134189056</td>\n",
-       "      <td>1455.309675</td>\n",
+       "      <td>1537.726277</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>25</th>\n",
-       "      <td>82412</td>\n",
+       "      <td>79844</td>\n",
        "      <td>134189056</td>\n",
-       "      <td>1552.840075</td>\n",
+       "      <td>1602.783631</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>26</th>\n",
-       "      <td>76448</td>\n",
+       "      <td>55142</td>\n",
        "      <td>134189056</td>\n",
-       "      <td>1673.983051</td>\n",
+       "      <td>2320.783727</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>27</th>\n",
-       "      <td>63385</td>\n",
+       "      <td>47196</td>\n",
        "      <td>134189056</td>\n",
-       "      <td>2018.973831</td>\n",
+       "      <td>2711.514879</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>28</th>\n",
-       "      <td>130470</td>\n",
+       "      <td>122906</td>\n",
        "      <td>134189056</td>\n",
-       "      <td>980.858866</td>\n",
+       "      <td>1041.223832</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>29</th>\n",
-       "      <td>169088</td>\n",
+       "      <td>116225</td>\n",
        "      <td>134189056</td>\n",
-       "      <td>756.840558</td>\n",
+       "      <td>1101.076844</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>30</th>\n",
-       "      <td>67470</td>\n",
-       "      <td>117415424</td>\n",
-       "      <td>1659.642422</td>\n",
+       "      <td>84852</td>\n",
+       "      <td>134189056</td>\n",
+       "      <td>1508.186681</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1198,36 +1207,36 @@
       "text/plain": [
        "          dur       size      bw_mbps\n",
        "step                                 \n",
-       "1     8969676  201283584    21.400883\n",
-       "2     4938643  201283584    38.868771\n",
-       "3     3436547  201283584    55.858100\n",
-       "4     2582914  201283584    74.318767\n",
-       "5      540996  201283584   354.825145\n",
-       "6      515565  201283584   372.327416\n",
-       "7      125295  201283584  1532.056222\n",
-       "8      163435  201283584  1174.528004\n",
-       "9       55500  201283584  3458.720439\n",
-       "10      81733  201283584  2348.610529\n",
-       "11     129335  201283584  1484.199825\n",
-       "12     151079  201283584  1270.586808\n",
-       "13     116262  201283584  1651.089646\n",
-       "14     166410  201283584  1153.530343\n",
-       "15     167225  201283584  1147.908413\n",
-       "16     291999  201283584   657.396033\n",
-       "17     200940  201283584   955.304988\n",
-       "18     186395  201283584  1029.850502\n",
-       "19     186498  201283584  1029.281732\n",
-       "20     245686  201283584   781.318367\n",
-       "21     116016  134189056  1103.060408\n",
-       "22     137272  134189056   932.256077\n",
-       "23     160872  134189056   795.493661\n",
-       "24      87935  134189056  1455.309675\n",
-       "25      82412  134189056  1552.840075\n",
-       "26      76448  134189056  1673.983051\n",
-       "27      63385  134189056  2018.973831\n",
-       "28     130470  134189056   980.858866\n",
-       "29     169088  134189056   756.840558\n",
-       "30      67470  117415424  1659.642422"
+       "1     7771342  201283584    24.700880\n",
+       "2     5561607  201283584    34.515021\n",
+       "3     3799894  201283584    50.516931\n",
+       "4      702792  201283584   273.137691\n",
+       "5      125441  201283584  1530.273072\n",
+       "6      133285  201283584  1440.214461\n",
+       "7      117639  201283584  1631.763143\n",
+       "8      107326  201283584  1788.559942\n",
+       "9      110120  201283584  1743.180025\n",
+       "10     126935  201283584  1512.262058\n",
+       "11     163528  201283584  1173.860038\n",
+       "12     169468  201283584  1132.715229\n",
+       "13     117409  201283584  1634.959708\n",
+       "14     117613  201283584  1632.123867\n",
+       "15     164210  201283584  1168.984741\n",
+       "16     221632  201283584   866.115833\n",
+       "17     172387  201283584  1113.535153\n",
+       "18     139189  201283584  1379.124675\n",
+       "19     147919  201283584  1297.730409\n",
+       "20     163072  201283584  1177.142516\n",
+       "21      59622  134189056  2146.399924\n",
+       "22     125650  134189056  1018.485127\n",
+       "23     104923  134189056  1219.681636\n",
+       "24      83222  134189056  1537.726277\n",
+       "25      79844  134189056  1602.783631\n",
+       "26      55142  134189056  2320.783727\n",
+       "27      47196  134189056  2711.514879\n",
+       "28     122906  134189056  1041.223832\n",
+       "29     116225  134189056  1101.076844\n",
+       "30      84852  134189056  1508.186681"
       ]
      },
      "execution_count": 27,
@@ -1246,12 +1255,79 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 34,
+   "id": "eb0e8d7c",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-01-29T07:20:09.050328Z",
+     "start_time": "2024-01-29T07:20:08.072190Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>dur</th>\n",
+       "      <th>size</th>\n",
+       "      <th>bw_mbps</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>trange</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Empty DataFrame\n",
+       "Columns: [dur, size, bw_mbps]\n",
+       "Index: []"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_item = analyzer.events.query(\"name == 'dyad_fetch_request_cb'\").\\\n",
+    "            groupby([\"trange\",\"pid\",\"tid\"]).agg({\"dur\":sum, \"size\":sum}).\\\n",
+    "            groupby([\"trange\"]).agg({\"dur\":max, \"size\":sum}).compute()\n",
+    "get_item[\"bw_mbps\"] = get_item[\"size\"]/1024**2/get_item[\"dur\"]*1e6\n",
+    "get_item\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
    "id": "e856d38d",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T03:58:21.308014Z",
-     "start_time": "2024-01-28T03:58:20.483271Z"
+     "end_time": "2024-01-29T07:15:00.622125Z",
+     "start_time": "2024-01-29T07:15:00.468850Z"
     }
    },
    "outputs": [
@@ -1293,21 +1369,23 @@
        "      <th>filename</th>\n",
        "      <th>phase</th>\n",
        "      <th>size</th>\n",
+       "      <th>epoch</th>\n",
+       "      <th>step</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>739</th>\n",
+       "      <th>574</th>\n",
        "      <td>DYADTorchDataset.__getitem__</td>\n",
        "      <td>data_loader</td>\n",
-       "      <td>11</td>\n",
-       "      <td>2402121</td>\n",
-       "      <td>86860472</td>\n",
-       "      <td>88211479</td>\n",
-       "      <td>1351007</td>\n",
+       "      <td>2</td>\n",
+       "      <td>4159035</td>\n",
+       "      <td>29229612</td>\n",
+       "      <td>30394381</td>\n",
+       "      <td>1164769</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>86.0</td>\n",
-       "      <td>corona173</td>\n",
+       "      <td>29.0</td>\n",
+       "      <td>corona171</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -1315,19 +1393,21 @@
        "      <td>/p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...</td>\n",
        "      <td>0</td>\n",
        "      <td>2096704</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1309</th>\n",
+       "      <th>1263</th>\n",
        "      <td>DYADTorchDataset.__getitem__</td>\n",
        "      <td>data_loader</td>\n",
-       "      <td>11</td>\n",
-       "      <td>2402121</td>\n",
-       "      <td>88211568</td>\n",
-       "      <td>88916497</td>\n",
-       "      <td>704929</td>\n",
+       "      <td>2</td>\n",
+       "      <td>4159035</td>\n",
+       "      <td>30394466</td>\n",
+       "      <td>31006417</td>\n",
+       "      <td>611951</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>88.0</td>\n",
-       "      <td>corona173</td>\n",
+       "      <td>30.0</td>\n",
+       "      <td>corona171</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -1335,19 +1415,21 @@
        "      <td>/p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...</td>\n",
        "      <td>0</td>\n",
        "      <td>2096704</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1816</th>\n",
+       "      <th>1330</th>\n",
        "      <td>DYADTorchDataset.__getitem__</td>\n",
        "      <td>data_loader</td>\n",
-       "      <td>11</td>\n",
-       "      <td>2402121</td>\n",
-       "      <td>88916583</td>\n",
-       "      <td>89507140</td>\n",
-       "      <td>590557</td>\n",
+       "      <td>2</td>\n",
+       "      <td>4159035</td>\n",
+       "      <td>31006506</td>\n",
+       "      <td>31016252</td>\n",
+       "      <td>9746</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>88.0</td>\n",
-       "      <td>corona173</td>\n",
+       "      <td>31.0</td>\n",
+       "      <td>corona171</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -1355,19 +1437,21 @@
        "      <td>/p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...</td>\n",
        "      <td>0</td>\n",
        "      <td>2096704</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2413</th>\n",
+       "      <th>2050</th>\n",
        "      <td>DYADTorchDataset.__getitem__</td>\n",
        "      <td>data_loader</td>\n",
-       "      <td>11</td>\n",
-       "      <td>2402121</td>\n",
-       "      <td>89507219</td>\n",
-       "      <td>90053700</td>\n",
-       "      <td>546481</td>\n",
+       "      <td>2</td>\n",
+       "      <td>4159035</td>\n",
+       "      <td>31016334</td>\n",
+       "      <td>31992225</td>\n",
+       "      <td>975891</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>89.0</td>\n",
-       "      <td>corona173</td>\n",
+       "      <td>31.0</td>\n",
+       "      <td>corona171</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -1375,19 +1459,21 @@
        "      <td>/p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...</td>\n",
        "      <td>0</td>\n",
        "      <td>2096704</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2482</th>\n",
+       "      <th>2119</th>\n",
        "      <td>DYADTorchDataset.__getitem__</td>\n",
        "      <td>data_loader</td>\n",
-       "      <td>11</td>\n",
-       "      <td>2402121</td>\n",
-       "      <td>90059598</td>\n",
-       "      <td>90083467</td>\n",
-       "      <td>23869</td>\n",
+       "      <td>2</td>\n",
+       "      <td>4159035</td>\n",
+       "      <td>32003877</td>\n",
+       "      <td>32046094</td>\n",
+       "      <td>42217</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>90.0</td>\n",
-       "      <td>corona173</td>\n",
+       "      <td>32.0</td>\n",
+       "      <td>corona171</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -1395,6 +1481,8 @@
        "      <td>/p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...</td>\n",
        "      <td>0</td>\n",
        "      <td>2096704</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>...</th>\n",
@@ -1415,19 +1503,21 @@
        "      <td>...</td>\n",
        "      <td>...</td>\n",
        "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3808</th>\n",
+       "      <th>6294</th>\n",
        "      <td>DYADTorchDataset.__getitem__</td>\n",
        "      <td>data_loader</td>\n",
-       "      <td>11</td>\n",
-       "      <td>2402843</td>\n",
-       "      <td>102975109</td>\n",
-       "      <td>102990564</td>\n",
-       "      <td>15455</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4159691</td>\n",
+       "      <td>62938744</td>\n",
+       "      <td>62947356</td>\n",
+       "      <td>8612</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>102.0</td>\n",
-       "      <td>corona173</td>\n",
+       "      <td>62.0</td>\n",
+       "      <td>corona171</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -1435,19 +1525,21 @@
        "      <td>/p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...</td>\n",
        "      <td>0</td>\n",
        "      <td>2096704</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>19</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3875</th>\n",
+       "      <th>6361</th>\n",
        "      <td>DYADTorchDataset.__getitem__</td>\n",
        "      <td>data_loader</td>\n",
-       "      <td>11</td>\n",
-       "      <td>2402843</td>\n",
-       "      <td>103018750</td>\n",
-       "      <td>103026998</td>\n",
-       "      <td>8248</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4159691</td>\n",
+       "      <td>62972950</td>\n",
+       "      <td>62979398</td>\n",
+       "      <td>6448</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>103.0</td>\n",
-       "      <td>corona173</td>\n",
+       "      <td>62.0</td>\n",
+       "      <td>corona171</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -1455,19 +1547,21 @@
        "      <td>/p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...</td>\n",
        "      <td>0</td>\n",
        "      <td>2096704</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>20</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3942</th>\n",
+       "      <th>6428</th>\n",
        "      <td>DYADTorchDataset.__getitem__</td>\n",
        "      <td>data_loader</td>\n",
-       "      <td>11</td>\n",
-       "      <td>2402843</td>\n",
-       "      <td>103027081</td>\n",
-       "      <td>103051099</td>\n",
-       "      <td>24018</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4159691</td>\n",
+       "      <td>62979474</td>\n",
+       "      <td>62988491</td>\n",
+       "      <td>9017</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>103.0</td>\n",
-       "      <td>corona173</td>\n",
+       "      <td>62.0</td>\n",
+       "      <td>corona171</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -1475,19 +1569,21 @@
        "      <td>/p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...</td>\n",
        "      <td>0</td>\n",
        "      <td>2096704</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>20</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4009</th>\n",
+       "      <th>6495</th>\n",
        "      <td>DYADTorchDataset.__getitem__</td>\n",
        "      <td>data_loader</td>\n",
-       "      <td>11</td>\n",
-       "      <td>2402843</td>\n",
-       "      <td>103051177</td>\n",
-       "      <td>103068757</td>\n",
-       "      <td>17580</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4159691</td>\n",
+       "      <td>62988583</td>\n",
+       "      <td>63002057</td>\n",
+       "      <td>13474</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>103.0</td>\n",
-       "      <td>corona173</td>\n",
+       "      <td>62.0</td>\n",
+       "      <td>corona171</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -1495,19 +1591,21 @@
        "      <td>/p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...</td>\n",
        "      <td>0</td>\n",
        "      <td>2096704</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>20</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4076</th>\n",
+       "      <th>6562</th>\n",
        "      <td>DYADTorchDataset.__getitem__</td>\n",
        "      <td>data_loader</td>\n",
-       "      <td>11</td>\n",
-       "      <td>2402843</td>\n",
-       "      <td>103068837</td>\n",
-       "      <td>103078514</td>\n",
-       "      <td>9677</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4159691</td>\n",
+       "      <td>63002132</td>\n",
+       "      <td>63019534</td>\n",
+       "      <td>17402</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>103.0</td>\n",
-       "      <td>corona173</td>\n",
+       "      <td>63.0</td>\n",
+       "      <td>corona171</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -1515,69 +1613,84 @@
        "      <td>/p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...</td>\n",
        "      <td>0</td>\n",
        "      <td>2096704</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>20</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>2560 rows × 17 columns</p>\n",
+       "<p>2560 rows × 19 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "                              name          cat  pid      tid         ts  \\\n",
-       "739   DYADTorchDataset.__getitem__  data_loader   11  2402121   86860472   \n",
-       "1309  DYADTorchDataset.__getitem__  data_loader   11  2402121   88211568   \n",
-       "1816  DYADTorchDataset.__getitem__  data_loader   11  2402121   88916583   \n",
-       "2413  DYADTorchDataset.__getitem__  data_loader   11  2402121   89507219   \n",
-       "2482  DYADTorchDataset.__getitem__  data_loader   11  2402121   90059598   \n",
-       "...                            ...          ...  ...      ...        ...   \n",
-       "3808  DYADTorchDataset.__getitem__  data_loader   11  2402843  102975109   \n",
-       "3875  DYADTorchDataset.__getitem__  data_loader   11  2402843  103018750   \n",
-       "3942  DYADTorchDataset.__getitem__  data_loader   11  2402843  103027081   \n",
-       "4009  DYADTorchDataset.__getitem__  data_loader   11  2402843  103051177   \n",
-       "4076  DYADTorchDataset.__getitem__  data_loader   11  2402843  103068837   \n",
+       "                              name          cat  pid      tid        ts  \\\n",
+       "574   DYADTorchDataset.__getitem__  data_loader    2  4159035  29229612   \n",
+       "1263  DYADTorchDataset.__getitem__  data_loader    2  4159035  30394466   \n",
+       "1330  DYADTorchDataset.__getitem__  data_loader    2  4159035  31006506   \n",
+       "2050  DYADTorchDataset.__getitem__  data_loader    2  4159035  31016334   \n",
+       "2119  DYADTorchDataset.__getitem__  data_loader    2  4159035  32003877   \n",
+       "...                            ...          ...  ...      ...       ...   \n",
+       "6294  DYADTorchDataset.__getitem__  data_loader    0  4159691  62938744   \n",
+       "6361  DYADTorchDataset.__getitem__  data_loader    0  4159691  62972950   \n",
+       "6428  DYADTorchDataset.__getitem__  data_loader    0  4159691  62979474   \n",
+       "6495  DYADTorchDataset.__getitem__  data_loader    0  4159691  62988583   \n",
+       "6562  DYADTorchDataset.__getitem__  data_loader    0  4159691  63002132   \n",
        "\n",
-       "             te      dur  tinterval  trange   hostname  compute_time  io_time  \\\n",
-       "739    88211479  1351007       <NA>    86.0  corona173          <NA>     <NA>   \n",
-       "1309   88916497   704929       <NA>    88.0  corona173          <NA>     <NA>   \n",
-       "1816   89507140   590557       <NA>    88.0  corona173          <NA>     <NA>   \n",
-       "2413   90053700   546481       <NA>    89.0  corona173          <NA>     <NA>   \n",
-       "2482   90083467    23869       <NA>    90.0  corona173          <NA>     <NA>   \n",
-       "...         ...      ...        ...     ...        ...           ...      ...   \n",
-       "3808  102990564    15455       <NA>   102.0  corona173          <NA>     <NA>   \n",
-       "3875  103026998     8248       <NA>   103.0  corona173          <NA>     <NA>   \n",
-       "3942  103051099    24018       <NA>   103.0  corona173          <NA>     <NA>   \n",
-       "4009  103068757    17580       <NA>   103.0  corona173          <NA>     <NA>   \n",
-       "4076  103078514     9677       <NA>   103.0  corona173          <NA>     <NA>   \n",
+       "            te      dur  tinterval  trange   hostname  compute_time  io_time  \\\n",
+       "574   30394381  1164769       <NA>    29.0  corona171          <NA>     <NA>   \n",
+       "1263  31006417   611951       <NA>    30.0  corona171          <NA>     <NA>   \n",
+       "1330  31016252     9746       <NA>    31.0  corona171          <NA>     <NA>   \n",
+       "2050  31992225   975891       <NA>    31.0  corona171          <NA>     <NA>   \n",
+       "2119  32046094    42217       <NA>    32.0  corona171          <NA>     <NA>   \n",
+       "...        ...      ...        ...     ...        ...           ...      ...   \n",
+       "6294  62947356     8612       <NA>    62.0  corona171          <NA>     <NA>   \n",
+       "6361  62979398     6448       <NA>    62.0  corona171          <NA>     <NA>   \n",
+       "6428  62988491     9017       <NA>    62.0  corona171          <NA>     <NA>   \n",
+       "6495  63002057    13474       <NA>    62.0  corona171          <NA>     <NA>   \n",
+       "6562  63019534    17402       <NA>    63.0  corona171          <NA>     <NA>   \n",
        "\n",
        "      app_io_time  total_time  \\\n",
-       "739          <NA>           0   \n",
-       "1309         <NA>           0   \n",
-       "1816         <NA>           0   \n",
-       "2413         <NA>           0   \n",
-       "2482         <NA>           0   \n",
+       "574          <NA>           0   \n",
+       "1263         <NA>           0   \n",
+       "1330         <NA>           0   \n",
+       "2050         <NA>           0   \n",
+       "2119         <NA>           0   \n",
        "...           ...         ...   \n",
-       "3808         <NA>           0   \n",
-       "3875         <NA>           0   \n",
-       "3942         <NA>           0   \n",
-       "4009         <NA>           0   \n",
-       "4076         <NA>           0   \n",
+       "6294         <NA>           0   \n",
+       "6361         <NA>           0   \n",
+       "6428         <NA>           0   \n",
+       "6495         <NA>           0   \n",
+       "6562         <NA>           0   \n",
        "\n",
-       "                                               filename  phase     size  \n",
-       "739   /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      0  2096704  \n",
-       "1309  /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      0  2096704  \n",
-       "1816  /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      0  2096704  \n",
-       "2413  /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      0  2096704  \n",
-       "2482  /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      0  2096704  \n",
-       "...                                                 ...    ...      ...  \n",
-       "3808  /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      0  2096704  \n",
-       "3875  /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      0  2096704  \n",
-       "3942  /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      0  2096704  \n",
-       "4009  /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      0  2096704  \n",
-       "4076  /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      0  2096704  \n",
+       "                                               filename  phase     size  \\\n",
+       "574   /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      0  2096704   \n",
+       "1263  /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      0  2096704   \n",
+       "1330  /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      0  2096704   \n",
+       "2050  /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      0  2096704   \n",
+       "2119  /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      0  2096704   \n",
+       "...                                                 ...    ...      ...   \n",
+       "6294  /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      0  2096704   \n",
+       "6361  /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      0  2096704   \n",
+       "6428  /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      0  2096704   \n",
+       "6495  /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      0  2096704   \n",
+       "6562  /p/lustre2/haridev/dyad/dlio_benchmark/dyad_un...      0  2096704   \n",
        "\n",
-       "[2560 rows x 17 columns]"
+       "      epoch  step  \n",
+       "574    <NA>     1  \n",
+       "1263   <NA>     1  \n",
+       "1330   <NA>     1  \n",
+       "2050   <NA>     1  \n",
+       "2119   <NA>     2  \n",
+       "...     ...   ...  \n",
+       "6294   <NA>    19  \n",
+       "6361   <NA>    20  \n",
+       "6428   <NA>    20  \n",
+       "6495   <NA>    20  \n",
+       "6562   <NA>    20  \n",
+       "\n",
+       "[2560 rows x 19 columns]"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1588,19 +1701,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 29,
    "id": "ad2d7964-1ef7-4bc3-808f-8aad6e1d6d8c",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T03:38:58.349304Z",
-     "start_time": "2024-01-28T03:38:57.520470Z"
+     "end_time": "2024-01-29T07:15:01.743240Z",
+     "start_time": "2024-01-29T07:15:00.624177Z"
     },
     "scrolled": true
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAuIAAAErCAYAAACb7ObeAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8g+/7EAAAACXBIWXMAAA9hAAAPYQGoP6dpAACbN0lEQVR4nOzdd3iUVfr/8ffU9F4mIaSRhBR6kyZNIMgiit0VBRTbiqg/1FUsKJbVla+uumax995QxBZ6lw4CSSghpEB675Mpvz+eFEIoSUiYlPt1Xc+VzDPPnDmZEHLnzDmfo7JarVaEEEIIIYQQF5Xa1h0QQgghhBCiO5JCXAghhBBCCBuQQlwIIYQQQggbkEJcCCGEEEIIG5BCXAghhBBCCBuQQlwIIYQQQggbkEJcCCGEEEIIG5BCXAghhBBCCBuQQlwIIYQQQggbkEJcCCGEEEIIG+gwhfhLL72ESqXiwQcftHVXhBBCCCGEjWzYsIHp06fTo0cPVCoVP/74Y6P7n3nmGaKionBycsLDw4NJkyaxbdu2c7a5dOlS+vfvj6urK66urowcOZLffvutHb+K5ukQhfiOHTt4++236d+/v627IoQQQgghbKi8vJwBAwYQFxd3xvt79+7Nm2++yf79+9m0aRMhISHExsaSm5t71jZ79uzJSy+9xK5du9i5cyeXXXYZV111FQcPHmyvL6NZVFar1WrLDpSVlTF48GD+97//8fzzzzNw4EBee+01W3ZJCCGEEEJ0ACqVimXLljFjxoyzXlNSUoKbmxurVq1i4sSJzW7b09OTJUuWMHfu3DboaetobfbMtebNm8e0adOYNGkSzz///Dmvra6uprq6uv62yWQiMTGRwMBA1OoOMbgvhBBCCCFOYbFYSEtLIyYmBq22ofS0s7PDzs7ugto2Go288847uLm5MWDAgGY9xmw28+2331JeXs7IkSMv6PkvlE0L8a+++ordu3ezY8eOZl3/4osvsnjx4nbulRBCCCGEaG9PP/00zzzzTKseu2LFCm666SYqKirw9/dn5cqVeHt7n/Mx+/fvZ+TIkVRVVeHs7MyyZcuIiYlp1fO3FZsV4unp6TzwwAOsXLkSe3v7Zj1m4cKFLFiwoFEbffv25Y2vfiGhSMPh7LL6+1ztdYwM82BMuDf+bg5t3n8hhBBCiO7G+bf7UFfkUjbhBSye4c16TGZmJqNGjeLAgQMEBgbWn7+Q0fAJEyawd+9e8vLyePfdd7nhhhvYtm0bvr6+Z31MZGQke/fupbi4mO+++47Zs2ezfv16mxbjNpsj/uOPP3L11Vej0Wjqz5nNZlQqFWq1murq6kb3nUlGRgaBgYGkp6fTs2dPThRVsvJgFquTciiqqKm/rk8PVybHGBgd7o297txtCiGEEEKIs/hgKtRUwI2fgXvg+a+nab3WEs2ZIw4QERHB7bffzsKFC5vd9qRJkwgLC+Ptt99uUZ/aks1GxCdOnMj+/fsbnbvtttuIiori0UcfPW8RfiYB7g7MGR3KLSOC2ZlaSPzBbHalFnDwZAkHT5bw9oZjjOvtQ2yMgXBfZ1QqVVt9OUIIIYQQXZvZpBThAPautu3LaSwWS6N1hO31mLZms0LcxcWFvn37Njrn5OSEl5dXk/MtpdWoGdHLixG9vMgrq2ZNYg7xCdlkl1Tx+4Esfj+QRai3E5NjDIyP9MHFXndBzyeEEEII0eUZSxs+17u029OUlZVx9OjR+tspKSns3bsXT09PvLy8eOGFF7jyyivx9/cnLy+PuLg4Tpw4wfXXX1//mIkTJ3L11Vdz3333Acr05qlTpxIUFERpaSlffPEF69at448//mi3r6M5bJ6a0t68ne24YVgg1w3pyYGTxcQfzGZLch4peeW8s+EYH25OYWSYF7ExfvQLcEOtllFyIYQQQogmqmsLcb0ztGNa3c6dO5kwYUL97br1gbNnz+att94iKSmJjz/+mLy8PLy8vBg2bBgbN26kT58+9Y9JTk4mLy+v/nZOTg6zZs0iMzMTNzc3+vfvzx9//MHkyZPb7etoDpvniF+I5sw5slqtmEwmzGZz/bny6hq2Hy9k85E8ThRV1p/3crJjdLgyku7hpG/3/gvRnjQaDVqtVqZgCSGEaBtZB+CneeDiDzd/1eyHXcgc8a6uS4+IG41GMjMzqaioaHJfiB5C+jhQY7ajqsZMVY0Fq9UKliIOJxeh12hw0KnRa9VSyIhOy9HREX9/f/R6+cNSCCHEBTL0gdt/h5rK818rmqXLFuIWi4WUlBQ0Gg09evRAr9efs6C2WKxUGE2UVZuoqrHUn9eowdlOh5OdFr1WNg0SnYPVasVoNJKbm0tKSgoRERGy6ZUQQogLo1KBzkE5RJvosoW40WjEYrEQGBiIo6Njsx7j6AjegNFkpqTKREllDWaLlTITlJnMOOiVfHJnO63MJRcdnoODAzqdjtTUVIxGY7Pz+oUQQghxcXTZQrxOa0YB9VoN3s4avJz0lFebKKkyUWE0UWk0U2k0k6tW4WKvxdVeh51MXREdmIyCCyGEaDNHV0PGTggaAb3G2bo3XUKXL8QvhEqlwtleh7O9jhqzhdLaUfIas4XiihqKK2qw02pwddDiYq9FI0WPEEIIIbqq7ANw6Fdw9JRCvI1IId5MOo0aTyc9Ho46KmvMlFTWUFZtptpkJrfUTF6ZEWc7La4OWhx0GhklF0IIIUTXUl2mfLRrvwzx7qZLFOIWiwWLxdLknNVqrT/akoNOg4NOg7fFSlm1MkpebbJQWlVDaVUNOo26dpRch1bmkl80oaGhPPDAAzz44IO27kqHUffv/0w/I0IIIURLqKqKAbDqnaEFv1Pk98/ZdcpCPC4ujri4OIxGIwD5+flN4tlqamqwWCyYTCZMJlO79cVJp8JRq8NotlJabaa82ozRZCav1Ex+WTUOOg0udkoUYnNHyefOncunn34KgE6nIygoiJkzZ/LYY4+h1SrfMrPZzJtvvslHH33E0aNHcXBwYPjw4SxcuJBRo0bVt2U2m3nllVf45JNPSEtLw8HBgfDwcObOncvtt99e/3xFRUV8//33mM1mJkyYgMFg4Ntvv61vp7i4mEGDBjFz5kyee+65M/Z70qRJDBgwgFdeeaXR+cmTJ/P3v/+9/vk++eQTli5dSkJCAhqNhkGDBrFgwQKmTZt2xnbXr19/3sD9lStXsmXLFpycnNr1+93ZmEwmLBYL+fn56HSyg6wQQojWcy3ORWeqobTCjDEnp9mPy8/PB2DChAnodDrmzZvHvHnz2qubnUqnLMTrvoF1AfFeXl74+vo2uqaqqorS0lK0Wm198dqedDpwsgeL1aos8Kw0UVljprLGQmWNBY1ahauDDld7LTrNueeSq9VqLr/8cj744AOqq6v59ddfue+++7Czs2PhwoVYrVZuvvlmVq1axcsvv8zEiRMpKSkhLi6OSZMm8c033zBjxgwAnn32Wd555x3++9//MnToUEpKSti5cyeFhYX1r4tarUatVte/Vh999BGDBg3i66+/ZubMmYCyq5WnpyeLFy8+6+upUqlQqVSN7i8oKGDLli189dVXaLVaHn74YeLi4njuueeYMWMGNTU1fPbZZ1x77bW89tpr9VvRnmrMmDGcPHmy/vaDDz5ISUkJH3zwQf05T09Pyco+A61Wi1qtxsvLS1JThBBCXBCVqga0Otz9guC0uutc6gZO165dKxv6nKZTFuKnqyskTz9XVxjWjURbrVaqTe3/9oheq8HbRaPEIFaaqDaZMVusFJYbKSw34qDXnDcG0c7ODn9/fwDuvfdefvzxR37++Wcef/xxvvnmG7777juWL1/O9OnT6x/z7rvvUlBQwJ133klsbCxOTk78/PPP3Hvvvdxwww311w0cOPCMz1n3OkVGRvLSSy9x//33M3HiRLZv385XX33Fjh07sLOzO+fXfurrDfDrr78yePBg/Pz8+PPPP3n11Vd54403mD9/fv01//rXv6iuruahhx5ixowZBAYGnvW1ACWWr7q6utE5gJCQEB588MH6qSkqlYq33nqLn3/+mTVr1hAcHMwHH3yAj48Pd9xxBzt27GDAgAF8+umnhIWF1bfz008/sXjxYhISEujRowezZ8/miSeeuCh/0LW1uu/HmX5GhBBCiBYxKlvcq+xdW7TFvfz+ObvOV1lcgGqThevf2nrRn/fru0dgsVjPGYNor9Ocsw0HB4f6t3a++OILevfu3agIr/PQQw/xww8/sHLlSmbMmIGfnx9r1qzh3nvvxcfHp9l9nj9/PsuWLePWW29l//79LFq0iAEDBrTsCweWL1/OVVddBcCXX36Js7Mzd9999xn7/eqrr/L999+36Rzv5557jldffZVXX32VRx99lJtvvplevXqxcOFCgoKCuP3227nvvvv47bffANi4cSOzZs3ijTfeYMyYMSQnJ3PXXXcB8PTTT7dZv4QQQohOxWqFqhLlcztX2/alC5E/US4CdW0MYg93B4K9nPBy1qPTqLFYrBRX1JBeUEFaQQVFFUbMlsYLS61WK6tWreKPP/7gsssuA+Dw4cNER0ef8bnqzh8+fBiAV199ldzcXPz8/Ojfvz/33HNPfdF5LiqViqVLl7J69WoMBgOPPfZYi7/u6upqfv/9d6688sr6PoWFhZ1xCkmPHj1wdXWt73dbue2227jhhhvo3bs3jz76KMePH2fmzJlMmTKF6OhoHnjgAdatW1d//eLFi3nssceYPXs2vXr1YvLkyTz33HO8/fbbbdovIYQQotO57VeY+S04etm6J11GtxoRt9Oq+faekTZ53jpKDKIdHo76xjGINWZya5QYxEqjmRUrVuDs7Fy/6PTmm2/mmWeeqW+nuUkwMTExHDhwgF27drF582Y2bNjA9OnTmTNnDu+99945H/vBBx/g6OhISkoKGRkZhISEtOjrXrNmDb6+vvTp06fF/W4r/fv3r//cYDAA0K9fv0bnqqqqKCkpwdXVlX379rF582ZeeOGF+mvMZjNVVVVUVFQ0e5dWIYQQokuR7e3bRbcqxFUq1XmngFwsKpUKR70WR70Ws0XZLKi4sgajyUKN2cLw0WN5YclreLo60js0CHu7hlHk3r17k5iYeMZ268737t27/pxarWbYsGEMGzaMBx98kM8++4xbb72VJ554gtDQ0DO2s2XLFv7zn/8QHx/P888/z9y5c1m1alWL8tGXL19ePxpe16dNmzZhNBqbjIqfPHmSkpKSRv1uC6cmhdT1/Uzn6qKVysrKWLx4Mddcc02TtmSxoxBCCCHakkxN6QA0ajXujnqCPB0J9HREr1Xj6OhIQHAoDh4GMoqrOVlUSVm1CavVyk033cSRI0f4+eefm7T1yiuv4OXldc64v5iYGADKy8vPeH9FRQVz5szhH//4BxMmTOD9999n+/btvPXWW83+mqxWKz///HP9/HCAm266ibKysjNO8/i///s/dDod1157bbOfoz0MHjyYQ4cOER4e3uSQxSZCCCG6rfxkWPdv2Pe1rXvSpXSrEfGOrm7E3l6nwVGvxeBqT3FlDVU1ZsqrTZRXm9Bq1Ey64mqumjGD2bNns2TJkkbxhcuXL+fbb7/FyckJgOuuu47Ro0czatQo/Pz8SElJYeHChfTu3ZuoqKgz9qMuIvGll14ClDSS//u//+Phhx9m6tSpzZqismvXLioqKrj00kvrz40cOZIHHniARx55BKPR2Ci+8PXXX+e1115rkphysS1atIgrrriCoKAgrrvuOtRqNfv27ePAgQM8//zzNu2bEEIIYTPF6cr29n79YMCNtu5NlyFDfB2USgWuDjoCPR0J9nLE3VGPRq3CZLZQVFHDi29+wL0PPswrr75KZGQkY8aMITU1lXXr1tVniANMmTKFn3/+menTp9O7d29mz55NVFQU8fHxZ4zjW79+PXFxcXz44YeN5kPffffdjBo1irlz5zZrnvdPP/3E3/72tybP8dprr/G///2PL7/8kr59+zJ06FA2bNjAjz/+2CjS0FamTJnCihUriI+PZ9iwYYwYMYL//Oc/BAcH27prQgghhO1IYkq7UFkv9uq5NlS3oU96enqTgPiqqipSUlIIDQ3tMnN7LVYrFdUmSqpMlBtNUPudU7cgBvFi6d+/P08++WSj/HJx8XXFnwMhhBA2sOdz2P4ORE6F8S1LUjtXvdbdydSUTqQuBtHZXkeN2UJJVQ2llSZqzBaKK2oorqjBTqfBzV6Ls70OzVk2C2pvRqORa6+9lqlTp9rk+YUQQgjRxqqVzXzQO9u2H12MFOKdlE6jxsvJDk9HPZVGM8VVNZTXxiDm1JjJLTPibKfFzUGLvU7TorSTC6XX62XzGyGEEKIrqSvE7WVqSluSQryTU6lUONppcbTTYrJYKDslBrG0qobSqhr0WjUu9jpc7bVoNbIsQAghhBAtVF03R9zFtv3oYrpEIW6xWOpzoE89Z7Va64/uQKNS4eagw81BR1WNmZIqE2VVJowmC/ll1eSXV+Ok1+JqrxTutpm4Ii6mun//Z/oZEUIIIZpLVVuIW/Uu0MLfJ/L75+w6ZSEeFxdHXFwcRqMRgPz8/CYbxNTtSGkymTCZTLbopk1pVeDpoMHdXk250UxZlZkqk4WyqhrKqmrQqFW42GlwttOgk1HyLstkMmGxWMjPz2+0kZEQQgjRIoMWoO5bhkXrCDk5LXpofn4+ABMmTECn0zFv3jzmzZvXHr3sdLpEakpqauoZU1OOHz8uaRGnMJpqF3hWmTBbGr7tDnoNrvY6nO20XMSp5OIiqEtNCQkJkZ8DIYQQNpGRkUFwcLCkppxBpxwRP51arW6y66FarUalUtUfAux0Gnx0GryclRjE4ioTFUYTlUYzlUYzeWoVzvZa3Ox12HWQGERxYer+/Z/pZ0QIIYS4GOT3z9l1iUJctEyTGMRKZZT81BhEe50GVxvHIAohhBCiAzDXwMZXwc4Zht0JWv35HyOaRQrxbk6nUePlbIenk54Ko5mS2hjEqhrlyC0z1o6SX/wYRCGEEEJ0ANWlyvb2KhUM/4ete9OlyHsFAlCmMDjZafF3cyDEyxEfFzv0WjVWq5XSyhoyCitJK6igsNyIydw9Vz+rVCp+/PHHVj12/PjxPPjgg+e8JiQkhNdee+2c1zzzzDMMHDiwVX0QQgghWqUuulDvDDLNpE3Jq9kBzZkzp35ur16vJzw8nGeffbZR+ovZbOY///kP/fr1w97eHg8PD6ZOncrmzZsbtWU2m3nppZeIiorCwcEBT09Phg8fznvvvdfo+WbMmFF//dgxl3L7LTcR5OlITw9HXB10lJeWMKJ/JI8/8QTH8yvILKqkvNrUKBrybMXmhAkTGj3fxx9/zLBhw3B0dMTFxYVx48axYsWK874uISEh9a+LRqOhR48ezJ07l8LCwua+tDbzww8/8Nxzz7XoMRdS+AshhBBtprpM+Wgnm/m0NSnEO6jLL7+czMxMjhw5wkMPPcQzzzzDkiVLACUb+qabbuLZZ5/lgQceIDExkXXr1hEYGMj48eMbFW+LFy/mP//5D8899xwJCQmsXbuWu+66i6KiojM+r0aj4aOPPuL333/niy++wEGvweBqzyuLF+Ll5cnDjz2B1WqlrNrEyaJKjudXkF9WTY3pzKPkBQUFbN68menTpwPw8MMPc/fdd3PjjTfy119/sX37di699FKuuuoq3nzzzfO+Ls8++yyZmZmkpaXx+eefs2HDBu6///6Wvbg24OnpiYuLbIIghBCiE5LNfNpN9yzEayrPfpiMLbi2+vzXtpKdnR1+fn4EBwfzj3/8g0mTJrF8+XIAvvnmG7777js++eQT7rjjDkJDQxkwYADvvPMOV155JXfccQfl5eUALF++nHvvvZfrr7++/rq5c+fy8MMPn/W5e/fuzUsvvcT8+fPJzMzkp59+4uuvv+LzTz8lzM+dIC9H3B31aNQqTGYLBeVGjueXU22yYDRZsJwySv7LL78wePBgDAYDf/75J6+88gpLlizh4YcfJjw8nOjoaF544QUefPBBFixYQHp6+jlfFxcXF/z8/AgICGDChAnMnj2b3bt319+fn5/P3//+dwICAnB0dKRfv358+eWXjdoYP348999/P//85z/x9PTEz8+PZ555ptE1R44cYezYsdjb2xMTE8PKlSsb3X/ddddx33331d9+8MEHUalUJCUlAWA0GnFycmLVqlX1z3nquwU5OTlMnz4dBwcHQkND+fzzzxu1HxISAsDVV1+NSqWqv13n008/JSQkBDc3N2666SZKS0vP+boJIYQQrVa3vb0U4m2uey7W/ODys98XNAKm/rvh9iczwFR15mv9B8CVbzTc/uJGqCpufM3d61vdzVM5ODjUB+J/8cUX9O7du36U+VQPPfQQP/zwAytXrmTGjBn4+fmxZs0a7r33Xnx8fJr9fPPnz2fZsmXceuut7N+/n0WLFjFgwAAA7LQafFw0eDnrKa82UVIbg2ixWKkwmjieV46LvRZXex3Lly/nqquuAuDLL7/E2dmZu++++4z9fvXVV/n+++/PO5e6zokTJ/j5558ZPnx4/bmqqiqGDBnCo48+iqurK7/88gu33norYWFhXHLJJfXXffzxxyxYsIBt27axdetW5syZw+jRo5k8eTIWi4VrrrkGg8HAtm3bKC4ubtKncePG8fbbb9ffXr9+Pd7e3qxbt46oqCh27NhBTU0No0aNOmPf58yZw8mTJ1m7di06nY7777+fnFM2SNixYwe+vr58+OGHXH755Wg0DXGSycnJ/Pjjj6xYsYLCwkJuuOEGXnrpJV544YVmvW5CCCFEi0gh3m6654h4J2K1Wlm1ahV//PEHl112GQCHDx8mOjr6jNfXnT98+DAAr776Krm5ufj5+dG/f3/uuecefvvtt/M+r0qlYunSpaxevRqDwcBjjz3W5Bq1SoWLvY4AdwdCvJzQapT522aLlaKKGo5mFvLbb78zIXYqZouVw4cPExYW1mQXVIAePXrg6upa3++zefTRR3F2dsbBwYGePXuiUql49dVX6+8PCAjg4YcfZuDAgfTq1Yv58+dz+eWX88033zRqp3///jz99NNEREQwa9Yshg4dyurVqwFYtWoVSUlJfPLJJwwYMICxY8fyr3/9q9Hjx48fT0JCArm5uRQWFpKQkMADDzzAunXrAFi3bl39PPjTHT58mN9++413332XESNGMGTIEN5//30qKxveQan7o8nd3R0/P79Gf0RZLBY++ugj+vbty5gxY7j11lvr+y6EEEK0OZma0m6654j47b+f/T7VaRvZzPrxHNee9nfMzV+3ukunW7FiBc7OztTU1GCxWLj55psbTZ9o7oaoMTExHDhwgF27drF582Y2bNjA9OnTmTNnTqMFlGfywQcf4OjoSEpKChkZGU2mR5xKp1Gj06hxtdfSw92Bkqoafl2zEk9vb7x6hnE8T5m6YrFYsFqtrY5BfOSRR5gzZw5Wq5X09HQef/xxpk2bxoYNG9BoNJjNZv71r3/xzTffcOLECYxGI9XV1U0K4v79+ze67e/vXz8inZiYSGBgID169Ki/f+TIkY2u79u3L56enqxfvx69Xs+gQYO44ooriIuLA5QR8vHjx5/xa0hMTESr1TJkyJD6c1FRUbi7uzfrNQgJCWk03/zUvgshhBBtbuAtEDUd1LLZX1vrniPiOoezH6eH1J/zWrvzX9tKEyZMYO/evRw5coTKyko+/vhjnJycAGUOd2Ji4hkfV3e+d+/e9efUajXDhg3jwQcf5IcffuCjjz7i/fffJyUl5azPv2XLFv7zn/+wYsUKLrnkEubOndus4v/UGMTt6+OZdsV09Fo1FquVwJBeHDuWwtGsoiYxiCdPnqSkpKRRv8/E29ub8PBwIiIiuOyyy3jttdfYsmULa9euBWDJkiW8/vrrPProo6xdu5a9e/cyZcoUjMbGc/91Ol2TflsszY9lVKlUjB07lnXr1tUX3f3796e6upoDBw6wZcsWxo0b1+z2WuJC+y6EEEK0iFYPzj7g6GnrnnQ5XWJE3GKxNClE6kZe647OxsnJibCwsPrbp34NN954IzNnzmT58uVN5om/8soreHl5MWnSpLN+3XXTV8rKyhpdU/d5RUUFc+bM4Z577mH8+PGEhITQv39/li5dyj/+ce4g/1Nf819WrODTTz8lyNORqhozN9x4I5+89xaffPAes+64h/zyapz0WlwddCxZsgSdTsc111xzzu/X6d/Pum1zKyoqsFqtbN68mSuvvJKZM2cCyr+Dw4cPExMT0+RrPdPzWK1WoqKiSE9P5+TJk/j7+wOwdevWJo8bO3Ys7733HnZ2djz//PP1xfmSJUuorq5m1KhRZ3zOyMhITCYTO3fuZNiwYQAcOnSIoqKiRu3rdDpMJtMZv0fnO3f6c57pZ0QIIYS4GOT3z9l1ykI8Li6OuLi4+lHO/Pz8JvOO66Z0mEymRvnbnUFd0XS2fl933XV88803zJkzh5deeokJEyZQUlLCW2+9xfLly/nyyy+xs7PDZDJx4403MmrUKEaOHInBYOD48eM8+eSTREREEB4ejslkavJ8jz32GFarleeffx6TyUTPnj3597//zaOPPsrkyZPPOkWlrugzmUzs2rWLiooKRowYgclkQquC2HGjue+++1jy3FNYzTWMj/0bNTUmln//Ne/89w2ee/FlvH0N5/x+FRcXk5GRgdVqJSMjg4ULF+Lj48Mll1yCyWQiLCyMH374gY0bN+Lu7s7rr79OdnY2UVFR9e2e2s8zvebjx48nIiKC2bNn8+KLL1JaWsoTTzwBKDnrdY+79NJLWbBgAXq9vv7rHDNmDI8++ihDhw6t/x6c/pxhYWFMmTKFu+++mzfffBOtVstDDz2Eg4NDo+9DcHAwq1atYvjw4djZ2eHh4VH/B+bpfQfO+LrVfX/z8/ObjKQLIYQQzeGQ+C0qYzlVvWKxuPQ4/wNOUxc2MWHCBHQ6HfPmzWPevHlt3c1OqVMW4nXfwIyMDAIDA/Hy8sLX17fRNVVVVZSWlqLVatFqO9eXqVarUavV5+z3t99+y2uvvcYbb7zB/Pnzsbe3Z+TIkaxdu5bRo0fXX3f55Zfz1Vdf8fLLL1NcXIyfnx+XXXYZTz/9NPb29k2eb/369SxdupS1a9fi6toQ3P+Pf/yDn376iXvuuYeVK1eecY533WY7Wq2WFStW8Le//a3+Oeq88cYbDBw4kKVLl/LKi8+h1mjo028A//voSy6LncqJYiOOeg2uDjqc9FpOf5rFixezePFiQFnQOGzYMP744w8MBgMATz31FMePH2fatGk4Ojpy5513MmPGDIqLi+tfz1P7ebbXfNmyZdxxxx2MHj2akJAQXn/9daZOnYpGo6m/ZtCgQbi7u9O7d+/6+d2XXXYZZrOZ8ePHN2r/9Of88MMPufPOO5k4cSIGg4HnnnuORYsWNerDK6+8wkMPPcT7779PQEAAKSkpqNXqM/YdOOO/F61Wi1qtxsvLq8n3QgghhGgO1bo/oTgD576Xw2n1VnPUDZyuXbuWnj17tnX3OjWVtTPO26hVV4inp6c3+cZWVVWRkpJCaGioFCA20L9/f5588kluuOGG815rsVqVGMRKJQaxjkatpLK42mux08kCkdaQnwMhhBAX7OMrlXjm6z8Cz9AWP/xc9Vp317mGikWnYDQaufbaa5k6dWqzrq+LQXSx11FjtlBSWUNJlQmT2UJRhZGiCiP2OmWU3NlOi0bdusQVIYQQQrSQxSI54u1ICnHR5vR6PU8//XSrHqvTqPFytsPTSU+F0UxJVQ3l1WaqapQjT6XCuXazIHudutUxiEIIIYRohpoKsNYutpRCvM1JIS46pLoYRCc7LSazhdIqEyVVNRhNtSPmlTXotWpcHXS42GnRarpnEqcQQgjRrupGw7V2TWObxQWTQlx0eFqNGg8nPe6OOqpqLJRU1VBWZcJospBXWk1+mREnOw2u9joc9RoZJRdCCCHaikxLaVddvhDvxGtRxWlUKhUOeg0Oeg3ezlbKqmsoqTRRVWOmrMpEWZUJbe3unq4OOnQySi7//oUQQlwYKcTbVZctxOsykysqKnBwaP0Ol6Jj0qhVuDnocXPQU11jpqTKRGlVDSazhYJyIwUVRhx1WlwdlOkt6m46Sl5RUQE03Y1TCCGEaBb/ATDzOzAbz3+taLEuW4hrNBrc3d3JyckBwNHRUaYsdGEuOnDSaqg0KiPjlUYLpUYjpeWgUYOTnQ5nOw16bfeIQbRarVRUVJCTk4O7uzsaTff4uoUQQrQxjVbZ3l60iy5biAP4+fkB1BfjovswW6xU1iatWCwN0zN0GjX2eg322u6RuOLu7l7/cyCEEEKIjsWmhfjSpUtZunQpx48fB6BPnz4sWrSo2fnT56NSqfD398fX15eampo2aVN0LhaLlYTMYjYfzWdfRnH9nGm9Vs2QIA9Gh3vTy8epSxblOp1ORsKFEEJcmOS1kJMAgSOg55CL9rSlpaU89dRTLFu2jJycHAYNGsTrr7/OsGHDzvqYuLg43nzzTY4fP05QUBBPPPEEs2bNumh9bg2bFuI9e/bkpZdeIiIiAqvVyscff8xVV13Fnj176NOnT5s9j0ajkYKkGxsa5sDQMD+KKoysTsxhZUI2J4oqOXkwj58P5hHo6UBsjB8TIn1xc5S51EIIIUS9jB2Q9AvYuV7UQvyOO+7gwIEDfPrpp/To0YPPPvuMSZMmkZCQQEBAQJPrly5dysKFC3n33XcZNmwY27dv584778TDw4Pp06dftH63VIfb4t7T05MlS5Ywd+7cJvdVV1dTXV1df/vEiRPExMSQkpJyxm+KEGditVpJzCplVWIOm5MLMJqUjQo0ahWXhHgwOdqXAT3dUMsOnkIIIbo59eqnUR3fhGXUA1ijr2xVGydOnCA0NLRJEW1nZ4edXdNs8srKSlxcXPjpp5+YNm1a/fkhQ4YwdepUnn/++SaPGTVqFKNHj2bJkiX15x566CG2bdvGpk2bWtXvi6HDzBE3m818++23lJeXM3LkyDNe8+KLL7J48eIm51evXo23t3d7d1F0MeFAoB8kFanYX6Aiq1LF74VF/L4nBRedlX6eVvp4WHHT27qnQgghhG0MSDuIe0UxCfsSyU1pXdmYl5cHQExMTKPzTz/9NM8880yT600mE2azGXt7+0bnHRwczlpUV1dXn/H67du3U1NT0ybpYdXV1Wzbto3U1FQqKirw8fFh0KBBhIaGtrpNm4+I79+/n5EjR1JVVYWzszNffPEFf/vb3854rYyIi/aUklfOqqQcNhzOo6zaDIBKBQN6ujEp2pdhwR7otZJNLoQQovvQLLsTCo5hufxlrAGtm5rS0hFxUEa49Xo9X3zxBQaDgS+//JLZs2cTHh7OoUOHmlz/+OOP8+GHH7JixQoGDx7Mrl27uOKKK8jOzubkyZP4+/u3qu8Amzdv5vXXX+fnn3+mpqYGNzc3HBwcKCgooLq6ml69enHXXXdxzz334OLSsrx1m4+IR0ZGsnfvXoqLi/nuu++YPXs269evb/JXEzT9hpWUlACg1WolJ1lcsN7+7vT2d+eOMeFsPZbPyoQs9qUXsy+jhH0ZJbjYa7ksypfYGD+CvBxt3V0hhBCi/RnLQKVC7egOray1tFql3HRxccHV1bVZj/n000+5/fbbCQgIQKPRMHjwYP7+97+za9euM17/1FNPkZWVxYgRI7BarRgMBmbPns3LL7+MWt36QbQrr7yS3bt3c/PNNxMfH8/QoUMb7U9z7NgxNm7cyJdffsmrr77KJ598wuTJk5vdvs1HxE83adIkwsLCePvtt897bUZGBoGBgaSnp9OzZ8+L0DvR3WQVV7EyIYtViTkUlDdsZhDp50JsjIExET446GUhsBBCiC7q/SlgqoK/fwmuPVrVxIXUa+Xl5ZSUlODv78+NN95IWVkZv/zyy1mvr6mpITs7G39/f9555x0effRRioqKWl2Mv/3229x+++3NGvBNSEggMzOTiRMnNrt9m4+In85isTSafiKELfm52XPryBBuHh7M7rRC4g9msf14IYeySjmUVcq7G48xJsKH2D4GIg0uXTIGUQghRDdlMipFONhsi3snJyecnJwoLCzkjz/+4OWXXz7n9Tqdrr7Y/+qrr7jiiisuaET87rvvbva1MTExZ5zRcS42LcQXLlzI1KlTCQoKorS0lC+++IJ169bxxx9/2LJbQjShUasYFuLJsBBPCsuNrEnKIT4hi5NFVaxMyGZlQjZBno7E9jEwPtIXNweZKiWEEKKTU2uV7e2rS0DndFGf+o8//sBqtRIZGcnRo0d55JFHiIqK4rbbbgOUGvLEiRN88sknABw+fJjt27czfPhwCgsLefXVVzlw4AAff/xxm/UpPT0dlUpVX+hv376dL774gpiYGO66665WtWnTQjwnJ4dZs2aRmZmJm5sb/fv3548//mjR3BohLjYPJz3XDunJNYMDOHiyhPiEbDYfzSOtoIL3Nqbw4ebjjOjlRWwfAwN7uksMohBCiM5JrVa2tz9li/uiCiM6jRpHvaZd3wUuLi5m4cKFZGRk4OnpybXXXssLL7xQP0UkMzOTtLS0+uvNZjOvvPIKhw4dQqfTMWHCBLZs2UJISEib9enmm2/mrrvu4tZbbyUrK4vJkyfTp08fPv/8c7Kysli0aFGL2+xwc8RbQuaIi46ivNrEhsO5xCdkczSnrP68r4sdE6MNTIrxxdfF/hwtCCGEEB3fM8sPsiu1kPsnRjA5xtCsx3SVes3Dw4M///yTyMhI3njjDb7++ms2b95MfHw899xzD8eOHWtxmx1ujrgQnZGTnZap/fyZ2s+fY7llxCdks+5QDjml1Xy5PY2vdqQxKNCd2D5+XBLqiU4jMYhCCCE6uLwjcCQePEIhSomWrgsu8OiGO1HX1NTUp/etWrWKK69UNjiKiooiMzOzVW1KIS5EG+vl48w945y5bXQIW5PziU/IZn9GMbvTitidVoSrg5YJkRKDKIQQooPLT4a/voHAS+oL8cKK2kLcqfvtdtenTx/eeustpk2bxsqVK3nuuecAOHnyJF5eXq1qUwpxIdqJnVbD+Ehfxkf6kllcyaqEbFYm5lBYbuSnvSf5ae9JovxciO3jx6Xh3hKDKIQQomOpLlU+1iammC1WiitrAPB07H6F+L///W+uvvpqlixZwuzZsxkwYAAAy5cv55JLLmlVm1KIC3ER+Ls51Mcg7kpVYhB3HC8gKauUpKxS3t1wjDER3sT28aO3wVliEIUQQthedbHy0U7ZhKeowojVCmoV3SodrKKiAkdHR8aPH09eXh4lJSV4eHjU33/XXXfh6Ni6d7ilEBfiItKoVVwS6skloZ4U1MUgHswis7iK+IRs4hOyCfJyJDZGYhCFEELYWP2IuDPQMC3FzVHfrRLBvL29ueyyy7jyyiu56qqrMBgaL1K9kGQWWTEmhI14Oum5bkhP3r51CC9e048JkT7oNCrS8pUYxDkfbufl35PYk1aIxdJpw42EEEJ0VlUlykc7NwAKK+qmpXSvQaKkpCSmTJnCN998Q3BwMMOHD+eFF15g//79F9x2lxgRt1gsWCwWW3dDiFaL8Xchxt+FO8aEsuFwLisTc0jOLWPDkVw2HMnF4GLPxGhfJkb54uNiZ+vuCiGE6AZUtSPiVr0TWCzkl1VjxYq7g65FdVdnr9GCgoKYP38+8+fPp7i4mF9//ZWffvqJJUuW4OnpyZVXXsmVV17JuHHj0Ghatt6rU+aIx8XFERcXh9FoJDk5md27d+Pv72/rbgnRplILqthwrIgtKcVU1ij/ialU0NffiXFh7gzs4YJW033eGhRCCHFxua35J9rCo5SMXEhNj2H8dCCPZX/lMjbMnduHN7/uyszMZPDgwYSHh6PT6Zg3bx7z5s1rx55fHDU1Naxdu5aff/6Z5cuXU1payn//+19mzpzZ7DY6ZSFepy4gPjU1tVMHxAtxLtUmM1uTC1iZkM3+k8X1590cdEyI9GFytIFAT4lBFEII0cYqCqCqCJx9Qe/M0vXJ/HYgixuG9OSWEcHNbiYjI4Pg4OBOv6HP+ezZsweTycSwYcOa/ZguMTVFrVajVst0d9E1OejVXBZt4LJoAyeLKlmVmM3KhGyKKmr4aW8mP+3NJNrfhckxfoyJ8MZeJzGIQggh2oCzt3LUKqqoQYUKL2f7FtVdXbFGKy8v5+uvv6ayspLY2FgiIiIYNGhQi9vpEoW4EN1FD3cHZo0MYebwYHYeLyA+IZudxwtIzCwlMVOJQRwX6cPkGAMRvhKDKIQQou3ULdb0cOpeizXT0tK49dZb2b17NyNGjOD9999n8uTJHDlyBAAHBwd+++03xo4d2+K2u96fKEJ0Axq1iuG9vHjqihg+vO0SZo0Mxs/NnsoaM78fyOKhb/Yx/8s9LN93kpKqGlt3VwghRGdjrIAtb8LuT6B2sWVh/fb23Wszn4cffhij0chbb72Fo6MjU6ZMISIigszMTLKzs5k6dSrPPPNMq9ruEnPEu/qcIyGaw2q1cuBECSsTsth0NI8as/KjrdWoGNnLi9g+fvQPcOtW2a9CCCFaqeQkfPl30NrD3D+wWq1cs3QLJrOV92YPxeBq3+ymOnu95ufnV797ZkFBAd7e3mzevJmRI0cCsG/fPiZOnEheXl6L25apKUJ0ESqVin493ejX0427xoWx/lAu8QlZHMstZ+ORPDYeycPgasfkGAMTow14O0sMohBCiLOozxBXtrcvqzZhqh3g6W4j4jk5OQQHK4tTPT09cXR0bLSpj5+fH4WFha1qWwpxIbogZzst0/r7M62/P0dzyliZkM26Qzlkl1Tz2Z9pfLEtjUFBHsTGGLgk1BOtRmapCSGEOEXdrpr2yvb2heXKNEdnOy16bff7nXHqmqu2XH8lhbgQXVy4rzPhvs7cNjqErcn5xCdkceBECbtSC9mVWoi7o47LonyZHGOgp4fEIAohhACqG4+IF9Rub+/p1L1Gw+ssWrQIR0fld6TRaOSFF17AzU3ZcbSioqLV7baqEE9LSyM1NZWKigp8fHzo06cPdnbyNrcQHZm9TsOEKF8mRPlyoqiSVQnZrEpUYhB/2H2CH3afIMbfldg+BkaHSwyiEEJ0a3Uj4rWFeP1CzW6WmAIwduxYDh06VH971KhRHDt2rMk1rdHsQvz48eMsXbqUr776ioyMDE5d46nX6xkzZgx33XUX1157bZfMixSiKwlwd2D2qBBmDg9iZ2ohK2tjEBMyS0jILOHt9UoMYmyMgXCJQRRCiO6nvhBXpqYUdNPEFIB169a1W9vNqpjvv/9+BgwYQEpKCs8//zwJCQkUFxdjNBrJysri119/5dJLL2XRokX079+fHTt2tFuHhRBtR6tRM6I2BvGDOcO49bQYxAXf7OP+r/by876TlEoMohBCdB/1U1Nq54hXdN9CvD01a0TcycmJY8eO4eXl1eQ+X19fLrvsMi677DKefvppfv/9d9LT01u0vacQwva8nO24YWgg1w3uyYGTxaxMyGbz0TyO55XzzoZjfLg5hZFhXsTG+NFPYhCFEKJrG3QL9L4c9M5Aw4h4d5wjXlRUxJdffsk//vEPAGbOnEllZWX9/RqNhnfffRd3d/cWt90lcsRTU1M7ZS6lEB1daVUNGw7nEZ+QTUp+ef15g4s9k2N8uSzKV2IQhRCiG3h82QEOnCzm4cm9Gdvbp0WPzcjIIDg4uNPmiC9ZsoS9e/fy+eefA+Di4sKUKVNwcVHmz2/dupWbbrqpVZv6tLgQT0lJwWQyERER0ej8kSNH0Ol0hISEtLgTLRUXF0dcXBxGo5Hk5GR2796Nv79/uz+vEN2V1WrleGEVG5OL2Xq8mMoaZZc1tQr6+TszNsydAQHOaGWUXAghuqTHViSTVWLksYlBRBmcWvTYzMxMBg8eTHh4ODqdjnnz5jFv3rx26mnbGz58OC+88AKTJk0ClEJ837599OrVC4Bly5bx7LPPsmfPnha33eLUlDlz5nD77bc3KcS3bdvGe++9164T2uvUfQPrRsS9vLzw9fVt9+cVojszGGB4FFTXmNmcnM+qxBwOnCzmYG4VB3OzcHdoiEEMcHewdXeFEEJciH1fgaVGmZ7i5EOF6RhanZZePQ34tjDq1mhUprWsXbu2U46IHzt2jMjIyPrbkZGR6PUNU3QGDBjAkSNHWtV2iwvxPXv2MHr06CbnR4wYwX333deqTlwotVotSS1CXCQOdmomxfgxKcaPjMIKViZksyYph6KKGpbtOcmyPSfp00OJQRwVJjGIQgjRKR38HsrzIGgkVfbeVNZYUKHCy9m+xTVXZ6/RysvLKS4uJjAwEICdO3c2ud9isbSq7RYX4iqVitLS0ibni4uLMZvNreqEEKJz6unhyG2jQ7l1RDA7jisxiLtSCzh4soSDJ0t4a/0xxvX2YUofA2E+EoMohBCdxilb3Nclpui1ahz13W9wpVevXuzevZu+ffue8f6dO3cSGhraqrZb/CfK2LFjefHFFxsV3WazmRdffJFLL720VZ0QQnRuWo2akWFeLJoew/tzhnHriGAMrvZUGpUYxP/39T4e+GovK/6SGEQhhOjwTNVgVopv7F0bZYh3xwGVq6++mieffJLs7Owm92VlZfH0009z9dVXt6rtFo+I//vf/2bs2LFERkYyZswYADZu3EhJSQlr1qxpVSeEEF2Ht7MdNwwL5LohPdl/QolB3JKcR0peOW+vP8YHm1IYFeZNbB8DfXtIDKIQQnQ4dZv5qNSgc6SwPB8Az264qybAP//5T77//nsiIiK49dZb6d27NwCHDh3is88+IyAggEcffbRVbbe4EI+JieGvv/7izTffZN++fTg4ODBr1izuu+8+PD09W9UJIUTXo1arGBDozoBAd0qrerHuUC7xCdkczytn/eFc1h/OxeBqT2yMgYnRvnhJDKIQQnQM1Q3TUlCpGjbz6YYZ4qCkpGzevJmFCxfy5ZdfUlRUBIC7uzs333wz//rXv+qjDFuqS+SId9ZcSiG6G6vVytGcMuITsll/OJdKozLFTa2CIcGexPYxMDTYA62mcy/sEUKITu3kXvj5AXDrCTd9zidbj/Ptzgym9ffnnnFhLW6uK9VrVquV3NxcAHx8fC54qk6LR8RBmYry9ttvc+zYMb799lsCAgL49NNPCQ0NlXniQoizUqlURBhciDC4MPfSUDYfzWNlQjYHT5aw43gBO44X4O6oY2KUL5P7+EkMohBC2ELd1BR7N+CUXTVle3tUKlWbRma3eNjp+++/Z8qUKTg4OLB7926qq6sBJTXlX//6V5t1TAjRtdnrNEyMNvDStf3538zBXDM4AHdHHUUVNXy/+wT3fLqLhT/8xdqkHKpqJJFJCCEumoAhcN0HMOYhAArLu+/UlMsvv5w///zzvNeVlpby73//m7i4uBa13+IR8eeff5633nqLWbNm8dVXX9WfHz16NM8//3xLmxNCCAI9G2IQtx8vIP5gNnvSCjlwooQDJ0pwXK9hXKQPsTF+hPs627q7QgjRtekdwathCkpBhZJ21R0Xa15//fVce+21uLm5MX36dIYOHUqPHj2wt7ensLCQhIQENm3axK+//sq0adNYsmRJi9pvcSF+6NAhxo4d2+S8m5tb/eR1IYRoDa1Gzagwb0aFeZNXVs3qxGxWJmSTXVLNb/uz+G1/FqHeTsT2MTCutw8u9t3vl4IQQlxshafEF3Y3c+fO5ZZbbuHbb7/l66+/5p133qG4uBhQpqnExMQwZcoUduzYQXR0dIvbb3Eh7ufnx9GjRwkJCWl0ftOmTfTq1avFHRBCiDPxdrbjxmFBXD8kkL9OFBN/MIutx/IbxSCODvcmNsaPvgGu3TLbVggh2sWx9VCUCj2HYfKKpKSqbkS8+xXiAHZ2dtxyyy3ccsstgDIdu7KyEi8vL3S6CxsQanEhfuedd/LAAw/wwQcfoFKpOHnyJFu3buXhhx/mqaeeuqDOCCHE6dRqFQMD3RkY6E5JVY0Sg3gwi9T8CtYdymXdoVz83OyZHGNgYpTEIAohxAU7tg6S14DOkSLHXlitSrqVq7wLCSizQNzc3NqkrRYX4o899hgWi4WJEydSUVHB2LFjsbOz4+GHH2b+/Plt0qmWslgsWCwWmzy3EOLicdZruKKfH9P6GpQYxMQcNhzOJbO4kk+2HuezP1MZGuxBbIyBIcEeaGSzICGEaDFVbY64VedEfmkVVqy4O+oBKxZLy1OvpUY7u1bniBuNRo4ePUpZWRkxMTE4O1+8BVRxcXHExcVhNBpJTk5m9+7d+Pv7X7TnF0J0HFUmCzvSStiQXMSR3Mr68+4OWkaHujE2zB2DS/d8O1UIIVrDbc0/0RYepWTU42w3R/L6hgxCPO155vLQVrWXmZnJ4MGDCQ8PR6fTMW/ePObNm9fGve6cLnhDn7qt7SMjI1s1Sf1C1AXEp6amdvqAeCHEhcsorGBlQg5rDuVQXFlTf75fDzcmxfgyKswLO63Ghj0UQoiOT/XVzVCaifXK//J7rjf/W5/MsBBPnprWujovIyOD4ODgLrGhT1tr8dSUG264gbFjx3LfffdRWVnJsGHDSElJwWq18tVXX3Httde2Rz/PSa1Wo1bLTnxCdHdBXs7MHePMrFEh7EgpID6hNgbxZAkHTpbwzoYUxkf6EtvHQJiPxCAKIcQZGcsAUNm7UVxlQoUKLyd9q2stqdHOrsWF+IYNG3jiiScAWLZsGRaLhaKiIj7++GOef/55mxTiQghxKp1Gzahwb0aFe5Nb2hCDmFNaza/7M/l1fyZhPk5MjvFjXKQPznat2mRYCCG6HoulYWdNOxcKygsAaueIC1CmZ+fk5DSZ+x4UFNTitlr826e4uBhPT08Afv/9d6699locHR2ZNm0ajzzySIs7IIQQ7cnHxY6bLgnihqGNYxCTc8tJXp/M+5uOcWm4N7F9/OjTQ2IQhRDdXO1oOAB2rhSWZwHdN7rwVEeOHOH2229ny5Ytjc5brVZUKhVmc8t3gW5xIR4YGMjWrVvx9PTk999/r99ds7CwEHt7+xZ3oC3ot/8PSkaATxR49gKNjG4JIRo7PQZxbVIO8QnZpOVXsPZQLmsP5dLD3Z7JMX5MjPLtlls5CyEEeidle3tjGWi0FFR03818Tjdnzhy0Wi0rVqzA39+/TQZuWlyxPvjgg8ycORNnZ2eCg4MZP348oExZ6dev3wV3qDV0x9dA7mblhkYP3hFKUe7fH3qNt0mfhBAdl6u9jqsGBnDlgB4cySkj/mAWGw7ncbKoio+3HOfTrccZFuLJ5BgDQ0M8JQZRCNF9qDWNtrev21VTRsRh79697Nq1i6ioqDZrs8WF+L333svw4cNJS0tj8uTJ9RPwe/XqxfPPP99mHWsJY/Q1YMmG3EPKvKbsg8qRf7RxIb7va3DtAb7R4ORtk74KIToOlUpFb4MLvQ0uzL20F5uO5hF/MIukrFK2pRSwLaUADyc9k6N9mRRjwN/NwdZdFkKIi8ZqtVJYoSRQeTjJZj4xMTHk5eW1aZsXHF9oS3XxhfVxOBYLlJyA3CTlcAuEPjOUi6tL4aMrGh7s5K2MmvtEKYW5d2+wd7XJ1yGE6FjSCyqIT8hmTVI2JZWm+vP9eroxOcYgMYhCiK4r9zCkbQWvMEr8hjPz3W0AfP+PUei1rUs/aVKvdSIlJSX1n+/cuZMnn3ySf/3rX/Tr16/J9vauri2vI5s1Iv7SSy/xwAMP4OBw/tGgbdu2kZeXx7Rp01rcmQumVoN7oHJETG58n6kaoqYpBXpBCpTnQfkmOL5JuT9qGoz7p/K52aRc5x0BWtkuW4juJtDTkbmXhjJrZHB9DOLutEL2ZxSzP6OYt+00SgxijIFeEoMohOhKsg/Azg8gdCyFLoMAcLbTtroI7+zc3d0bzQW3Wq1MnDix0TXtvlgzISGBoKAgrr/+eqZPn87QoUPx8fEBwGQykZCQwKZNm/jss884efIkn3zySbOe/MUXX+SHH34gKSkJBwcHRo0axb///W8iIyNb/IWcl5N3Q6FdUwl5R5RiOydR+ehzynyfgmPw0zxlnpRnr4ZRc58o8AhVCn4hRJd3agxiTmkVqxNzWFUbg/jLX5n88lcm4b7OTI4xMK63D04SgyiE6OzqowtdKbDh/PATJ07w6KOP8ttvv1FRUUF4eDgffvghQ4cOPetjqqurefbZZ/nss8/IysrC39+fRYsWcfvtt7e6H2vXrm31Y5ujWb81PvnkE/bt28ebb77JzTffTElJCRqNBjs7OyoqKgAYNGgQd9xxB3PmzGl2esr69euZN28ew4YNw2Qy8fjjjxMbG0tCQgJOTk6t/6rOR+egLOT0799w7tQZOpWF4OChfMw7ohyJPyv3ae1hzALoPUW5bbGASqUcQoguy9fFnr9fEsSNQwPZl1FEfEI2W5PzOZpTxtGcMt7flMLocG9iYwwSgyiE6LxOyRAvrEtMucjzwwsLCxk9ejQTJkzgt99+w8fHhyNHjuDh4XHOx91www1kZ2fz/vvvEx4eTmZmZpOs75YaN25c/edpaWkEBgY2+f/darWSnp7eqvZbPEfcYrHw119/kZqaSmVlJd7e3gwcOBBv7wtf/Jibm4uvry/r169n7Nix572+XeccWa1QlgO5iZCTpHzMPQw1FTDtVeg5RLkueS1sehV8osEnsmHk3NGzbfsjhOhwiitrWHcoh/iD2aQVVNSf7+FuT2yMH5dJDKIQorNZ+yIc/h2G38135rF8vOU4EyJ9WBDb+tkKLa3XHnvsMTZv3szGjRub/Ry///47N910E8eOHavf76ataTQaMjMz8fX1bXQ+Pz8fX1/fi5MjrlarGThwIAMHDmzxk51PcXExwFlfwOrqaqqrq+tvl5Yqf7WZTCZqamravD/Ye0LgaOUAsFqgKA1c/KD2+dTZCagqiyHtT+Wo4+yL1ScKy5DblUWjQogux1ELf+vjy9QYH47klLEyMZdNR/M4UVjJh5tT+HhLCsNCPJgU7cugQHeJQRRCdHjqyiJUVisWjSP5RZVYrVZc7TUXVGeZTMqi99LS0kaLH+3s7LCza7oWb/ny5UyZMoXrr7+e9evXExAQwL333sudd9551udYvnw5Q4cO5eWXX+bTTz/FycmJK6+8kueee65Zaxybo24u+OnKyspavZdOh5nQaLFYePDBBxk9ejR9+/Y94zUvvvgiixcvbnJ+9erVbTIi33wJ9Z+pLH44u9+ES9UJXKoycKk6iaMxF1VxMZw4wrbScKp0ylspfsW7cas4Tql9T0rtAyizM2BVd5hvgRDiAoUCAQY4VKxif4GKkxUq4vcWE7/3OM46K308rPTzsOIua8CFEB3UwNQE3CqLObgvgR2FGoqLVaQeLuTXwoOtbrMu8i8mJqbR+aeffppnnnmmyfXHjh1j6dKlLFiwgMcff5wdO3Zw//33o9frmT179hmf49ixY2zatAl7e3uWLVtGXl4e9957L/n5+Xz44Yet7jvAggULACXy9qmnnsLR0bH+PrPZzLZt21o9QN1h4gv/8Y9/8Ntvv7Fp06azvm1x+oj4iRMniImJISUlhYCAgIvV1fMzlkP+EVT5R7H2ubZ+/rh69dOo6lJaADQ68OyF1TsKq08k1l4TlA2JhBBdQlpBBauTcll3KJeSqlNiEANcmRzty/BQz26bRCCE6Jg0P8yFwuNYpi7hiR12HDxZyoLJ4YwJb/2A54kTJwgNDSUhIaFRvXa2EXG9Xs/QoUMbbSV///33s2PHDrZu3XrG54iNjWXjxo1kZWXh5uYGwA8//MB1111HeXn5BY2KT5gwAVDWNo4cORK9vqFW0+v1hISE8PDDDxMREdHitjvEcOx9993HihUr2LBhwznnDp3+Dat7e0Or1TbJcrQpnTs4DYOgYY3P97tW2a0q9xDkJCgLIvIOK8cRHUROUYpzgGPrlY8+UeDsK4tBheiEwgxuhBncmDO6F9tTCliZkMWe9CIOnCzlwMlSnO1SGR/pw2SJQRRCdBSxz0FlIWqvMIoqD6FSqfB1dbygOkurVcpNFxeXZmVt+/v7Nxk9j46O5vvvvz/nYwICAuqL8LrHWK1WMjIyWlUk16lLTrntttt4/fXXW5UXfjY2LcStVivz589n2bJlrFu3jtDQUFt2p/0FDFEOUBaDlmY2xCfWVDYU4QC7P4b8ZOVzB4/aRaCRyqJQ3yiwd2vavhCiQ9Jr1Vwa4c2lEd7klFSxKjGHVYnZ5JZWs+KvTFb8lUmErzOxfQyM7e2Do75DjJEIIbojj2DlAArL63bVvLjv1o8ePZpDhw41Onf48GGCg4PP+Zhvv/2WsrIynJ2d6x+jVqvbLNDjQqe4nEmrp6YcPXqU5ORkxo4di4ODw1knsJ/LvffeyxdffMFPP/3UKDvczc2tWW8hdOadms7JaoXNr0H2QaUYt54WvePWE276vOF2fjK49lBiGYUQnYLFYmVPehErE7L581g+ZovyX7GdVq3EIPYxEOMvMYhCCNuoNJq54W1lGsg3d4/EQd/63YRbWq/t2LGDUaNGsXjxYm644Qa2b9/OnXfeyTvvvMPMmTMBWLhwISdOnKjfu6asrIzo6GhGjBjB4sWLycvL44477mDcuHG8++67re77Nddc0+xrf/jhhxa33+Jhl/z8fG688UbWrFmDSqXiyJEj9OrVi7lz5+Lh4cErr7zS7LaWLl0KwPjx4xud//DDD5kzZ05Lu9Z1qFRw6f9TPjdVN2w+VLcBkW90w7UWC/x0H5iqwDNUmcpStwGRRyhoZGRNiI5IrVYxJNiDIcEeFFfUsO5wQwzimqQc1iTlEODuwOQYAxOjfXF3lPUjQoh2VlUCB5eBgweFPZQdyu116gsqwltj2LBhLFu2jIULF/Lss88SGhrKa6+9Vl+EA2RmZpKWllZ/29nZmZUrVzJ//nyGDh2Kl5cXN9xwA88///wF9eXUqS5Wq5Vly5bh5uZWv7HQrl27KCoqalHBfqoWj4jPmjWLnJwc3nvvPaKjo9m3bx+9evXijz/+YMGCBRw82PpVtS3VZUfEz8diadjdsywXfrwHyvOaXqfRQ8xVMOq+hnNWq8w3F6KDslqtJGWVsjIhm41HcqmqUd4NU6tVDA/1JDbGwOAgD9QSgyiEaA/5yfDd7eDgwYGJH7Pwh/34udnz7qyz72bZHF2lXnv00UcpKCjgrbfeQqNR/jgxm83ce++9uLq6smTJkha32eLh0vj4eP74448mL2RERASpqakt7oBoBfUpKQvOPnDL90pBfuqoee4hMJaBviFih4oC+GYWePdWRszrNh9yupjRj0KIs1GpVET7uxLt78qdY3qx4UguKxOyOZRVytbkfLYm5+PlrGditIHYGAMG19bl1gohxBlV12Z8n7Krpqe8G1fvgw8+YNOmTfVFOCib/CxYsIBRo0ZdnEK8vLy8UX5inYKCgjNG0IiLxNlHOULHKLctFig5AdpTflHnJCpJLSd2KUcdJx9lIWjMDAg8LelFCGETDnoNU/r4MaWPH2n5FcQnZLEmKYf8MiPf7Ejnmx3pDAh0IzbGjxG9vCQGUQhx4eq3t3eloLxue3spxOuYTCaSkpIarWsESEpKwmKxnOVR59biQnzMmDF88sknPPfcc4AygmOxWHj55ZfrcxZFB6BWg/tpO3oGDodr32tIaslJhMLjUJ6rHKFjG67NOwJ/faMU6L7R4BUBWvlhFMIWgrwcuWNML2aNDGFbSj4rE7LZm17EvvRi9qUX42ynZUKUD5Nj/Aj1drJ1d4UQnVV9Ie5CYW0h7unUgeKhbey2225j7ty5JCcnc8kllwCwbds2XnrpJW677bZWtdniQvzll19m4sSJ7Ny5E6PRyD//+U8OHjxIQUEBmzdvblUnxEWi0YJ3hHJwpXKuplLJMc89BP4DG649uReOxCsHgFoDnmENhXnQSHD0vMhfgBDdm16rZkyED2MifOpjEFcmZJFXZuTnfZn8vE9iEIUQF6Dq1KkptdGFMjWl3v/93//h5+fHK6+8QmZmJqDklz/yyCM89NBDrWqzVfGFxcXFvPnmm+zbt4+ysjIGDx7MvHnz8Pf3b1UnWqurTP7vkPKOQuomyKmdd15Z2Pj+q+LAr6/yeU6SMg3GNwZc/GQxqBAXkRKDWEh8QjbbjhU0ikG8NMKb2Bg/ov1dJAZRCHF+29+FPZ9B32tZlHcZe9KKeGBiBJNiDBfUbFes1+o2lbzQzX1aNVzi5ubGE088cUFPLDo473DlACVppSy7djpLbWHuFd5w7eHflbgjAHvXhk2H6qIUZeRciHajxCB6MiTYk6IKI2sP5bAyIZv0gkpWJ+awOjGHnh5KDOJlURKDKIQ4h6pi5aOdi8wRP4+22l2zVSPiVVVV/PXXX+Tk5DSZnH7llVe2Sceaoyv+hdUp7fsaktdA/lGwmJref+uyhmK8NAvsXBunuQgh2lRdDGL8QSUGsdrUEIM4ItST2D4GBgVKDKIQ4jSlWcrh7MvMb9IoqTTxxt8HXfDak85crw0ePJjVq1fj4eHBoEGDzvnu4u7du1vcfotHxH///XdmzZpFXl7T3GqVSoXZbG5xJy6UxWJp9WpV0Qb6Xa8cZqOSQZqbhCo3SZl3bqrCau+upLgAqo2vQMYOcA/G6hOlzDn3iVLmn2tkQYgQbSXS4EykwZm5lwaz8UgeqxJzOJRdyubkPDYn5+HlZMekaF8mRftKDKIQQuHkC06+1JgtFFcmA+DuoL3gGqsz12hXXXVVfSrgVVdd1ebT/Fo8Ih4REUFsbCyLFi3CYLiwOUOtFRcXR1xcHEajkeTkZHbv3n3R56eLZjIblY2FarmteghtcUqTy6xqHSavaErGPnMROydE95JeVMWG5GK2pBRTblQGTVQqiDY4MS7MncE9ndFpJAZRiO4uv7yGh346iloF790UhfoCi8/MzEwGDx5MeHg4Op2OefPmMW/evDbqbefW4kLc1dWVPXv2EBYW1l59ara6tzpSU1M73Vsd3VpFAeQqmw6p6jYhqi4F/wFYr3it/jLVsrtB74jVJ7phvrmTjywGFeICGU2W2hjEHPZmFNWfd7HTMiHSl8kxvgR7SQyiEN3Oge9BpSbZ5RL+38/H8XKy48M5F7arJij1WnBwcKecmnKqRYsWMWHCBEaOHIm9fdu8k9jiqSnXXXcd69at6xCFeB21Wo1aLaM4nYazNziPadh8yGqFkpNQU4mq7vtYVaLEKgKqk3sbHuvgoaSzhIyGqGkXt99CdBH2ejXjIg2MizSQXVLFyoRsViVmk19m5Oe/Mvn5r0x6G1yYHGNgXG8fHPSa8zcqhOj8dn0IxnLKRv4XFSq8nPRtUl91lRpt69atvPrqq5hMJoYNG8a4ceMYP348o0ePxsHBoVVttnhEvKKiguuvvx4fHx/69euHTtd4Xu/999/fqo60Rmee/C/Ow2KBwpSGjYdyk5T559baeWZRV8C4R5TPzTWw/t/gHanMOffuDTqZ8ypES9THIB7M5s+UAiy1MYj2OjWXhvsQ28dAlJ/EIArRZVnM8O5lAKwa9javb87jklBPnroi5oKb7kr1mslkYtu2bWzYsIH169ezZcsWqqurGTZsGJs2bWpxey0eEf/yyy+Jj4/H3t6edevWNfpPWaVSXdRCXHRhajV4hSlH3ci3qVrZ8TM3CTxDG64tOAZHVioHgEqt3O8TrRTmAUPALeDifw1CdCKnxyCuSVJiEDMKK1mVqIyYB3rWxiBGGnBzlMXVQnQpdbtqArlGZXGip0QXNqHVahk9ejQ+Pj54enri4uLCjz/+SFJSUqvaa/GIuJ+fH/fffz+PPfaYzd9q6Ep/YYkLUJqt7ABaN3pekd/4/kvugkEzlc8rCuDEbiXn3DVA5psLcQ5Wq5XEzFLiE7LYdCSvPgZRo1YxvJcnsTESgyhEl1GUDl/fAnon4kLe4PcDWfz9kiBuHh50wU13lXrtnXfeYd26daxfv57q6mrGjBnD+PHjGT9+PP3792/VO4YtHhE3Go3ceOONNi/ChajnYoDBtzbcLsutXwxKTmLDDqAAmXthzXPK53YutYtAI5V55z5R4OR1UbsuREemUqmI6eFKTA9X7hrbiw2Hc4k/mM2RnDK2HM1ny9F8vJ31TIoxMCnaIDGIQnRmdSPip2zm4+kk73yd6p577sHHx4eHHnqIe++9F2dn5wtus8WF+OzZs/n66695/PHHL/jJhWgXzj7KETq26X1qHRj6KFNcqkuVTPOMHQ33xz7fsIi0qkSZ5mJ34T9oQnR2jnotl/f15/K+/qTklbMyIYu1SbnklRn5ans6X+9IZ2CgO5NjDAwP9UKvlcEaITqVUwrxwtpCXHbibeyHH35gw4YNfPXVVzz99NMMGjSofkT80ksvxdGx5ZsVtrgQN5vNvPzyy/zxxx/079+/yWLNV199tcWdEOKiCa1NazHXQEGKMnKek6R8LEwFr/CGaxOXw/Z3wT1QmW/uWxuh6BUBWvnPSXRfod5O3DU2jDmjQvnzWD7xCVnsSy9mT1oRe9KKcLHXclmUL7ExfgR5yS66QnQK1SXKRztXCkrqRsTld92pZsyYwYwZMwAoLi5m48aNfPvtt1xxxRWo1Wqqqqpa3GaLC/H9+/czaNAgAA4cONDoPllNLzoNjQ58eitHzFXKOWMF6E6JHyrNVD4WpSvHkXjltlqj7AQ65V/KyLsQ3ZReq2Zsbx/G9vYhq7iKlYnZrK6NQfxp70l+2nuSSD8lBnFshMQgCtGh9RwGV76BRa2n8LsCADxkRLyJ/Px81q9fz7p161i3bh0HDx7Ew8ODMWPGtKq9Fi/W7Ei6yuR/0YFVFkLuYchJUOac5yZCZZGyW+htv4Gm9m/ZzW9A/pFTRs6jwcVPFoOKbsdisbI7rZD4hGy2nRaDOCbCh8kxEoMoREdWXFHDLe9vA+CHe0e1yW67XaVe69evH4mJiXh4eDB27FjGjx/PuHHj6N+/f6vbbPGIuBDdioMHBA1XDlA2HyrLhuITDUU4wMk9Soxi5l8N5+zdlKksvtEwZI4U5aJbUKtVDA3xZGiIEoO4OjGH+IQsThYpGwetTMgmyNORyTEGJkT6SgyiEB1MQYUyLcXVQdsmRXhXcs899zBu3Dj69u17/oubqVkj4tdccw0fffQRrq6uXHPNNee89ocffmizzp1PV/kLS3QBBbWbD+UmKXPO84+CxaTc59YTbvq84dqdHypTYHyilM2H9DKHVnRtVquVhMwS4g9ms+loHsZTYhBH9PJicoyBQYHuEoMohC0d3wRlORxQhbNwTQnBXo68efPgNmla6rWza9aIuJubW/3biG5ubu3aodawWCxYLBZbd0N0Z+7ByhExRbltNio7geYmgVqr7BQKYLWg+utrqKlUbqtU4B6M1ad2IaihT+MFo0J0EdF+LkT7uXDHpSFsPJLHykQlBnHT0Vw2Hc3Fx9mOSdG+TIo24ONiZ+vuCtHtqBJXQNpWTL3uxEow7g66NqutOnONtmDBgmZf25rAkmbPEX/22Wd5+OGHWxXN0tbi4uKIi4vDaDSSnJzM7t278ff3t3W3hDg/sxH7o7+gLTiCtvAomsq8RncbDYMpvfTJ+tv69E2Y3UIwu/RQohSF6ELSCqvYkFzE1uMllBvNgPK3aR8/J8aFuTMowAWtRkbJhbgYXNcuRFdwiHi/u/lvahCjQ924c2SPNmk7MzOTwYMHEx4ejk6nY968ecybN69N2m5vEyZMaHR79+7dmEwmIiMjATh8+DAajYYhQ4awZs2aFrff7EJco9GQmZmJr69vi5+kvdS91ZGamipvdYjOqaKgdvOhJFS5h7D2HAr9bqi9Lx/V59cpn+scwSeyYeTcNxocvWXeuegSjCZLbQxiNn+dKK4/72qvY0KkssAzyNP2g0BCdGWqb2dDURo/BDzMhynuXDsogNmjQtqk7YyMDIKDgzv91JRXX32VdevW8fHHH+Ph4QFAYWEht912G2PGjOGhhx5qcZvNXqzZkcNV1Gq17PQpOidnb3AeU7+JUKOy2lim7AqadwRqKuDkHlQn9zTcP3AmDL9L+dxsUq6xd71oXReirdjr1YyPMjA+yqDEICZksSoxh4JyI8v3ZbJ8XyZRfi7E9vHj0nBviUEUoj3UbuiTZ7RDhQpPZ7s2q626So32yiuvEB8fX1+EA3h4ePD8888TGxvbvoU4SE64EBeVZyhcFQcW8ymLQWs3ICo4Bh4hDdfmJMDy+eAa0BCf6Fu7+ZBOth0XnYefmz23jgzh5uHBSgziwSy2pxSQlFVKUlYp7244xpgIbyb3MRBpkBhEIdqE1VpfiOcalexw2cynqZKSEnJzc5ucz83NpbS0tFVttqgQ792793n/0ysoKGhVR4QQZ6HWgHe4ckRfoZyrOW33rqI05WPJCeU4ulq5rVKDZy8YcS/0HHLx+izEBdKoVQwL8WRYiCeF5UbWJDXEIMYnZBNfG4MY28fA+Ehf3BwkBlGIVquprE/6yqzSAVbZzOcMrr76am677TZeeeUVLrnkEgC2bdvGI488ct5UwbNpUSG+ePHiDpmaIkS3c/ood/QVEDq2dtOhJMhJVEbPKwqUKEXtKSkUR1fDgR+UeeY+UcrIuWuAzDcXHZaHk55rh/TkmsEBHDxZQnxCNpuP5pFWUMF7G1P4aMvx+hjEgT0lBlGIFjOWKR81OnJqQ708ZES8ibfeeouHH36Ym2++mZqaGgC0Wi1z585lyZIlrWqz2Ys11Wo1WVlZHXKxZmef/C9Eu7BaoTxPKcgDhzcU45v+Awd/bHytnYtSlPtEQt9rwdHzondXiJYorzax4XAu8QnZHM0pqz/v62LHpBiDxCAK0RImI+QmUl1ZznW/KFGD39w9ss3WY3S1eq28vJzk5GQAwsLCcHJyanVbzR4Rl3l4QnQyKhU4+yjHqfrfBL59atNaDimLQatLIWOHcvS9tuHao6uhNEsZNfeOBDvni/s1CHEWTnZapvbzZ2o/f47llhGfkM26QznklFbzxbY0vtyexuAgD2JjDAwL9ZQdAoU4F60e/AeQV1QJ7MJBp5FF0efg5OR0Qdvan6pLpKYIIVrA1V85escqt801yuLP3CQoSm88Gn74d0jf3nDbPbBhIahP7dSWLrIaXnRevXycuWecM7eNDmFrshKDuD+jmF2phexKLcTNQceEKF9iYwwESgyiEGdVWK5sb+/hJGsuzqS8vJyXXnqJ1atXk5OT02SjomPHjrW4zWYX4p15VyQhxDlodMqUFJ/IpveFXKpkmOcegtJMpVAvSocj8aB3gtkrGq49uRfs3ZQdRqU4FzZgp9UwPtKX8ZG+ZBZXsiohm5WJORSWG/lxzwl+3HNCYhCFOJPcw5B9AGOZB6CTxJSzuOOOO1i/fj233nor/v7+bTJbpEWLNYUQ3UzMVcoBUFmoFOQ5ygZEaO0bF9wblkBxhlK4e0c0LAb1iQIXP1kMKi4qfzeH+hjEXalKDOKO441jEMf29ia2jx8Rvs4y/VJ0byd2wba3cHQdCVyBuySmnNFvv/3GL7/8wujRo9usTSnEhRDN4+ABQSOU43TmGnD0gop8ZWOhzH3KUafHIJj+WsPt6jKZby4uCo1axSWhnlwS6klBuZHVidmsTMgms7iKPw5m88fBbIK8HImNMTAhyhdXe3lLXnRD1SUAlFiVqVueUoifkYeHB56ebRtmIIW4EOLCaXRw5RtgsUBRakN8Yu4hJT7RNaDhWnMNfDoDHL2V6TB1I+fevUEv83dF+/F00nP90ECuG9JTiUE8mMWmo3mk5TfEII7s5UVsHz/6B7hJDKLoPmo38ykyK0lDEl14Zs899xyLFi3i448/xtGxbX5fSSEuhGg7arWyI6hnKET9TTlnMiqj5HWK0pRivDRTOY6tU86r1OARrEyF6XP1Re+66D5UKhV9A9zoG+DGXePCWH8ol5UJWSTnlrPxSB4bj+RhcLVjUrSBSTEGvJ0lBlF0cbUj4gUm5d+6pyzWPKNXXnmF5ORkDAYDISEh6HSNX6fdu3e3uM0uUYhbLBZZTCpER6XWgp2rMloO4BEKs39WFgflJqHKTVJGz8vzoCAFq7Gi4drSTFRrnsPqfcrIuVtPpWgXog046tRM7Wtgal8Dx3LLWJmYw7pDuWSVVPHZtlS+2J7GoEB3JscYGBbiITGIoktSVSmFeH6NHVasuDvo2rSu6io12owZM9q8zWZv6NORxMXFERcXh9FoJDk5md27d+Pv72/rbgkhLoCqsgBtYTJm155YnJWfZ336Jly2v9roOqvWEZNHGCbPCKoDx2B2C7ZFd0UXZjRZ2JleyobkIpJyGt7NcbXXMDrUjTG93OnhJqPkoutwW/UQ2uIUnqmZzS5Lb577WyiB7vbnf2AzZWZmMnjwYMLDw9HpdMybN4958+a1WfudWacsxOvU7dSUmpraJXZqEkKcprIQTuxuGDnPOwxmY/3d1onPQK9xyo38o5D2Z0MUo52rbfosupSTRZWsSsxhdVIOhRUN//ai/VyJjfFldLg39jqJQRSdm+rLm7CWZjG/8k5StSF8dvsluDq03fSUjIwMgoODu8zOmm2pS0xNUavVqCW3WIiux8kLek9WDgCLGQpSaheCJqHy69sQoZi+DXa+3/BYt561RXl0w86gWlmAJFqmp6cTc0aHcuvIEHYeLyA+IZudp8YgbjzOuEgfYmMMhEsMouisJi6iqDCXnJUmtGo1bo76Nv233FVqNLPZzH/+8x+++eYb0tLSMBqNje4vKChocZtdohAXQnQTag14hytH9PTG93n2gvCJSlJLcUbDcXS1cv+17yuPAyg8DmaTsqhULaOZ4vw0ahXDe3kxvJcX+WXVrE7KYWVCNlnFVfx+IIvfD2QR4u3E5BgDEyJ9cJEYRNGZ+PUlh1KqVPvwdtTJH5RnsXjxYt577z0eeughnnzySZ544gmOHz/Ojz/+yKJFi1rVphTiQoiuIWS0cgBUlSgFeW4i5CRBwTHwCGm4dt/XcOhX0Nopmw/VjZr7RINrD9l8SJyTl7MdNwwN5LrBSgziygQlBvF4XjnvbjjGR5tTGBnmxeQYiUEUnUdB/fb28s7h2Xz++ee8++67TJs2jWeeeYa///3vhIWF0b9/f/7880/uv//+FrcphbgQouuxd4XAYcpxJmo16J3AWA5ZB5Sj/rFuMPNbpUgHMFU3fC7EKdRqFf16utGvpxt3ju3F+sO5xB/MJiWvnA2H89hwWIlBnBxjYGK0xCCKDqqyEJLXos5WAT6ymc85ZGVl0a9fPwCcnZ0pLi4G4IorruCpp55qVZtSiAshup+xj8ClD0FxujJynpMAuUnKgk97t8aF96+PQMlJJT7RN7p23nmUUsgLUcvFXscV/XtwRf8eHM0pY2VCNusO5ZBdUs1nf6bxxbY0Bgd7MDnGwCUhnmglBlF0FMUnYPPrBJjdgH/KiPg59OzZk8zMTIKCgggLCyM+Pp7BgwezY8cO7Oxa94e2FOJCiO5JXbuBkEcw9I5VzplrlDzzOhaLUpwbyyElF1I2KOdVKnALhMDhMOq+i9930aGF+zoT7uvMbaND2JqcT3xCFgdOlLDzeCE7jxfi7qjjsihfJscY6Okhu8kKGzOWAVCG8m/RQ0bEz+rqq69m9erVDB8+nPnz53PLLbfw/vvvk5aWxv/7f/+vVW1KIS6EEHU0OnA9ZU8CtRpmfqfEJuYmQU6iMoJemqnsEOoa0Pjxv/4TXPyUEXPfaHAPbkh1Ed2OvU7DhChfJkT5cqKokpUHs1idlENRRQ0/7D7BD7tP0KeHK5NjDBKDKGyndjOfUqsDILtqnstLL71U//mNN95IUFAQW7duJSIigunTp5/jkWcnhbgQQpyL3hF6DFSOOhUFSnF+6hSWslwlQhGAn5QPOkdlMahvtDJ6HjD4InVadDQB7g7MGR3KLSOC2ZlaSPzBbHalFnDwZAkHT5bw9oZjjOstMYjCBmq3ty+2KIW4jIg338iRIxk5cuQFtWHToZoNGzYwffp0evTogUql4scff7Rld4QQonkcPSFoBPQY1HBO7wSTnob+N4L/ANA5QE0FZO6DfV/B8U0N19ZUws4PIW0bVBZd9O4L29Fq1Izo5cWi6TG8P2cYt44IxuBqT6XRzO8HsljwzT4e+GovK/46SWlVja27K7qD6lIACs3KwIJnB5gjvnTpUvr374+rqyuurq6MHDmS33777azX//DDDwwdOhR3d3ecnJwYOHAgn376aZv3Kz8/v/7z9PR0Fi1axCOPPMLGjRtb3aZNR8TLy8sZMGAAt99+O9dcc40tuyKEEBdG7whhlykHKPPLi44r8Ym5icqIeJ28w7Dro4bbLv618Ym1h3dvpT3RpXk723HDsECuG9KTAyeLiT+YzZbkPFLyynl7/TE+2JTCqDBvJscY6CcxiKK9VJdiBQpMdqDpGPGFPXv25KWXXiIiIgKr1crHH3/MVVddxZ49e+jTp0+T6z09PXniiSeIiopCr9ezYsUKbrvtNnx9fZkyZcoF92f//v1Mnz6d9PR0IiIi+Oqrr7j88sspLy9HrVbzn//8h++++44ZM2a0uO0Os8W9SqVi2bJlLfoi6ra4ly1ThRCdSt4R+OsbpUAvSm96/6j50O865fPKIijLUTYs0shswq6utKqmUQxiHYOrPbExBi6L9pUYRNG21ryA6dAfvFE+iXX2l/HDP0a1eapPW9Rrnp6eLFmyhLlz5zbr+sGDBzNt2jSee+65Vj3fqaZOnYpWq+Wxxx7j008/ZcWKFUyZMoV3330XgPnz57Nr1y7+/PPPFrfdqf5Xr66uprq6uv52aanydorJZKKmRt7CE0J0Em4hMOafyufVpajyjkDeIVR5SahyD2H2jIDa/9NUxzag3vh/oNGDVzhW795YfaKw+kQpi0VVshi0K7HXwJRoH2KjvEnOLWdVYg4bjuaTVVzJJ1uP89mfxxkc5M6kaF+GBLlLDKK4cH1vIMttKPs3lOFsp8FqMVNjMbfpU5hMJkCp20pKSurP29nZnTf2z2w28+2331JeXt6s+dhWq5U1a9Zw6NAh/v3vf19Yx2vt2LGDNWvW0L9/fwYMGMA777zDvffei7p2Mf78+fMZMWJEq9ruVIX4iy++yOLFi5ucX716Nd7e3jbokRBCtBU3YDi4DocdKaA6DkBA4Z8ElxnRmYuhIBeObK1/hEljz189b6XUIRAAldWMVSXJG11JEHCjAQ4Xq9hfoCKjXMXqomJW/5WKo9ZKXw8rfT2teMogubgAKaVwtMwOH1Mev/76a5u3n5enxMLGxMQ0Ov/000/zzDPPnPEx+/fvZ+TIkVRVVeHs7MyyZcuaPP5UxcXFBAQEUF1djUaj4X//+x+TJ09uk/4XFBTg5+cHKBv5ODk54eHhUX+/h4dH/eBwS3WqQnzhwoUsWLCg/vaJEyeIiYlh4sSJBAQEnOORQgjRWf0NrFYoOYEq7xCqXGXUnPwjYDYy5m83gIPyC0G98wNUR37H6hOJ1VuZb2717g12Ljb+GkRbOVFUyarEHNYeyqO4soZDRjiUBX16uDAxypdRvTyxkxhE0UKrE3NwKzhGn0A3/va36DZv/8SJEwAkJCQ0qtfONRoeGRnJ3r17KS4u5rvvvmP27NmsX7/+rMW4i4sLe/fupaysjNWrV7NgwQJ69erF+PHj2+RrOD3JqK2SjTpVIX76Wxh1b29otVp0Osm9FEJ0Yd6hyhF1uXLbbIKiVNSuvg3XFB6FygJI26ocddx6KotAL/1/YOd8cfst2lSIj447fFyZM7oXO44XEp+Qxe7UQhIyy0jILOO9zamMj/QhNsaPcF/5XotmSFyBY0Yp9vjg5WLfLvWUVquUmy4uLri6ujbrMXq9nvDwcACGDBnCjh07eP3113n77bfPeL1ara6/fuDAgSQmJvLiiy+2WSE+Z86c+hq0qqqKe+65BycnZYflU6dNt1SnKsSFEELU0mjBK6zxucnPKSPldUktOUlQcgKKM6CyEHRPNFy7/V2oKgKfaKVI9wwFtYykdhZajZqRYV6MDPMir6yaNYk5xCdkkV1SzW/7s/htfxah3k7E9jEwrrcPLvYyWCXOwGqFTa8SXVKBvfbJDp0hbrFYWlTwtvT6c5k9e3aj27fcckuTa2bNmtWqtm1aiJeVlXH06NH62ykpKezduxdPT0+CgoJs2DMhhOiEdPbg10856lQVK7uBVhY13uUzea1SpCeuUG5r7ZTNh3yiwdAHwiZc1K6L1js1BnH/iWLiE7LYmpzfKAZxdLgSg9i3h8QgilPUVILFjMlipULl2CGiC0GZijx16lSCgoIoLS3liy++YN26dfzxxx+AUvQGBATw4osvAsoawqFDhxIWFkZ1dTW//vorn376KUuXLm2T/nz44Ydt0s6Z2LQQ37lzJxMmNPxnXzf/e/bs2Xz00Uc26pUQQnQh9m4QeEnjc1YrDL8bcpMgJ1Ep1GsqIOuAcpzc07gQP/gjOPkoO4Q6el7U7ovmU6tVDAh0Z0CgO6VVNaw7lEt8QjbH88pZdyiXdYdy8XOzZ3KMgYlRvnhJDKKo3VWz2qKhBh2eHWREPCcnh1mzZpGZmYmbmxv9+/fnjz/+qF98mZaWVp9YAsq+NPfeey8ZGRk4ODgQFRXFZ599xo033mirL6HZOkyOeGtIjrgQQrQBiwWK05SCPCcRnH1h4M3KfSYjfDgVLEr8GM6+ylQW32jwiVQ+1zvZru/inKxWK0dzyohPyGb9oVwqa5RYOrUKhoZ4MjnGwNBgD4lB7K7yjsD3d3CgSMdCx2d46dp+9Onh1uZPI/Xa2ckccSGE6O7UavAIUY7ep+1CV1MBEZOVAr0oVdlcqCwHUjYo94eOhdjaDTOsVqWY9+wF2o4xstbdqVQqIgwuRBhcmHtpKJuP5hF/MJuEzBK2pxSwPaUAd0cdk6INTIoxEODuYOsui4upugQrUGKxBzrG9vbdjRTiQgghzs7BHcY/pnxurIC8w7XTWZKUw/eUKLGSk7DsblBrwSscfJUIRXyiwD248Rx1cdHZ6zRMjDYwMdpAekEFqxKzWZOUQ1FFDd/tyuC7XRn0DXAlNsaPUeFe2Gll8W6XV12KxWqlDOUPsI68WLOrkkJcCCFE8+gdocdA5ahjsTR8Xp6jzEmvKm4o1OvoHGHEPRBzVcPjVCrlEBddoKcjt40O5dYRwWw/XkD8wWz2pBVy4EQJB06U8NZ6DeMjfYntYyDMR2IQu6yqEsy1CzUddBrsJYP+opNCXAghROudOsrdYxDM+glKsyAnQZmmkpsIuYeVKS727g3XntgFa1+onW8eVRujGKmMwIuLRqtRMyrMm1Fh3uSVVbM6MZuVCdlkl1Tz6/5Mft2fSS8fJ2Jj/BgX6YOznZQNXUrQCNKHPcWaTZl4OEnEpS3IT5QQQoi2o1KBq79yhE9UzlnMUHgcnA0N1+UmKdnmp28+5OKvLAQddEvTnHTRrryd7bhxWBDXDwnkrxPFxB/MYuuxfI7llvPW+mTe33SMS8O9ie3jR58erm22s6CwIWdfMtwGkaJ1pK/MD7cJKcSFEEK0L7WmaVHd/0YIGFwboVi7AVFROpRmKsfAmQ3XHlsH6dsb5pt79lI2NBLtQq1WMTDQnYGB7pTUxSAezCI1v4K1h3JZeygX/7oYxGiDLPDr5ArLjYDMD7eVLvE/mcViwXLqPEUhhBAdm1pbOx0lGurWe1aXKotBc5OUxZ11/6+n/onq8G+Q9ItyW6MDrwisPlHKdJaQMaCTtI/24KzXcEU/P6b1NSgxiIk5bDicy8niSj7eepxP/0xlaLAHsTEGhgR7oJHNgjqXtD9xTD2Ku8UNd0f/dqulpEY7u06ZIx4XF0dcXBxGo5Hk5GR2796Nv7+/rbslhBCiHWhz9qPL+Qtt4VG0hUdR15Sfcq+Kgis/xapzBECXtRuVuQaTZzgWBy/bdLiLqzJZ2JFWwobkIo7kVtafd3fQcmkvN8b0csfgIqOrnYHrhkUUpewhTvV3woZO4W8x7fMzk5mZyeDBgwkPD0en0zFv3jzmzZvXLs/V2XTKQrxOXUB8amqqBMQLIUR3YLVCSYYynSXvEKrKQqyXPVV/t+rnByDrL+WGoxf4RNWOnEeBT2+wc7VRx7umjMIKVibksOZQDsWVNfXn+/VwY3KMgZFhnhKD2IGpfriDk8kH+I/uDqZOvZIJkb7t8jwZGRkEBwfLhj5n0CWmpqjV6kZbnQohhOjCPIKVI1LZfKjRZAjvCKgph4IUqMiH1M2oUjcr9zl4wK3LGiITi9KUBaRa2eq9tYK8nJk7xplZo0LYkVJAfEI2u9MKOXCyhAMnS3hnY20MYoyBXhKD2PFUl2KyWKlQOePlbN9utZTUaGfXJQpxIYQQAoDR9ysfaypr55sfatiAyCOkcW75zw9CVZGy+NMnSklr8YlSrlPLKG5L6DRqRoV7Myrcm9zShhjEnNJqfvkrk1/+yiTMx4nYPn6M7S0xiB1GdRlmi5VKlQOesljTJuQnQQghRNejcwD/AcpRx9wwdYKqErBalGjFvCPKkfizcp/WHiIvh0v/X8P1VqtsPtRMPi523HRJEDcMDWRfRhErE7LZeiyf5Nxylq5L5v1NKYwO85IYRFsz12CpqcBssVKucpIccRuRQlwIIUT3oDml0LB3VaaplOXURijWjprnHlI2H1Kf8uvRWAFf3QzevZWUlrqRc0fPi/81dCJqtYpBQR4MCvKgpKqGtUk5xCdkk3ZKDGIPd3smx/gxMcoXD4lBvLiqSzFbrIAKk9ZB3qWwEXnVhRBCdE8qFbgYlKPXOOWcxQLFaaA5pSjMO6xsPpS+TTnqOBuUwjzybxA88uL2vZNxtddx1cAArhzQg8PZZaxMyGLD4TxOFlXx8ZbjfLr1OMNCPInt4ycxiBdLdSkmi4VKlT3uTvbyzoSNSCEuhBBC1FGrlTnipzL0gavfVjYdqptzXpQKZdnK0WNgw7VF6bDnM/CNUjLSPXuBVkZ666hUKiL9XIj0c2Hupb3YdDSP+INZJGWVsi2lgG0pBXg66ZkU7cukGAP+bpIP326cvEke9Dhf/3lMNvOxISnEhRBCiHPR6JTC2jeq4ZyxXBkpz0mCnsMazmfth8O/K0fdYz3DGgrzwEtkSkstB72GyTEGJscYSMuvID4hi7WHcigoN/LNzgy+2ZlB/55KDOKoMG/0WkneaFN6J1KdB/GXzpURMj/cZqQQF0IIIVpK7wQ9BinHqXwiYfAsZeQ8N1FZFJqbpBz8CFP/DUEjlGsLjikRij7R4OzbrReDBnk5cseYXsweFcL2lAJW1sYg/pVRzF8Zxbxtd4xxkT4Sg9jGCipqt7eX+fk2I4W4EEII0Va8wpQDlKSV0sxTFoImKYV6naOrlWksoGSc+0Yr9/vUfnRwv+jdtzWdRs3ocG9Gh3uTU1rFqoQcViVmk3tKDGKErzOTYwyM7e2DkywwbL28o7ilbyTA7ICnY5Cte9Ntyb9gIYQQoj2oVODaQznCJza938FD2YCo4JiyGDR1i3LUuelzcKvdhbA8TxmF13WfOdO+LvbcPDyIm4YFsrcuBjE5nyM5ZRzJKeO9TSmMDvcmNsYgMYitcXwDQ1PeppDhuDuOt3Vvui0pxIUQQghb6HedcpiqlRzzulHznESoKgaXHg3Xbo2DY+uUhaR18Ym+0eARCpqu/atcrVYxOMiDwUEeFFfWsO5QDvEHs0krqGBtUg5rk3Lo4W5PbIwfE6N9cZeFh81TVYLJYqFC44inTE2xma790yuEEEJ0dFo78OurHHVqqpQElzplOcoGRAXHlCPpF+W8Rq8U5Fe81vj6LsrNoSEG8VB2KSsPZrPhSC4ni6r4aMtxPvkzleGhnkyOMTA4SGIQz8mo7KpZoXXEUxZr2kyXKMQtFgsWi8XW3RBCCCHahkavZJrXufK/UJ5buwg0CVVdlKKxHIzlWKH+etWvDwNWrD61I+c+UeDkbYuvol319nWmt68zt48OYdPRPFYmZpOUVcqW5Dy2JOfh5WTHxCgfJscYMLja27q7HU9lMSaLlXKVI2722nato6RGO7tOWYjHxcURFxeH0ais9s3Pz0evl7dVhBBCdHGOvSG4NwRfCVYL6rIs1DVlmHJylPvNRjzTdqKymiC1YfMhi70nJs8IjIZBVPeKtVHn288AbxUDxvhxotiD9clFbEkpJruonC/+LOeLP48T4+fE2F5uDAl0Qafp+u8cNIdDQTZWi5Uyix3GsiJyKtrv3YP8/HwAJkyYgE6nY968ecybN6/dnq8zUVmtVqutO9FaGRkZBAYGkpqaSs+ePW3dHSGEEMK2rBbIT66fb67KTYLC48p5gNBxWCc9U3utFTa+Ap6hyqi5d0TjHUU7MaPJwvbjSgzi3vRirMp7BrjYaRkf6cOkaAOh3k427qVtVXz6dzLTjvKx14M8e8/Mdn2ujIwMgoODSU9Pl3rtNJ1yRPx0arUadTeYGyeEEEKcmxp8I5WDq5RTNZXK5kO5h8CtJ6q635fFGXDol1MeqlF2Aq1bCOo/oCG1pZOx16sZ29uXsb19ySmpYlViQwziir+yWPFXFhG+zsT2UWIQHfVdohxqEUtVKQB6J492r6GkRju7LjEiLn9hCSGEEC1UngdJK5QCPSdRiVA81cCZMPwu5fPqMkjfBr4x4OLXKTcfslis7ElXYhD/PJaP2aKUP3ZaNZdGeDM5xkCMf/eJQdyx/hd+23kITdg4npgxpF2fS+q1s+t+fwIKIYQQQlnAOWSO8rnVqiSz5CZCTpLy0b9/w7U5CbD6WeVze1dl0yHfqIbNhxw9L3r3W0qtVjEk2IMhwR4UV9Sw9lAOKxOUGMTViTmsTswhwN2B2D4GLovq+jGIKY792aF3Y5Kzq6270q1JIS6EEEJ0dyoVuBiUo9f4pvdbrcqUlfyjUFWijI6nNywG5bInIWKy8rmxQvmod2z3breWm6OOGYMCuGpgD5KySlmZkM3GI7mcKKrkw83H+XhrKiNCPYntY2BQoAfqLhiDWLe9vUQX2pYU4kIIIYQ4t6DhymEyKjnmOQkNGxAVpSlzy+sc+QM2vw7uwbWbD0UqI+deYaDpWEWfSqUi2t+VaH9X7hzTiw1Hcok/mM3h7FK2JOezJTkfL2c9k6INXSsGsaIAzxPriDCp8HDqdf7rRbuRQlwIIYQQzaPVK1NSfKMazhnLQevQcLs4QxlBLzyuHId+U85rdOAVroyed8BFoA56DVP6+DGljx+p+eWsTMhmTVIO+WVGvt6Rztc70hkQ6EZsjB8jenmh13biBYgFKYxMext/iy9qxytt3ZtuTQpxIYQQQrSe/rQYwFHzlYWeuUnKItDcQ8oIenWpcs7hlPnkO96HrP0NSS0+UeDsa/PFoMFeTtwxphezRoawLSWf+IPZ7MsoYl96MfvSi3G203JZlC+TYwyEdMYYxOoSZVdNlSOBXXwufEcnhbgQQggh2pajJwSPUg5QRshLM6EgpfHc8ZO7IesAnNzTcM7Bo6EoHzgTNLYrVfRaNWMifBgT4UN2SRWrErNZlZBNXpmR5ftOsnzfSSIMzsTG+DG2t3eniUG0Vpdgslhqt7eXQtyWOse/GCGEEEJ0XioVuPZQjlONeVgZLc9JVEbL85OVGMXULcq5wbMart33NajUypxz796gu7jztQ2u9swcHszfhwWxJ72Q+IPZbEsp4Eh2GUeyj/LexmOMifAhto+BKD+XDh2DWF1ehNUKFSpHPGSxpk1JIS6EEEII2/AMVY6oacptUzXkHVGKcou5YYqK1Qp/fQUVBcptlbphR1CfKDD0URaDXgRKDKInQ4I9Kaow1scgphdUKiPmidn09FBiECdEdswYxMrSYgBMOmfstBob96Z7k0JcCCGEEB2D1g78+irHqawW6HNNw7zzinxl9Dw/GZJ+Ua6/Kq7h+uObwT1IWRTajiPT7o56rh7UkxkDA0jKKiX+oBKDmFFYyQebjvPxllSGd8AYxOpyZfMmlb1kiNtalyjELRYLFovF1t0QQgghRLtQKfPF65TnKotAcxNR5SZhNfSFujqgpgJV/BPKKLqdC3j3xuoT1bAJkaNXu/Qw0uBMpMGZuZcGs/FIHisTcjicU8rm5Dw2J+fh7WzHpChfJkb72jwG0ViujIhr7F0uSv0kNdrZdcot7uPi4oiLi8NoNJKcnMzu3bvx9/e3dbeEEEIIYWPqsiycd7yOtigFlcXY5P7KsL9RMfAO5YbVgqqmAqveuV36kl5UxYbkYrakFFNuNAPKAH2MwYmxYe4M7umMTnPxYxD/3LGN3QmHcA/qw80T2nd7e4DMzEwGDx5MeHg4Op2OefPmMW/evHZ/3s6gUxbidTIyMggMDCQ1NZWePTteJqkQQgghbMRcA4UptdNZklDlJkFRKtaR90Gfq5VrCo6h+n4uuAWCTxRW3yjwjgTvCNC03dxuo8mixCAm5LAvo6j+vIudjglRPkyO9iXY6+LFIH6wOYUf957kqgE9mHtpaLs/X0ZGBsHBwaSnp0u9dpouMTVFrVajVnfiYH0hhBBCtC21XcPmQ31qzxkrUAHU1QxFx5WPxelQnI7q6Mrax2rAMwyG3g7BIy+4K/Z6NeMiDYyLNJBdUsXKBGVRZ36ZkZ/3ZfLzvkx6G1yI7WNgbIQPDvr2XUBZVGFChQovZ7uLUj9JjXZ2XaIQF0IIIYQ4r1MzzAHCJ0HA0Pr55uQkKR8riyDvsJLOUiftT9j7uTLX3CcSfGPAxa/Fi0ENrvbcMiKYmy9piEH8M6WAw9mlHM4u5b2Nx7g0vH1jEL2zNhBTY8HTPqTN2xYtI4W4EEIIIbovB3cIGq4coCzyLMtWprQYYhquy9oPmX8pRx17t9pdQaMgajo4+zT7aU+PQVyTlEP8wWxOFDXEIAZ6OhAb48eESF/cHNso79tkZMLJdxhtslBlN61t2hStJoW4EEIIIUQdlUoZ6Xbxa3w+6gplLnndyHn+UagqhvRtyhE+ueHa1C1QmKrsEOrdu+lI/GncHfVcM7gnVw8KIDGzlPiELDYdySO9oJL3N6Xw0ZbjDO/lSWyMH4MC3S8sBtFYhsliBVS4ubm3vh3RJqQQF0IIIYQ4H1d/5Yi8XLltMkJBspJrXpCsZJbXORIPyWuVz1UqcA9WinKfSGVqi3fvhnnqp1CpVMT0cCWmhyt3je3FhsO5xB/M5khOGVuO5rPlaD7eznomx/gxKdoX31bEIFaXF2KxWKlQOeLnbNeaV0K0ISnEhRBCCCFaSqtXimvf6Kb3BQxRdgbNTYKyHCg8rhyHfgO1Fm77DdS1qSzZCaB3UkbbTynOHfVaLu/rz+V9/UnJK2dlQhZrk3LJKzPy5fY0vtqRxsBAd2Jj/Lgk1BO9tnkLIstKigCoUjvhbCdloK3Jd0AIIYQQoi1FT1cOgIoCZdQ8N0k5rFaliK+z+TVlsajeqXbEPKp23nkMOHmDSkWotxN3jQ1jzqhQ/jyWT3xCFvvSi9mTVsSetCJc7LVcFuVLbIwfQV7nngZTWpQPgFnv1C4LQUXLSCEuhBBCCNFeHD0hZLRynM5qBZ0jaO3AWA4nditHHUMfmPG/+pt6azVje/swtrcPWcVVrEzMZnVtDOJPe0/y096TRPq5EBtjYMxZYhArS4vQAha9bG/fEUghLoQQQghhCyoVTH9NmcZSULv5UN1i0IJj4OzbcK3VCp9fD3au4BuFn080t4ZEMXNwP3afrCQ+IZttKQUcyirlUFYp721M4dIIb2L7GIg0NMQgVpYX4QKo7Fxs8iWLxjpEwnpcXBwhISHY29szfPhwtm/fbusuCSGEEEJcHGoNeIdD9BUw9hG47n1lHvnI+Q3XlGZBdSmUnICjq2Hrm/DTfag/+htDdz7C4z0P8PFtw5gzKoQe7vZU1phZmZDNI9/+xX1f7OGnvScorqzhuEMfvnCcSab/JNt9vc3U0vrw22+/JSoqCnt7e/r168evv/56kXraejYvxL/++msWLFjA008/ze7duxkwYABTpkwhJyfH1l0TQgghhLANnT04eTXcdvWH2T/DtFdg2B0Qcqky7cVqqY1SLMLdUc+1Q3ry1nXhfOL1MQ+7xHOJeTeVucd5b8MxZn+wnWUpWnbqL8HsP9BmX1pztLQ+3LJlC3//+9+ZO3cue/bsYcaMGcyYMYMDBw5c5J63jMpqtVpt2YHhw4czbNgw3nzzTQAsFguBgYHMnz+fxx577JyPzcjIIDAwkPT0dHr27HnOa4UQQgghuhSrFcrzlOksbj3Bs5dyPm0b/PZPAMxWK2VVJnKMeg6ZA0jXBvKnfiS3TB7B5BjDRelma+q1ltaHN954I+Xl5axYsaL+3IgRIxg4cCBvvfVW23wh7cCmc8SNRiO7du1i4cKF9efUajWTJk1i69atTa6vrq6murq6/nZxcTEA6enpmEym9u+wEEIIIURHowqCEqDkuHK7yg5t1Fw0hcnKUZmKl6aSIRzGYC2hRteDAFMQx49XXpTuZWZmAkrd5urasEjUzs4OO7umWeYtrQ8Btm7dyoIFCxqdmzJlCj/++GMbfAXtx6aFeF5eHmazGYOh8V9kBoOBpKSkJte/+OKLLF68uMn5UaNGtVsfhRBCCCG6lhXnv6Qd9O3bt9Htp59+mmeeeabJdS2tDwGysrLOeH1WVtaFdbqddarUlIULFzb6a6egoIDQ0FAOHDiAm5tbmz7X+PHjWbduXZu22Z7ttlfbpaWlxMTEkJCQgItL266w7myvsby+7d+2vMadr932fH2hc70W7dWu/Btu/3blNW7fdouLi+nbty8pKSl4enrWnz/TaHh3Y9NC3NvbG41GQ3Z2dqPz2dnZ+Pn5Nbn+bG9hBAYGNnqroy3o9fp2mXfeXu22V9slJSUABAQEdPvXWF7f9m9bXuPO1257vr7QuV6L9mpX/g23f7vyGrdvu3WvqaenZ7Ne35bWhwB+fn4tur6jsGlqil6vZ8iQIaxevbr+nMViYfXq1YwcOdKGPYN58+Z1qnbbu+320NleY3l9279teY07Z7vtqbO9Fp3tNe5sr0Nne32h870WHeE1bk19OHLkyEbXA6xcudLm9eT52Dw15euvv2b27Nm8/fbbXHLJJbz22mt88803JCUlNZnrc7qSkhLc3NyaTP4XbUde4/Ylr2/7k9e4fcnr2/7kNW5/8hq3r9a8vuerD2fNmkVAQAAvvvgioMQXjhs3jpdeeolp06bx1Vdf8a9//Yvdu3c3mZvekdh8jviNN95Ibm4uixYtIisri4EDB/L777+ftwgHZarK008/LXOM2pG8xu1LXt/2J69x+5LXt/3Ja9z+5DVuX615fc9XH6alpaFWN0zsGDVqFF988QVPPvkkjz/+OBEREfz4448dugiHDjAiLoQQQgghRHdk8501hRBCCCGE6I6kEBdCCCGEEMIGpBAXQgghhBDCBqQQF0IIIYQQwgY6dSEeFxdHSEgI9vb2DB8+nO3bt9u6S53Ciy++yLBhw3BxccHX15cZM2Zw6ND/b+/Oo6K8zj+Af0cY9lUGELRsGpQaBKWKoAIislRxjRoXQgw11aARamzlVMXltJTYE9OSqA0QBKNBUFyKQiVskYgKOCOiHoIEpFYUlwiy6LA8vz/88daRxZgKw/J8zplzmHvvPPfe19d3nnnnvu+UCvWVlZUQiUSdPpKTkwEA+/fv77JNTU2NsqbWJ2zbtq3DNhkzZoxQ7+Hh0aF+9erVncZ68OABRowYAZFIhEePHvXSDPq+1tZWbNmyBdbW1tDU1MTIkSOxc+dOPH/t+bZt2zBmzBhoa2vD0NAQXl5euHDhgkKcP/3pT3B1dYWWlhYMDAx6eRZ9x7fffgt/f3+Ym5tDJBLh+PHjCvUpKSnw9vaGkZERRCIRZDJZhxhPnjxBcHAwjIyMoKOjg4ULF3b4cY2CggLMmDEDBgYGMDQ0hI+PDy5fvtyDM+s7XraNf8r++v3332Pu3LmQSCTQ09PD1KlTkZ2drdCms2NyYmJiT09P6V62fQHg+vXrmDNnDvT19aGtrY2JEyeiqqpKoU1+fj48PT2hra0NPT09uLm5oampSaifM2cOLCwsoKGhATMzMwQEBOD27ds9Pb0+4WXb+O7du3j33Xdhbm4OLS0t+Pr6oqysrNNYRAQ/P79O41RVVWHWrFnQ0tKCiYkJNm7ciJaWlh6alfL120T88OHD+N3vfofw8HBcunQJDg4O8PHxGfRJ4E+Rm5uL4OBgnD9/HhkZGWhuboa3tzcaGhoAPPul0urqaoXH9u3boaOjAz8/PwDPbiv0YhsfHx+4u7vDxMREmdPrE8aOHauwbfLy8hTqV61apVD/8ccfdxonKCgI48aN640h9yuRkZHYu3cvPvvsM1y/fh2RkZH4+OOPERUVJbSxtbXFZ599hitXriAvLw9WVlbw9vbGvXv3hDZyuRyLFi3CmjVrlDGNPqOhoQEODg74/PPPu6yfOnUqIiMju4wRGhqKf/7zn0hOTkZubi5u376NBQsWCPX19fXw9fWFhYUFLly4gLy8POjq6sLHxwfNzc2vfU59zcu28U/ZX2fPno2WlhZkZWWhqKgIDg4OmD17Nu7cuaMQKy4uTuH4Mm/evJ6cWp/wsu1bXl6OqVOnYsyYMcjJyUFxcTG2bNkCDQ0NoU1+fj58fX3h7e2NixcvoqCgAGvXrlW4Rd706dORlJSE0tJSHD16FOXl5Xjrrbd6fH59QXfbmIgwb948/PDDDzhx4gSkUiksLS3h5eUl5BbP+/TTTyESiTqUt7a2YtasWZDL5Th37hzi4+Oxf/9+bN26tUfm1CdQPzVp0iQKDg4Wnre2tpK5uTlFREQocVT9U01NDQGg3NzcLts4OjrSe++9120MsVhMCQkJPTHEfiU8PJwcHBy6rHd3d6f169e/NM6ePXvI3d2dMjMzCQD9+OOPr22M/d2sWbM67I8LFiyg5cuXd/ma2tpaAkDffPNNh7q4uDjS19d/3cPslwDQsWPHOq2rqKggACSVShXKHz16RGKxmJKTk4Wy69evEwDKz88nIqKCggICQFVVVUKb4uJiAkBlZWWvfR59WXfbuN2L++u9e/cIAH377bdCm7q6OgJAGRkZrxR7oOtsGyxZsoRWrFjR7eucnZ1p8+bNr9TXiRMnSCQSkVwuf9Vh9msvbuPS0lICQCUlJUJZa2srGRsbU3R0tMJrpVIpDR8+nKqrqzvEOX36NA0ZMoTu3LkjlO3du5f09PTo6dOnPTYfZeqXZ8TlcjmKiorg5eUllA0ZMgReXl7Iz89X4sj6p9raWgDA0KFDO60vKiqCTCZDUFBQlzESEhKgpaU1aM4MvExZWRnMzc1hY2OD5cuXd/j68+DBg5BIJHjzzTcRFhaGxsZGhfpr165hx44dSEhIUDgbw55xdXVFZmYmvv/+ewDA5cuXkZeXJ3xj8yK5XI4vvvgC+vr6cHBw6M2hDgpFRUVobm5WOCaPGTMGFhYWwjF59OjRMDIyQmxsLORyOZqamhAbGws7OztYWVkpaeR9U2f7q5GREUaPHo2EhAQ0NDSgpaUF//jHP2BiYgInJyeF1wcHB0MikWDSpEn48ssvFZZsDUZtbW04deoUbG1t4ePjAxMTEzg7OyssiaipqcGFCxdgYmICV1dXmJqawt3dvcO3mc97+PAhDh48CFdXV4jF4l6YSd/19OlTAFD4hmHIkCFQV1dX2IaNjY1YtmwZPv/8cwwbNqxDnPz8fNjb2yv8qKOPjw/q6upw9erVHpyB8vTLd/j79++jtbW1w69vmpqadviKjnWvra0NISEhmDJlSpe/PtX+Zunq6tplnNjYWCxbtgyampo9NdR+w9nZGfv370d6ejr27t2LiooKTJs2DY8fPwYALFu2DF999RWys7MRFhaGAwcOYMWKFcLrnz59iqVLl2LXrl2wsLBQ1jT6tE2bNuHtt9/GmDFjIBaLMX78eISEhGD58uUK7VJTU6GjowMNDQ3s3r0bGRkZkEgkShr1wHXnzh2oqal1WGf//DFZV1cXOTk5+Oqrr6CpqQkdHR2kp6cjLS0NqqpK/5HnPqG7/VUkEuGbb76BVCqFrq4uNDQ08MknnyA9PR2GhoZCjB07diApKQkZGRlYuHAhPvjgA4UlW4NRTU0N6uvr8Ze//AW+vr44c+YM5s+fjwULFiA3NxcA8MMPPwB4tlZ/1apVSE9Px4QJEzBjxowO65z/8Ic/QFtbG0ZGRqiqqsKJEyd6fU59TfsH77CwMPz444+Qy+WIjIzErVu3UF1dLbQLDQ2Fq6sr5s6d22mcO3fudJrbtdcNRHz0G+SCg4NRUlLS5af+pqYmHDp0CFu2bOkyRn5+Pq5fv44DBw701DD7lefPyo4bNw7Ozs6wtLREUlISgoKC8P777wv19vb2MDMzw4wZM1BeXo6RI0ciLCwMdnZ2Csk5U5SUlISDBw/i0KFDGDt2LGQyGUJCQmBubo7AwECh3fTp0yGTyXD//n1ER0dj8eLFwlkv1ruampoQFBSEKVOm4Ouvv0Zrayv++te/YtasWSgoKOAP8eh+fyUiBAcHw8TEBGfPnoWmpiZiYmLg7++PgoICmJmZAYDCsXr8+PFoaGjArl278OGHHyprWkrX1tYGAJg7dy5CQ0MBAI6Ojjh37hz27dsHd3d3oc1vf/tbrFy5EsCz7ZeZmYkvv/wSERERQryNGzciKCgIN2/exPbt2/HOO+8gNTW10zXPg4VYLEZKSgqCgoIwdOhQqKiowMvLC35+fsI3MidPnkRWVhakUqmSR9u39Msz4hKJBCoqKh2uyL97926nX3Wwzq1duxapqanIzs7GiBEjOm1z5MgRNDY24p133ukyTkxMDBwdHTt8PcqeMTAwgK2tLW7cuNFpvbOzMwAI9VlZWUhOToaqqipUVVUxY8YMAM/2+/Dw8N4ZdB+3ceNG4ay4vb09AgICEBoaqvBmCQDa2toYNWoUJk+ejNjYWKiqqiI2NlZJox64hg0bBrlc3uHOPs8fkw8dOoTKykrExcVh4sSJmDx5Mg4dOoSKigo+o/j/uttfs7KykJqaisTEREyZMgUTJkzAnj17oKmpifj4+C5jOjs749atW8LSgcFIIpFAVVUVv/zlLxXK7ezshGWD7R9kumvzfDxbW1vMnDkTiYmJOH36NM6fP9+DM+gfnJycIJPJ8OjRI1RXVyM9PR0PHjyAjY0NgGf7cHl5OQwMDIT3NwBYuHAhPDw8ADw7lnSW27XXDUT9MhFXU1ODk5MTMjMzhbK2tjZkZmbCxcVFiSPrH4gIa9euxbFjx5CVlQVra+su28bGxmLOnDkwNjbutL6+vl4408s6V19fj/LycuFA/6L2W8G11x89ehSXL1+GTCaDTCZDTEwMAODs2bMIDg7ulTH3dY2NjR3WzquoqAhntbrS1tY2qBOSnuLk5ASxWKxwTC4tLUVVVZVwTG7/N3v+rGH785f9uw1Wz++v7deRvLjfDxkypNvtJ5PJYGhoCHV19Z4baB+npqaGiRMnKtymF3h2O0hLS0sAgJWVFczNzbtt05n2bc/Hlf/S19eHsbExysrKUFhYKCxD2bRpE4qLi4X3tvb3vt27dyMuLg4A4OLigitXrijcAS8jIwN6enodPiQNGMq9VvTnS0xMJHV1ddq/fz9du3aN3n//fTIwMFC40pZ1bs2aNaSvr085OTlUXV0tPBobGxXalZWVkUgkorS0tC5jxcTEkIaGBt/R4zkbNmygnJwcqqiooO+++468vLxIIpFQTU0N3bhxg3bs2EGFhYVUUVFBJ06cIBsbG3Jzc+syXnZ2Nt815QWBgYE0fPhwSk1NpYqKCkpJSSGJREK///3viYiovr6ewsLCKD8/nyorK6mwsJBWrlxJ6urqClf137x5k6RSKW3fvp10dHRIKpWSVCqlx48fK2tqSvH48WNh7gDok08+IalUSjdv3iQiogcPHpBUKqVTp04RAEpMTCSpVErV1dVCjNWrV5OFhQVlZWVRYWEhubi4kIuLi1B//fp1UldXpzVr1tC1a9eopKSEVqxYQfr6+nT79u1en3Nv624b/5T99d69e2RkZEQLFiwgmUxGpaWl9NFHH5FYLCaZTEZERCdPnqTo6Gi6cuUKlZWV0Z49e0hLS4u2bt2qzKn3ipftwykpKSQWi+mLL76gsrIyioqKIhUVFTp79qwQY/fu3aSnp0fJyclUVlZGmzdvJg0NDbpx4wYREZ0/f56ioqJIKpVSZWUlZWZmkqurK40cOZKePHmilHn3ppdt46SkJMrOzqby8nI6fvw4WVpa0oIFC7qNiRfumtLS0kJvvvkmeXt7k0wmo/T0dDI2NqawsLCenJpS9dtEnIgoKiqKLCwsSE1NjSZNmkTnz59X9pD6BQCdPuLi4hTahYWF0S9+8QtqbW3tMpaLiwstW7ash0fcvyxZsoTMzMxITU2Nhg8fTkuWLBEO5FVVVeTm5kZDhw4ldXV1GjVqFG3cuJFqa2u7jMeJeEd1dXW0fv16srCwIA0NDbKxsaE//vGPwu2tmpqaaP78+WRubk5qampkZmZGc+bMoYsXLyrECQwM7PT/QnZ2thJmpTzt+9iLj8DAQCJ6dnvHzurDw8OFGE1NTfTBBx+QoaEhaWlp0fz58xUSdSKiM2fO0JQpU0hfX58MDQ3J09NTuL3hQNfdNv6p+2tBQQF5e3vT0KFDSVdXlyZPnkynT58W6tPS0sjR0ZF0dHRIW1ubHBwcaN++fd0ewweKl+3DRESxsbE0atQo0tDQIAcHBzp+/HiHOBERETRixAjS0tIiFxcXhUS9uLiYpk+fLhy/raysaPXq1XTr1q3emKLSvWwb/+1vf6MRI0aQWCwmCwsL2rx580tvOfhiIk5EVFlZSX5+fqSpqUkSiYQ2bNhAzc3NPTQr5RMRDfL7GjHGGGOMMaYE/XKNOGOMMcYYY/0dJ+KMMcYYY4wpASfijDHGGGOMKQEn4owxxhhjjCkBJ+KMMcYYY4wpASfijDHGGGOMKQEn4owxxhhjjCkBJ+KMMcYYY4wpASfijLFB591338W8efN6vB8PDw+EhIQIz62srPDpp5/2eL8AEBAQgD//+c+90temTZuwbt26XumLMcYGEv5lTcbYgCISibqtDw8PR2hoKIgIBgYGPToWDw8PODo6Csn3vXv3oK2tDS0trR7t9/Lly/D09MTNmzeho6PTo30BwP3792FjYwOZTAYbG5se748xxgYKVWUPgDHGXqfq6mrh78OHD2Pr1q0oLS0VynR0dHolOe2MsbFxr/QTFRWFRYsW9do8JRIJfHx8sHfvXuzatatX+mSMsYGAl6YwxgaUYcOGCQ99fX2IRCKFMh0dnQ5LUzw8PLBu3TqEhITA0NAQpqamiI6ORkNDA1auXAldXV2MGjUKaWlpCn2VlJTAz88POjo6MDU1RUBAAO7fv9/l2F5cmiISiRATE4P58+dDS0sLb7zxBk6ePPk/9dHa2oojR47A399foXzPnj144403oKGhAVNTU7z11ltCXVtbGyIiImBtbQ1NTU04ODjgyJEjCq+/evUqZs+eDT09Pejq6mLatGkoLy8X6v39/ZGYmNjluBhjjHXEiThjjAGIj4+HRCLBxYsXsW7dOqxZswaLFi2Cq6srLl26BG9vbwQEBKCxsREA8OjRI3h6emL8+PEoLCxEeno67t69i8WLF79Sv9u3b8fixYtRXFyMX//611i+fDkePnz4s/soLi5GbW0tfvWrXwllhYWF+PDDD7Fjxw6UlpYiPT0dbm5uQn1ERAQSEhKwb98+XL16FaGhoVixYgVyc3MBAP/5z3/g5uYGdXV1ZGVloaioCO+99x5aWlqEGJMmTcKtW7dQWVn5SvNnjLFBjRhjbICKi4sjfX39DuWBgYE0d+5c4bm7uztNnTpVeN7S0kLa2toUEBAglFVXVxMAys/PJyKinTt3kre3t0Lcf//73wSASktLhbjr168X6i0tLWn37t3CcwC0efNm4Xl9fT0BoLS0tJ/cx4uOHTtGKioq1NbWJpQdPXqU9PT0qK6urkP7J0+ekJaWFp07d06hPCgoiJYuXUpERGFhYWRtbU1yubzTPomIamtrCQDl5OR02YYxxpgiXiPOGGMAxo0bJ/ytoqICIyMj2NvbC2WmpqYAgJqaGgDPLojMzs7udB12eXk5bG1tX7lfbW1t6Onp/U99NDU1QV1dXeGi1ZkzZ8LS0hI2Njbw9fWFr6+vsBzmxo0baGxsxMyZMxXiyOVyjB8/HgAgk8kwbdo0iMXiLuehqakJAMI3Bowxxl6OE3HGGAM6JJkikUihrD2xbWtrAwDU19fD398fkZGRHWKZmZn9T/3+L31IJBI0NjZCLpdDTU0NAKCrq4tLly4hJycHZ86cwdatW7Ft2zYUFBSgvr4eAHDq1CkMHz5cIZa6ujqA/ybZ3WlfTtNbF6QyxthAwIk4Y4z9DBMmTMDRo0dhZWUFVdWeOZT+nD4cHR0BANeuXRP+BgBVVVV4eXnBy8sL4eHhMDAwQFZWFmbOnAl1dXVUVVXB3d2905jjxo1DfHw8mpubuzwrXlJSArFYjLFjx77SHBljbDDjizUZY+xnCA4OxsOHD7F06VIUFBSgvLwc//rXv7By5Uq0trYqrQ9jY2NMmDABeXl5Qllqair+/ve/QyaT4ebNm0hISEBbWxtGjx4NXV1dfPTRRwgNDUV8fDzKy8tx6dIlREVFIT4+HgCwdu1a1NXV4e2330ZhYSHKyspw4MABhdtCnj17FtOmTftJZ88ZY4w9w4k4Y4z9DObm5vjuu+/Q2toKb29v2NvbIyQkBAYGBhgy5PUcWn9uH7/5zW9w8OBB4bmBgQFSUlLg6ekJOzs77Nu3D19//bVw9nrnzp3YsmULIiIiYGdnB19fX5w6dQrW1tYAACMjI2RlZaG+vh7u7u5wcnJCdHS0wtnxxMRErFq16rXMmzHGBgv+ZU3GGBtgmpqaMHr0aBw+fBguLi493l9aWho2bNiA4uLiHlumwxhjAxGfEWeMsQFGU1MTCQkJ3f7wz+vU0NCAuLg4TsIZY+wV8RlxxhhjjDHGlIDPiDPGGGOMMaYEnIgzxhhjjDGmBJyIM8YYY4wxpgSciDPGGGOMMaYEnIgzxhhjjDGmBJyIM8YYY4wxpgSciDPGGGOMMaYEnIgzxhhjjDGmBJyIM8YYY4wxpgT/Bzh4ztEHz4fkAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAuIAAAErCAYAAACb7ObeAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8g+/7EAAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOydd3gV1daH3zk1vfdGCC0JoVdBelcpdsWrol4roHxYsQGKonLFcuWq9167V1BUqqj0Kl1aIKFDeu/t1Pn+mJwTYhJIQjr7fZ48OWfOnr3XzJw585s1a68lybIsIxAIBAKBQCAQCJoUVXMbIBAIBAKBQCAQXIsIIS4QCAQCgUAgEDQDQogLBAKBQCAQCATNgBDiAoFAIBAIBAJBMyCEuEAgEAgEAoFA0AwIIS4QCAQCgUAgEDQDQogLBAKBQCAQCATNgBDiAoFAIBAIBAJBMyCEuEAgEAgEAoFA0AwIIS4QCAQCgUAgEDQDzSrEt2/fzsSJEwkKCkKSJFauXNmc5ggEAoFAIBAImpmFCxfSr18/XF1d8fPzY8qUKZw8ebJKu927dzNy5EicnZ1xc3Nj6NChlJaW1mqMt956C0mSmDVrVgNbXzeaVYgXFxfTo0cPlixZ0pxmCAQCgUAgEAhaCNu2bWP69Ons2bOHDRs2YDKZGDt2LMXFxfY2u3fvZvz48YwdO5Z9+/axf/9+ZsyYgUp1ZWm7f/9+Pv30U7p3796Ym1ErJFmW5eY2AkCSJFasWMGUKVOa2xSBQCAQCAQCQQshMzMTPz8/tm3bxtChQwEYOHAgY8aM4fXXX69TX0VFRfTu3Zt//etfLFiwgJ49e/L+++83gtW1Q9NsI9cDg8GAwWCwvzebzcTFxREaGlqrOyCBQCAQCAQCQdNitVpJSEggOjoajaZCeur1evR6/RXXz8/PB8DLywuAjIwM9u7dyz333MOgQYM4e/YskZGRvPHGG1x//fWX7Wv69OnceOONjB49mgULFlzFVjUMrUqIL1y4kPnz5ze3GQKBQCAQCASCq2Tu3LnMmzfvsm2sViuzZs1i8ODBxMTEAHDu3DkA5s2bxz/+8Q969uzJ119/zahRo4iNjaVTp07V9rVs2TL+/PNP9u/f36DbcTW0KiE+Z84cZs+ebX+fmJhITEwMf/zxB4GBgc1omUAgEAgE5Vgt6I8vA9mKNvUgqqJUZK0zJQP+D4t/t6vqWpZlTqQWsupICmczlXhZjUqiTztP9p7PQa9R8a+pvRpiKwSCBiM1NZVBgwYRGxtLaGiofXltvOHTp08nNjaWnTt32pdZrVYAHn30UR544AEAevXqxaZNm/j8889ZuHBhlX4SExN56qmn2LBhAw4ODle7SQ1GqxLif32E4e7uDkBoaCghISHNZZZAIBAIBJWJeEn5X5oH61+CtFi8j74HEz+AgLqLcVmWOZKUz9K9CZxILQBccPdx5YZugdzaOwQZuP/zfUgStGvXDkmSGnJrBIKrwhaO4u7ujpubW63XmzFjBmvXrmX79u2VdJ7N+RodHV2pfVRUFAkJCdX2dfDgQTIyMujdu7d9mcViYfv27Xz00UcYDAbUanWtbWsoWpUQFwgEAoGgRWI2QuyP0O12UGsrljt6wI3vwdaFYCwGv+gau6iJo0l5fLc3geMpBQBo1RLjYwK4rU8oXs46AEqNFgBkGYwWK3pN0wsKgaChkGWZmTNnsmLFCrZu3Ur79u0rfR4eHk5QUFCVlIanTp1iwoQJ1fY5atQojh07VmnZAw88QGRkJM8//3yziHBoZiFeVFTEmTNn7O/Pnz/P4cOH8fLyIiwsrBktEwgEAoGglsgy7HwPTq6DtFgY/2blzzU6GPkKWE2gKr/YW8wgW5XPauBYUj7f7btIbHKFAB/XNYDb+oTg7VL5kb5eU5GwoMwkhLigdTN9+nS+++47Vq1ahaurK2lpaYDiUXd0dESSJJ599lnmzp1Ljx496NmzJ1999RXx8fH8+OOP9n5GjRrFzTffzIwZM3B1dbXHmNtwdnbG29u7yvKmpFmF+IEDBxgxYoT9vS3++/777+fLL79sJqsEAoFAIKgDJ1YpIlxSQcwt1bdRqUBVLp5lGXa9D7kXYOwCxWt+CbHJ+fxvbwKxyUqmCM0lAtzHpfqYWpVKQquWMFlkDCYLOGqrbScQtAY+/vhjAIYPH15p+RdffMG0adMAmDVrFmVlZfzf//0fOTk59OjRgw0bNtChQwd7+7Nnz5KVldVUZteLZhXiw4cPp7HTmMuyjNlsxmKxNOo4AkFLQ61Wo9FoRKyoQNCYpB6FPz5UXvd/BEL6XnmdonQ4uwWMRbBqOox/CzxCiU3OZ+m+BI4mVQjwsdEB3N63ZgF+KQ5aNSaLmTKT9Wq2SCBodmqrDV944QVeeOGFGj+/cOHCZdffunVrHaxqHNp0jLjRaCQ1NZWSkpLmNkUgaBacnJwIDAxEp6v58bdAIKgnRZmw4VWwWqDDSOhxV+3Wcw2AyR/Bby9AfhLFPzzKFy5/5/dsPwDUKokx0f7c0TcUX9crC3AbDlo1hWVmDGbheBIIWgttVohbrVbOnz+PWq0mKCgInU4nPIOCawZZljEajWRmZnL+/Hk6deokil4JBA2J2Qgb50JpLnhFwLDnoC7XGK/2nLzuHUpXP4dzwRlGZ7xNlvPf8O05gdv7hODnVvf0ag5a5RwXHnGBoPXQZoW40WjEarUSGhqKk5NTc5sjEDQ5jo6OaLVaLl68iNFobFF5UwWCVk9eAuReBL2rEuetdaz1qnGpBSzdl8ChhDy00qPcq/uWweoTvOSwHK2XH7h1rJdJDuUTNMuER1wgaDW0WSFuQ3gBBdcy4vsvEDQSPh3h5k+gJBvcg2u1ysm0Qr7be5E/E/IAZYLliMhQBvX9CL8TX8CxH8GzXb1N0ts94kKICwSthTYvxAUCgUAgaDCsViUDCoBHqPJ3BU6lF/Ld3gQOXswFQCXBqCh/7uwXir8tBOW66dDlBvBqf5meLo8tZaEITREIWg9CiAsEAoFAUBuKs2DdM3DdTAjpc8Xmp9ML+d9fBPjISEWAB7hXEyp2qQjPT4Ztb8PwOeAWWCvzHLSKEBeTNQWC1kObEOJWqxWr1VplmSzL9j9B26d9+/Y89dRTzJo1q7lNaTHYvv/VnSMCgaAOWIxIG16FnPOwZwnyzf9W8oZXw5mMIpbuT2T/hRwAVJLEiC6+3N4nhCAPJZb8SuejtH0RpB6BlY8jj3sTfCOvaKJeIyEjU2o0i/Nd0KIQ38eaaZVCfMmSJSxZsgSj0QhAdnZ2lfRsJpMJq9WK2WzGbDY3h5n15qGHHuKbb74BQKvVEhYWxj333MMLL7yARqMcMovFwkcffcSXX37JmTNncHR0ZMCAAcyZM4dBgwbZ+7JYLLz77rt8/fXXJCQk4OjoSMeOHXnooYd48MEH7ePl5eXx008/YbFYGDFiBP7+/ixfvtzeT35+Pr169eKee+7h9ddfr9bu0aNH06NHD959991Ky8eMGcPdd99tH+/rr7/m448/5sSJE6jVanr16sXs2bO58cYbq+1327ZtjBkz5rL7bMOGDfzxxx84Ozu3uuPdmJjNygU5OzsbrVYU+BAI6ovzn5/gkHwYq9aZ/J4zsWZWLRJyIaeMlccyOZxcBCge8OvC3ZkU44O/qw6MhWRkFNZqPFXMw7jmv4km/zzyz09Q1P//MAYPuOw6ZkMpZpOZjOx8MjJEylJByyE7OxuAESNGoNVqmT59OtOnT29mq1oGrVKI2w5gUlISoaGheHt74+fnV6lNWVkZhYWFaDQau3htLahUKsaPH8/nn3+OwWBg3bp1zJgxA71ez5w5c5BlmalTp7Jx40beeecdRo0aRUFBAUuWLGH06NH88MMPTJkyBYDXXnuNf//73/zzn/+kb9++FBQUcODAAXJzc+37RaVSoVKp7Pvqyy+/pFevXnz//ffcc889gFL11MvLi/nz59e4PyVJQpKkSp/n5OTwxx9/sGzZMjQaDc888wxLlizh9ddfZ8qUKZhMJr799ltuvfVW3n//fWbMmFGl3yFDhpCSkmJ/P2vWLAoKCvj888/ty7y8vESu7GrQaDSoVCq8vb1F1hSBoL7ErUFK3AJaHfK41/AJ7VHp43OZigd873nFA67TaRnWyYc7+oUS7FH7bCqV8YOgT5E2zYfEfXgefA9Z8zjE3FZjmkRvjxI02kK0jk5VrokCQXNic5xu2bKFkJCQZramZdG6FGoN2ITkX5fZhKEtf7gsyxjMTf94RK9R1TmHuV6vJzBQiQt84oknWLlyJWvWrOHFF1/khx9+4Mcff2T16tVMnDjRvs5//vMfcnJyePjhhxk7dizOzs6sWbOGJ554gjvuuMPermfPntWOabOxS5cuvPXWWzz55JOMGjWKffv2sWzZMvbv349ef/niEpfub4B169bRu3dvAgIC2LNnD4sXL+bDDz9k5syZ9jZvvvkmBoOBp59+milTphAaWnny06X7ApS0fAaDodIygPDwcGbNmmUPTZEkiU8++YQ1a9awefNm2rVrx+eff46vry9///vf2b9/Pz169OCbb76pVBJ31apVzJ8/nxMnThAUFMT999/PSy+91Opu6KDieFR3jggEglqQFltRObPvQ0jtrrN/dC6ziKX7EthzThHgakliaGdf7uwXSohnA6TN1bsoVTd3fQAnViHt+RcUpsKgmaBSV2nupNMgoZS5F+e7oCUhvo810/qUxVVgMFu5/ZPdTT7u8seus0+iqS+Ojo72RzvfffcdnTt3riTCbTz99NP8/PPPbNiwgSlTphAQEMDmzZt54okn8PX1rfV4M2fOZMWKFdx7770cO3aMV199lR49elx5xb+wevVqJk+eDMDSpUtxcXHh0UcfrdbuxYsX89NPPzVojPfrr7/O4sWLWbx4Mc8//zxTp04lIiKCOXPmEBYWxoMPPsiMGTP49ddfAdixYwf33XcfH374IUOGDOHs2bM88sgjAMydO7fB7BIIBK2AkpzyyplmaD8Uev0NgPNZxSzbl8AfZ5XfZEmCoZ0UAR7q1cB1K1RquP7/wD0E9vwLMk8q9lQjxG3XGZG+UCBoPVxTQrw1IssymzZt4vfff7d7kU+dOkVUVFS17W3LT506BcDixYu57bbbCAgIoGvXrgwaNIjJkyczYcKEy44rSRIff/wxUVFRdOvWjRdeeKHOthsMBn777TfmzZtnt6lDhw7VhpAEBQXh5uZmt7uheOCBB+xPA55//nmuu+46XnnlFcaNGwfAU089xQMPPGBvP3/+fF544QXuv/9+ACIiInj99dd57rnnhBAXCK41dC4Q2h8y4mD4HC5kl7D0LwJ8SCcf7uoX1vAC/FIkCbrfoYhx30jQVP9k0kHkERcIWh3XlBDXa1Qsf+y6KzdshHHrytq1a3FxcbFPOp06dapd0AK1zgQTHR1NbGwsBw8eZNeuXWzfvp2JEycybdo0/vvf/1523c8//xwnJyfOnz9PUlIS4eHhddqGzZs34+fnR9euXetsd0PRvXt3+2t/f38AunXrVmlZWVkZBQUFuLm5ceTIEXbt2sUbb7xhb2OxWCgrK6OkpERUaRUIriU0Ohj2PAlpGfxv00X+OFMhwK/vqAjwMO8m/E1oN6jy+6PLIaiXUlwIkUdcIGiNXFNCXJKkqw4RaSpGjBjBxx9/jE6nIygoqFJ8cufOnYmLi6t2Pdvyzp0725epVCr69etHv379mDVrFt9++y333nsvL730Eu3bV1884o8//uC9995j/fr1LFiwgIceeoiNGzfWKdZ99erVTJo0qZLdO3fuxGg0VvGKp6SkUFBQUMnuhuDSTCE226tbZkutVFRUxPz587nllluq9CUmOwoE1wgZ8eDTmYTcMpbuT2DXmSxsPoTrO/lwd1ML8Oo4uwV2fwRaJxg9F8IGisqaAkErRETPt1CcnZ3p2LEjYWFhVSYJ3nXXXZw+fZo1a9ZUWe/dd9/F29v7sun+oqOjASguLq7285KSEqZNm8bjjz/OiBEj+Oyzz9i3bx+ffPJJre2XZZk1a9bY48NtdhcVFfHpp59Waf+Pf/wDrVbLrbfeWusxGoPevXtz8uRJOnbsWOVPTDYRCK4B0k9g+PkJDvz7Uf7vuz3sPK2I8EEdvfloai+eHx/Z/CIcILiP4g03lcBvc+D4yksK+giPuEDQWrimPOJthbvuuovly5dz//33s2jRokrpC1evXs3y5ctxdnYG4LbbbmPw4MEMGjSIgIAAzp8/z5w5c+jcuTORkdUXiLClSHzrrbcAJRvJP/7xD5555hkmTJhQqxCVgwcPUlJSwvXXX29fdt111/HUU0/x7LPPYjQaK6Uv/OCDD3j//ferZExpal599VVuuukmwsLCuO2221CpVBw5coTY2FgWLFjQrLYJBILGJTk5CcPy2ViK8knQmDE5aRjU0Zu7+ofR3se5uc2rjIMb3LAIdrwLJ3+Fne8RFH4OSe4rPOICQStCuPhaIZIk8cMPP/Diiy/y3nvv0aVLF4YMGcLFixfZunWrPYc4wLhx41izZg0TJ06kc+fO3H///URGRrJ+/fpq0/Ft27aNJUuW8MUXX1SKh3700UcZNGgQDz30UK3ivFetWsUNN9xQZYz333+ff/3rXyxdupSYmBj69u3L9u3bWblyZaWUhs3FuHHjWLt2LevXr6dfv34MHDiQ9957j3bt2jW3aQKBoJFIyi1h8a/HOf71/2EpzCRd5c+Zrk/y/t29mXNDVMsT4TbUWhj2PPR7CADPMyu4v+RLLKayZjZMIBDUFkluxfXfbQV9EhMTqySILysr4/z587Rv317E9jYD3bt35+WXX66Uv1zQ9IjzQCComeS8Ur7fl8C2U5ncXLKcwYad6Jxc4OZ/0y6iS3ObVzdOb8S46U0uZubzrfujzH/ykea2SCCwczm9dq0jQlMEDY7RaOTWW2+9YopEgUAgaA4uFeBWGfob9zCWPXh5OeFw00Jo18pEOECn0ZSoPVjz8zoOq6KRZbnOheQEAkHTI4S4oMHR6XQi57ZAIGhxpOSV8v3+RLaezMBa/ix4cJgDT6VvwFF2gL4PVE0R2IrQBvdki74MZDBZZHTGXMhLgKCezW2aQCCoASHEBQKBQNCmSc1XBPiW+AoB3i/ci7v7h9LJ3xUyP4ST66DXfc1r6FVyaXresrJidOvnQPZpGPosdBFPKAWClkibEOJWq9WeB/rSZbIs2/8EgmsR2/e/unNEIGjrpOWX8cOBRDafzMRafh3oG+ZZIcApryHg3QkGPUX5guYy96qRAI1KwmS1Umq04uoaCJnxsPUt5Pwk6POgUo1IIGhixPWnZlqlEF+yZAlLlizBaDQCkJ2dXaVAjK0ipdlsxmw2N4eZAkGzYzabsVqtZGdnVypkJBC0ZTKLjKw5ns3Oc3l2D3i3IGemxPjSwccRKKVw29cY/Xth8erYrLY2NCrZgtlkITkzDznmERwlV5xO/gT7v8CQdoaiPtNBrbtyRwJBA5KdrVSlHTFiBFqtlunTpzN9+vRmtqpl0Cayply8eLHarCkXLlwQ2SIE1zS2rCnh4eHiPBC0edILylh+IIlN8RlYyi9tvUM9uat/KJEBrhUNT/6KtP0dUOuQ7/wWnH2byeKG58GvDpBVZODd27rbvf6cXIe0YzHIFgjohjzmdXBwb15DBdcUSUlJtGvXTmRNqYZW6RH/KyqVqkrVQ5VKhSRJ9j+B4FrE9v2v7hwRCNoKGQVlLD+YxPoT6VjLXeC9wzy5u38YUYFuf2kcD7veV173nIrk6t+0xjYyjlo1EhImKxXnfNRN4BoIG16BtGNI2xfB+Deb11DBNYW4/tRMmxDiAoFAILj2yChUPOAbTqRjKRfgPULdmdq/HdFBblVXKMlRxKjFCO0GQ+/7m9jixsc2YbNKdc2QPjB5CWx9CwbNaAbLmg6RulHQmhBCXCAQCAStisxCA8sPJrL+eGUBfnf/MLoG1RByYTHDxnlQlAHuITDiRWiDXjoHrbJNZaZqJsd5tYebP6k8YTM/GdyDm8i6xie/xMTTyw/TLdiDp0Z3am5zBIIr0vZ+hQSCRkKSJFauXFmvdYcPH86sWbMu2yY8PJz333//sm3mzZtHz54962WDQNDaySoy8PHWszzyzQF+PZaGxSrTLcSdhbd0Y8GUbooINxZD9llI2Ft55U3zIPUIaJ1g3Bugd2mWbWhs9JoaPOI2LhXhF/+A7/8Gf34DrXe6WCV2nskivcDAvgvZzW2KQFArhBBvgUybNs0e26vT6ejYsSOvvfZapewvFouF9957j27duuHg4ICnpycTJkxg165dlfqyWCy89dZbREZG4ujoiJeXFwMGDOC///1vpfGmTJlibz9o0CBuueWWSv3k5+cTGhrKSy+9VKPdNYnNESNGVBrvq6++ol+/fjg5OeHq6sqwYcNYu3btFfdLeHi4fb+o1WqCgoJ46KGHyM3NveK6zc3PP//M66+/Xqd1rkb4CwRtiawiA59sO8vDXx9g3bFUzBaZmGB3PhxYxJv+24g5vgh++jt8eRN8cQP8+CD8+hyYyio60buDSq14wj3Dm21bGhu9zSNurkGIX0r6cZCtsP+/sH2R8tSglbPvvCLAS4212H6BoAUgQlNaKOPHj+eLL77AYDCwbt06pk+fjlarZc6cOciyzF133cXGjRtZtGgRo0aNoqCggCVLljB8+HCWL19uF9bz58/n008/5aOPPqJv374UFBRw4MCBGsWrWq3myy+/pGfPnvzvf//jnnvuAWDmzJl4eXnVuWJmTk4Ou3btYtmyZQA888wzfPTRRyxYsIApU6ZgMpn49ttvmTx5Mh988AEzZlw+dvG1117j4YcfxmKxcOrUKR555BGefPJJvvnmmzrZ1dR4eXk1twkCQevAUASFaVCYSmFWIrHxp8hMuUCUJYdB1hyWR77HHQM70y3EHbb9CvG/VO3DwU2ZnGgoBG15tqAed0Hv+6CNTc78Kw7lHnFDdaEpf6X/w+DsA7s+VPZjYRqMmQ961yuv2wIpMZo5kpQPKJVFzRYrGrXwNwpaNtemEDeV1vyZpAaNrpZtVaDRX76t1rHu9gF6vZ6AgAAAHn/8cVasWMHq1auZM2cOP/zwAz/++COrV69m4sSJ9nX+/e9/k52dzd///nfGjBmDs7Mzq1ev5oknnuD222+3t+vRo8dlx+7cuTNvvfUWM2fOZOTIkezbt49ly5axf//+Kvnar8Qvv/xC79698ff3Z8+ePbz77rt8+OGHzJw5097mjTfeoKysjNmzZzN58mRCQ0Nr7M/V1dW+X4KDg7n//vtZunSp/fPs7GxmzJjB9u3byc3NpUOHDrz44ovcfffd9jbDhw+ne/fuODg48N///hedTsdjjz3GvHnz7G1Onz7NQw89xL59+4iIiOCDDz6oZMdtt91GQEAAH330EQCzZs3igw8+IC4ujsjISIxGI56enqxatYrRo0czfPhwevbsaQ89ycjI4KGHHmLjxo0EBASwYMGCSv2Hh4cDcPPNNwPQrl07Lly4YP/8m2++4ZVXXiE3N5cJEybwn//8B1fX1nnxFFyjZJ6C1MNQmAoDHqv4Ld29BHPcL+SWGMkvNeEjgw/gqFPj5abjtVG+SJ7lceChAxTR6OKvCG9Xf3AJAJ1T1fE8av5daUvYJ2vWxiMO0PVmZZ9tmg/JB2HVDJjwNrgGNKKVjcPBi7n2OQMApSYLrkKIC1o416YQ/3x8zZ+FDVR+hGx8PQXMZdW3DewBkz6seP/dnVCWX7nNo9vqbealODo62hPif/fdd3Tu3LmSCLfx9NNP8/PPP7NhwwamTJlCQEAAmzdv5oknnsDXt/a5cmfOnMmKFSu49957OXbsGK+++uoVBXx1rF69msmTJwOwdOlSXFxcePTRR6u1e/Hixfz0009XjKW2kZyczJo1axgwYIB9WVlZGX369OH555/Hzc2NX375hXvvvZcOHTrQv39/e7uvvvqK2bNns3fvXnbv3s20adMYPHgwY8aMwWq1csstt+Dv78/evXvJz8+vYtOwYcP49NNP7e+3bduGj48PW7duJTIykv3792MymRg0aFC1tk+bNo2UlBS2bNmCVqvlySefJCMjw/75/v378fPz44svvmD8+PGo1RWlq8+ePcvKlStZu3Ytubm53HHHHbz11lu88cYbtdpvAkGzYyiCVdOV7CUA0VPAsx25xUZi09S45qjIkQLJ0Xih9Qyie1Qkwe3aI7kGgtslEwsjhil/AjuXnaxZE+2ug0kfwW/PQ+4FWPEY3PY5OLWuJ3l7z+VUel9itODqIAqZCVo24laxhSPLMhs3buT3339n5MiRAJw6dYqoqKhq29uWnzp1CoDFixeTmZlJQEAA3bt357HHHuPXX3+94riSJPHxxx+zadMm/P39eeGFF+psu8Fg4LfffmPSpEl2mzp06FCtVz0oKAg3Nze73TXx/PPP4+LigqOjIyEhIUiSxOLFi+2fBwcH88wzz9CzZ08iIiKYOXMm48eP54cffqjUT/fu3Zk7dy6dOnXivvvuo2/fvmzatAmAjRs3Eh8fz9dff02PHj0YOnQob75ZOefu8OHDOXHiBJmZmeTm5nLixAmeeuoptm7dCsDWrVvtcfB/5dSpU/z666/85z//YeDAgfTp04fPPvuM0tKKJyq2myYPDw8CAgIq3URZrVa+/PJLYmJiGDJkCPfee6/ddoGgVZCXoIhwnTP0nEq+Wc1/d5zjoa/2807GAF5xW8CvnebR8Z53mfTIa7Qfeg9Su0FK1g+1EFaX44qTNWvCpyNM+QS8O0D7oeDo2QjWNR5mi5UDFysLcREnLmgNXJse8Qd/q/kzSV35/X0rL9P2L/cxU7+vt0l/Ze3atbi4uGAymbBarUydOrVS6ERtC6JGR0cTGxvLwYMH2bVrF9u3b2fixIlMmzat0gTK6vj8889xcnLi/PnzJCUl2cMlasvmzZvx8/Oja9eudba7Jp599lmmTZuGLMskJiby4osvcuONN7J9+3bUajUWi4U333yTH374geTkZIxGIwaDoYog7t69e6X3gYGBdo90XFwcoaGhBAUF2T+/7rrrKrWPiYnBy8uLbdu2odPp6NWrFzfddBNLliwBFA/58OHDq92GuLg4NBoNffr0sS+LjIzEw8OjVvsgPDy8UhjKpbYLBK2CgmQADB4d+NY0lnU/JmA0Kx7cLoFuTB0QRq9QD5ELuh7YPOKGugpxABdfxTOu0VdkVzEblZufFn4sYlMKKDZYcHfU4qBVkV5goLQ++0AgaGKuTSFel7jtxmp7BUaMGMHHH3+MTqcjKCgIjabiUHXu3Jm4uLhq17Mt79y5s32ZSqWiX79+9OvXj1mzZvHtt99y77338tJLL9G+fftq+/njjz947733WL9+PQsWLLDHM9flwrh69Wq7N9xm086dOzEajVW84ikpKRQUFFSyuzp8fHzo2LEjAJ06deL999/nuuuuY8uWLYwePZpFixbxwQcf8P7779OtWzecnZ2ZNWsWRqOxUj9abWWvmiRJWK21f5QrSRJDhw5l69at6PV6e9y5wWAgNjaWP/74g2eeeabW/dWFq7VdIGhuSjIvUlJkZEMBrExSRHlnf1emDgijd5gQ4FdDRYx4PX8TLo2vt5jh9zngHgqDZipZZ1ootmwp/cK9OJtZBBgoER5xQSugTQhxq9VaRYhYrVZkWbb/tTacnZ3p0KGD/f2l23DnnXdyzz33VJmsCfDuu+/i7e3N6NGja9xuW/hKUVFRpTa21yUlJUybNo3HHnuM4cOHEx4eTvfu3fn44495/PHHL2v3pft8zZo1fPPNN/Z+77zzTj788EM++eSTSpM1ARYtWoRWq+WWW2657PH66/G0lc0tKSlBlmV27drFpEmT7NlerFYrp06dIjo6usq2VjeOLMtERkaSmJhISkoKgYGBAOzevbvKekOHDuW///0ver2eBQsW2MX5okWLMBgMDBo0qNoxu3Tpgtls5sCBA/Tr1w+AkydPkpeXV6l/rVaL2Wyu9hhdadlfx6zuHBEImpr8UhMrDiXjuvsAPcuMpDp409HPman9KwR4a/3Nbino1BIyMqVG89Wf88l/IiUfhKQDUJiKPPIVJQ97C0OWZfacy0ZGpn+4Byl5JcjIFBtM4nevhSCOQ820SiG+ZMkSlixZYvdyZmdnV/Gw2kI6zGZzpfzbrQGbaKrJ7ttuu40ffviBadOm8dZbbzFixAgKCgr45JNPWL16NUuXLkWv12M2m7nzzjsZNGgQ1113Hf7+/ly4cIGXX36ZTp060bFjR8xmc5XxXnjhBWRZZsGCBZjNZkJCQnj77bd5/vnnGTNmTI0hKrYLqNls5uDBg5SUlDBw4EB7v/369WPmzJk899xzlJWVMWnSJEwmE9999x0ffvgh7777LoGBgZc9Xvn5+SQlJSHLMklJScyZMwdfX1/69++P2WymQ4cO/Pzzz+zYsQMPDw8++OAD0tPTiYyMtPd7qZ3V7fPhw4fTqVMn7r//fhYuXEhhYaE9f7rFYrGvd/311zN79mx0Op19O4cMGcLzzz9P37597cfgr2N26NCBcePG8eijj/LRRx+h0Wh4+umncXR0rHQc2rVrx8aNGxkwYAB6vR5PT0/7DeZfbQeq3W+245udnV3Fky4QNBWFZWZ+jc9h06lcDGYrs43p6NQSQ7p3JqR7AJJkIjMzs7nNbBOUFRdgNpnJKyy++pA1XRi6Pk/hsu8DpHM7MGc/SuHgF7E6ejeMsQ1EQm4ZKTnFaNUSQQ4mZLMRs8lMWmYOGW5CALYEbMkmRowYgVarZfr06UyfPr2ZrWoZtEohbjuASUlJhIaG4u3tjZ+fX6U2ZWVlFBYWotFoKoV1tAZUKhUqleqydi9fvpz333/fngrQwcHBHqIxePBge7vx48ezbNky3nnnHfLz8wkICGDkyJHMnTsXBweHKuNt27aNjz/+mC1btuDm5mbv5/HHH2fVqlU89thjbNiwodpHx7ZiOxqNhrVr13LDDTfYx7DxwQcf0KNHDz7++GPmzp2LWq2md+/erFixotosMH9l/vz5zJ8/H1AmNPbr14/ff/8df38lN/Arr7zChQsXuPHGG3FycuLhhx9mypQp5Ofn2/fnpXbWtM9XrFjB3//+dwYPHkx4eDgffPABEyZMQK1W29v06tULDw8POnfubI/vHjlyJBaLheHDh1fq/69jfvHFFzz88MOMGjUKf39/Xn/9dV599dVKNrz77rs8/fTTfPbZZwQHB3P+/HlUKlW1tgPVfl80Gg0qlQpvb+8qx0IgaGwKykysPJTC2qOpSjo9SUVkkBvuvT8ixKuMUGefVpuzuqUSUKZFo00Hta7KdbFe+E2G4E5I619GU5yEw65XkcctBO+OV993A7H5YiIarYZ+4V6EBgXg7Z6PJrMMnZNLw+wDwVVjc5xu2bKFkJCQZramZSHJrfgZoE2IJyYmVjmwZWVlnD9/nvbt2wsB0gx0796dl19+mTvuuKO5TbmmEeeBoDkoLDOx8lAya46k2ifMdfB15u7+YfRv7yViwBuR4yn5vPDTMYI8HPj03r4N13FBanl6w4tKeMrY1yGkAfu/CmYtO8TZzGJmjuzI2K4B/HPTadafSOeeAWHc1T+suc0TcHm9dq3TulzFglaB0Wjk1ltvZcKECc1tikAgaEKqE+ARvkoMuBDgTYN9smZd8ojXBrdAJaPKhlch8yQ4eDRs//Uks9DA2cxiJAn6t1fynjvqlH0gsqYIWgNCiAsaHJ1Ox9y5c5vbDIFA0EQUlplYdTiF1UdS7Lmb2/soHvCBEX8R4MkH4cwmCOoFncY0k8Vtlwoh3ggi1MENblikeMV9WkZoyr7zSu7wLv6ueDgpc8WcdIq0EVlTBK0BIcQFAoFAUC+KDGZWHU5m1eEKAR7u48zd/UMZ2N4blaoaD3j6cYj/BWSrEOKNgF5TXlmzvukLr4RaW1mEpx2D4yth6LOgbfrwt73laQsHRlRMIHXU2aqLCiEuaPkIIS4QCASCOlFsMLPqcAqrDifbvY5h3k7c0z+MgRE1CHAb+Ure8Eql6gUNhs0jbrXKmCxWtOpGLKBtNsLG+VCcCQUpMO4NcPJqvPH+QrHBzNGkfAAGRFSM61i+D4RHXNAaaPNCvBXPRRUIrhrx/Rc0JMUGM6uPKAK82FAuwL2cmDogjOuuJMBtFCQp/92CLt9OUC8cNBXCu8xkaVwhrtHBqFfg95cg4wSsfAImvAWe4Y035iUcvJiLxSoT7OFIiGdFfnMRmiJoTbRZIW7LmVxSUoKjY8NVvBQIWhMlJSVA1WqcAkFdKDGaWXMkhZWHUigyKPnqw7ycuKt/KIM7+NROgNuwecTdReaExkCjVqFWSVisMgazlUZPDhnYA6Z8DL8+DwXJsGoGjHkNgns39sj2sJRLveFQMVlThKYIWgNtVoir1Wo8PDzsBQ2cnJzEjH3BNYMsy5SUlJCRkYGHhwdqdcstTS1ouZQYzaw9ksqKQ8l2AR7q5chd/cK4vmMdBTiAsQRKc5XXwiPeaDhoVRQbLE0nRD1CYcq/FM94eiysewaGPgddxjfakGaLlQMXlO/SgPaVCwxVhKa0rmJ+gmuTNivEAQICAgCuvrqYQNBK8fDwsJ8HAkFtKTVaWHMkpZIAD/F05K7+YQypjwC3UZCi/HdwF4V8GhEHrbpciDdhVUlHD7jpPdi6EM5uhoTd0HkcNJIDLDalgBKjBXdHLZEBlb9LTjoRIy5oPTSrEN++fTuLFi3i4MGDpKamsmLFCqZMmdJg/UuSRGBgIH5+fphMpgbrVyBoDWi1WuEJF9SJUqOFtUcVAV5YpgjwYA9H7uofytBOvvUX4DaK0pX/IiylUbFnTmnq0AyNDka+ooSrdJnQaCIcYO85JSylX7hXle+lCE1p/VxJH6anp/P888+zfv168vLyGDp0KP/85z/p1KnTZft9//33+fjjj0lISMDHx4fbbruNhQsXNmvBu2YV4sXFxfTo0YMHH3yQW265pdHGUavVQpAIBAJBDZQaLfxyLJWf/0yyC/AgDwfu6h/GsIYQ4DbCB8ODv4GhqGH6E1SLLXOKwdwMQlSlgq5TKt5brXDwc3D0AkkFlE8gt00kD+kLHuXVLwtS4OIfFev+dbJ5cG/w7oAsy8SdPsNww15ukoPgyMFKbd2MZkLNahIJw2qVUZVkwenfq/ZnsyWwh/IHUJIDJ1ZVbSNf0tZWUbQsH47+UI295f/9Y5TvPEBhOpxcB1ETwdmn6n5rQEwWK/vP57DzTBbRQW7c1L31hYFdTh/KssyUKVPQarWsWrUKNzc3Fi9ezOjRozlx4gTOzs7V9vndd9/xwgsv8PnnnzNo0CBOnTrFtGnTkCSJxYsXN8VmVUuzCvEJEybUqfqiwWDAYDDY3xcWFgJgNpuFx1sgEAjqSJnJwq+x6aw8nEJBuQAPdHfgjr7BDOnoo0z6s5ixNKie04DeA8RvdqOhU0vIskxRqbHZr43Soa9R/fl1jZ9bh72A7ByotM08jWrXhzW3Hfx/yG5hnM8qRlWQyOSyVYSfccZ6tnI7ByDCPJoEdSiFpWU45SWj3vvvmvvtPQ3ZJ1p5U5iB+sAXNbaVu9+N1b9ctBfnof7zm5rbRk/BGtwfci+gXvU4WIzIFjPW3tNqXOdqOJdZzKaTGew4nW2/oY5PLWBclG+jjFcXzGbFnsLCQgoKCuzL9Xo9er2+SvvL6cPTp0+zZ88eYmNj6dq1KwAff/wxAQEBLF26lL///e/VrvfHH38wePBgpk6dCkB4eDh33303e/fuvaptu1paVYz4woULmT9/fpXlmzZtwsence8wBQKBoK1gssLhbIl9mRKlZsXb7aGTuc5fJspdpuRMCr+faWYjBfUmPVlFfqHEzj37yDvZvClMnQxWQmmP2mq8ZGnFE5bkw6fJP6XcLLiWJhMih1Xbj4xE2rHz5J1bxx/pEklFKo7rYrBIMjJSlbbnylzIL8tnza/r8ZVzCJM6/GVsqbwtZJ/OIid1HQA6UwHtpM6V+5Mq1sk9V0B2ptJWYy6mnSqqcr+XmJKfYMCc9E+6pnyPxlIGwJ5EHYa0dTXur7pSYoYTuRLHcyUyyyoGV0tgkUFnkFm3ruHGqy9ZWVkAREdHV1o+d+5c5s2bV6e+bA7ZS8NJVCoVer2enTt31ijEBw0axLfffsu+ffvo378/586dY926ddx77711Gnvv3r1cvHiRkpISfH196dWrF+3bt6/TNlxKqxLic+bMYfbs2fb3ycnJREdHM2rUKIKDRXEIgUAguBwGk4XfTmSw4lAK+aUmdM4Q6qbn9j7BDO/si7qhQlBqQLX5NdC5KB7BJiz8cq1x7PdT5JzLoVuPcCbEtITJ2tNq/CS8ypKHa2wbUf5/4/KjlHh4oh8+jogov2rb5ny+H3eDhUFDuxPq6QT8rcZ+q0YV31Vj26rcXuMn0qlfUe16D1z04N8Hy+jXGOXgXoe+q8dssfJnYh6b4zPZn5qL1QrowdtJYkC4FyMjfckvNfHh5rN0CXbjhhuir9hnY5OcrKQtPXHiRCW9Vp03/EpERkYSFhbGnDlz+PTTT3F2dua9994jKSmJ1NTUGtebOnUqWVlZXH/99ciyjNls5rHHHuPFF1+84pi7du3igw8+YM2aNZhMJtzd3XF0dCQnJweDwUBERASPPPIIjz32GK6udZuI3qqE+F8fYdgeb2g0GpEnWSAQNCuyLJNRaMDPVd/iUqUazBZ+i03jx4NJ5JUo3scAdwfu7BfGiC6+aBqz6IsNUxlc2A6A+rrHQPxmNxpOei2SJGGySm3u2phZaOBCdikqlcTAjr41bp+TXkux0YpZVjX9PrBa4cBncOhb5X2n0TDsBVQa3VV1ezG7mA0n0tl2KtN+HoNEZ38XRkX5M7SzD64OyrauPpKCJEm4O+lbxHdAo1HkpqurK25ublfVl1ar5eeff+ahhx7Cy8sLtVrN6NGjmTBhwmWL2G3dupU333yTf/3rXwwYMIAzZ87w1FNP8frrr/PKK6/UuN6kSZP4888/mTp1KuvXr6dv376V6tOcO3eOHTt2sHTpUhYvXszXX3/NmDFjar09rUqICwQCQUtl9ZEU/rvjPH8f0p7JPVvGE7rqBLi/m547+oYyMtKvaQS4jcLy1IV6V9Bf3YVYcHkctMpxNZibMH1hE2Er4hMZ4IqHU83CtlnL3GedhMP/U173vhf6PlTvDDKFZSa2ncpkU1wGZzIqJjl7OGkZ3sWP0VF+tPOuOjmxsEw5390c26bM69OnD4cPHyY/Px+j0Yivry8DBgygb9++Na7zyiuvcO+999pDV7p160ZxcTGPPPIIL730EipV9b+HN954Iz/99FONNzQRERFERERw//33c+LEict65aujbR4hgUAgaEKMZis/HlRKt685ksLE7kENl2mknvb8dlwR4LnFSmyun6ueO/opArxRy57XhK2ipltwo6a1E4CDpu2m79t7LgeoWsTnr1TkEm+Goj5+UTDoSdA6Kmkc64jVKnMoMZcNJzLYez4bs0Xx8qpUEgPaezEq0o8+7TwveyNtm6xp85C3VdzdlVCf06dPc+DAAV5//fUa25aUlFQR27aMepfzpD/66KO1tic6OrpKHPyVaFYhXlRUxJkzFTOCzp8/z+HDh/Hy8iIsrPoJGwKBQNDS2Hmm4lFxeoGBE6kFxARffSxoXTGarfxeLsBzygW4r6ueO/qGMCrKv3kEuI0CmxBvfanUWhu29IVlzZG+sBEpNpg5lpwPwMAOlxfiTZ5LPC8BVFpwUzLAEFP3lMxJuSVsPJHOlpOZ9vMXINzHmdFRfgzv7Ie7U+2EdUFpuUfcoXX6W6+kD5cvX46vry9hYWEcO3aMp556iilTpjB27Fj7Ovfddx/BwcEsXLgQgIkTJ7J48WJ69eplD0155ZVXmDhxYq1TXCcmJiJJEiEhSi2Effv28d133xEdHc0jjzxSr21t1iN04MABRowYYX9vm4h5//338+WXXzaTVQKBQFB7ZFlm1WEl7MJZr1Q03HAivUmFuNFsZf0JRYBnFykXcB8XHXf2C21+AW4jX3ligHvLCNtpy1QU9GlboSkHL+ZiscqEeDoS7OF42bZNGpqScgjWv6JMQJ68pE5VY4sNZnacVkJP4tMK7ctd9BqGd/FldLQ/HXxd6mxSgS00pZV6xK+kD1NTU5k9ezbp6ekEBgZy3333VYnzTkhIqOQBf/nll5EkiZdffpnk5GR8fX2ZOHEib7zxRq3tmjp1Ko888gj33nsvaWlpjBkzhq5du/K///2PtLQ0Xn311Tpva7MK8eHDh1/2cYBAIBC0dI6nFHAusxitWuL/RndmwS9x/HE2i8eGdbB75RoLo9nKxrh0fjiQaBfg3i467uyrCHCdpgUIcBu28vbuoc1rxzWAvaBPGwtN2VNeTbN/+ytn3HFsqjL3p36Hbe+A1awUJrJeORTGapU5mpzPprh0/jibjbE8ll8lQZ92XoyO8qNvuNdVnb8VoSmt0yN+JX345JNP8uSTT162j61bt1Z6r9FomDt3LnPnzq23XbGxsfTv3x+AH374gZiYGHbt2sX69et57LHHWp8QFwgEgtbO6iOKwBwV5U//9l4EeTiQklfGrjNZjI72b5QxTRYrG08oAjzrEgF+e59QxkS3MAFuw1is/HcTHvHGpi1O1jRZrBy8mAvAwIjLh6VARYx4o4WmyDIc/AIOfqW8jxgOI14ETc3p+FLzS9kUl8Hm+AwyCyuKE4Z6OTIq0p8RkX54OV9dZhUbNiHu5tg6PeItFZPJZM/et3HjRiZNmgQoKRXrOknThhDiAoFAUE/SC8rYW+6lm9g9CEmSGBXpzzd7LrIpPr3BhbjJYmVTXDo/HEiyX8i9nHXc3jeEsdEBLVOA27jlUzCWgLphhIagZuwx4m3II348pYASowUPJy1d/K8c+tGooSlmI2x/B05vUN73+puSGaWarBulRgs7z2SxOT6d2OSKipLOejVDO/syOsqfTn4uDZ7y1JY1pbV6xFsqXbt25ZNPPuHGG29kw4YN9smhKSkpeHtf+QaxOsQREggEgnqy5kgKVhl6hXkQ5u0EwMgoP77de5HY5AJS80sJdL98LGttMFusbIzLYPmBRDLKBbins47b+4QwrmsLF+CXonNqbguuCWwe8dI2JMRtYSn9wr1qlZHIUafIm9LGEOJ7/qWIcJUahjwNkTdW+liWZY6nFLAxLp1dZ7LssfqSBL1CPRgV5c/ACO9GO2+NZqt9zLaeNaWpefvtt7n55ptZtGgR999/Pz169ABg9erV9pCVuiKEuEAgENSDUqOF9SfSAZjcsyITiI+Lnp6hHhxKyGNzfAb3DGhX7zHMFiub4zP44UAi6QWKAPdw0nJbnxDGxwSg1zRuDLqgdaJvY+kLZVm2P3kaUIv4cKjwiDfKzUiveyH1CFw3A0L62BdnFJSxOT6DjXEZpBeU2ZcHeTgwKtKfkVF++LjUvZJkXbFN1FRJ4NzI81SuFUpKSnBycmL48OFkZWVRUFCAp6en/fNHHnkEJ6f6ORqEEBcIBIJ6sDEunVKjhWAPR3qFelb6bFSUvyLE4zK4u19YnXOKmy1WtpzM5Pv9CW1DgJ/8DU6vhw4jIGpic1vT5mlrMeLnsorJKjKi06joGeZRq3UaPI94USa4+Cqvnb3h1s9ApaLMZGH3uWw2xaVzNCkf2/xCR62a6zv5MDrKn6hA1yattntpDvGWVuW3teLj48PIkSOZNGkSkydPxt+/cthheHh4vfsWQlwgEAjqiNUq2ydpTupZtXjPwAgvnHRqMgoNHEvOp0eoR636tVhlNsdn8OGm0/ZlHk5abu2tCHBb7G+rIzMekg+Cb2RzW3JN0NY84rYiPr1CPWp9E2rLmlJqbICbkdMbYdvbMOw56DQGWZaJTy9iU1w6209nVQp/6R7izugof67r4N1s52tbr6rZHMTHx7Nq1Sp++OEHnnzySXr06MGkSZOYNGkS3bp1u6q+28RRslqtWK1t485fIBA0Hfsv5PDJtnOMjPRjav/QWnuP9p3PITW/FBedhuGdfar8/mhVEtd38uH342lsPJFGt+DLl3S3WGW2nsrkh/2JpF7ySNtVr+Xff+uNvvyC3lp/56TyHOKyWxC00m1oTeg1EjIyZSZLq/3OXMrus1nIyPRv71nr7bHtg1Kjuf77QJbh0DdIB78AoOT0Dn7J68Km+AyS80rtzfxdHRgZ6cvISD/83Rzsy5tr3+eXGJGRcdFrWszxbyl21JewsDBmzpzJzJkzyc/PZ926daxatYpFixbh5eVlF+XDhg2rdXEgG61SiC9ZsoQlS5ZgNCppu7Kzs9HpxEx8gUBQe46nFfP+tkRMFpn/7T6PoaSIm7r61Grd7/dcxGwyc11Hdwpysymopk0vPw2/HDazNT6NW6Jd7TGrl2Kxyuy5WMDq2CzSC41VPg/20ZOfm13XTWtxeGSeQ202kW92xJyR0dzmtHmKDRbMJjNmICUtHU0dQ6NaEtnFJk6n5aOSINzZQkYtvz9lhaWYTWZyi0pqvU4lLCZc/vwE3cUtlBitbHUYwX/ih2GJPwuATiPRL9SNIRHudPZzQiVJUFZARll1vwZNS2J6LmaTGbXVWL9tbwSys5XfsREjRqDVapk+fTrTp09vZqvqh7u7O3fffTd33303JpOJLVu2sGbNGh544AEKCwv55z//yT333FPr/lqlELcdwKSkJEJDQ/H29sbPz6+5zRIIBK2EuNQC/rX7HLJKTYS3Ewm5Jaw8kUtYgDejoy6fcvB8VjGnc4zodFruGtQJX9fqJ1/5+sq0O5RNcl4pp/JVjImu+I2yWmW2nc7k+/3JpOQrnjUvV0fCvZ04Wl7CG+BCnhkvbx80LaEyZn2xmpGMuaDR4hUeA86+zW1Rm8dksaLRngPAzdMbF32rvNQDsP9oKhqthuhANzqGBV15hXJM2lI02iSskqbO+kAuy6dwzXxKEg+RZrDwvf42dlsGIWmhe6Abo6P8GNzBp9ELdtUXVYIBjVaDv6dbi9FGNsfpli1b7OXh2wJarZaxY8cyduxY/vnPf3Lo0CHM5rrNS2i9Z+clqFSqSmVMBQKBoCbOZBTx2to4jGYrvcM8efnGaL7be5Gf/kxmyZazuDvqGHCZgiFrj6YhITG4ow/+V0hNOCY6gK/+uMDm+EzGxQTaBfiyfQmk5CkhKG4OWm7pHcKoSD+eXn4ECYmbugey9WQmRQYz57NL6RJQ+5LZLY7CDJCtoNEjOftWm2tZ0LDoVSrUKhVWq4zRIrfq6+PeCzlISAyM8K7TdjjpNUhIlJksSJJUq7CzvBIj204kELb1/3ApTcEg6fnS6SGyPHtwZ6Qfo6L8CfK4+nSkjU2RwYKEhLuTrsUc+5ZiR0NSXFzM999/T2lpKWPHjqVTp0706tWrzv20CSEuEAgEtSEhu4S5q2MpMVroGuTGizdEodOouH9QOPmlZjbGpfP2b/G8NjmGmGD3Kuvnl5jYdkp51Dupx5W9c8O7+PLN7gucSC1g2b4Etp3KJClX8YC76DXc3DuYid2DcNSp+ff2s2QWGvB303PfdeFkFBrYdz6H2OT81i3E85OV/25BQoQ3IQ4aFSVGS6vOnFJkMHOsvAjO5W6Oq8OpPI+4VVayx9Q0cdJksbL/Qg6b4jI4cCEHqww3yF3pry7lz+jnuad3X3qEeNQ581FzUmCrqilyiDcYCQkJ3Hvvvfz5558MHDiQzz77jDFjxnD6tDKx3tHRkV9//ZWhQ4fWuW8hxAUCwTVBan4pL6+KpaDUTCc/F16dGG2/OEuSxIyRHSkoM7HvfA6vrz3BW7d2p72Pc6U+fjueiski08nPhchaiGMvJx3W8nRm/9ubAJQL8F7BTOwRZH+0HZdawNqjSnnkJ0Z0xFGnpluwuyLEU/K5tU8rfpRrKgFHD1Havolx0KopMVpadeaUgxdzsVplQjwdCa6jJ1qvUSFJynzLUqOlihA/l1nEprgMtp7KoKDUjEq2YJXUdPZ3pX3UTLqEOdLHvXY5y1saoqpmw/PMM89gNBr55JNP+OGHHxg3bhydOnVi+/btqFQqHn/8cebNm8fmzZvr3Lc4SgKBoM2TWWjg5RWx5BYbCfN2Yt7krnaPmQ21SuK58V14deVxTqQW8OqqWP5xew97FgSTxWoXy5N6Bl32UbfVKrPrbBbL9iVWWj51QBiTewZVGttotvLhptPIMoyK8qN3mJKTPKY808rxlAKsVrlVeeQq0WGE8mdpoHzOglphyyXemoV4XYv4XIpKJeGgUVNqslBisuAJ5Jea2HYqk40n0jmfVaw0lGUmyZsZ5ngWxykfEOrnedl+WwMFpRV5xAUNw/bt2+3VMydMmICPjw+ff/65PZ/4K6+8wqhRo+rVtxDiAoGgTZNXYuTllcfIKDQQ5OHAgskxNT6y1WvUvHxTFC/8fIyE7BJeWRnLO7d1x8NJx87TWeSVmPBy1jG4Y/XZVaxWmT/OZrN0XwIJOSUAaNUSJoviFo8KdKtyA/D9gUSSckvxcNLy0PXt7csjfFxw1KopNVo4l1VMRz+XhtgdzYdaXG6akopc4q0zNMVksXLgYi5Q97AUG446RYhvP5XJhaxi9p7PwVL+iEqjlhgQ7sa9xp8ISt+CJAN5+8FvbENtQrMhPOINT0ZGBu3aKVWSvby8cHJyqlTUJyAggNzc3Hr1LQL2BAJBm6WwzMQrq46TkleGr6ue16fE4Ol8+VSnrg5aXpvUFT9XPan5ZcxbfZwSo5lVh5VY5xu7BaL9SxYTq1Vm15ksZi47xNu/xZOQU4KTTs3d/cP4+qEBTOgWAMCmuPRK653PKubHg0qO7ceHdajkwVKpJKKDbF7xfASCumCvrtlKPeKxyfmUGi14OGnp4l/3ORIJ2SXkFCuZOr7bm8AfZ7OxWGU6+Drz6LAIvronihesXxCcvgVJUsH1s6Bz6xfhUFFZU8SINyyXPgVtyIql4nZJIBC0SUqNFuauPs6FrGI8nLQsmBKDn6vDlVcEvF30vDYlhud+PMLZzGKeXX6UhJwStGqJcTEB9nZWq8yec9ks3Z/IhfJH3Y46NVN6BjOpZ5A9bdzoKH9+PZbGrjNZPDasA856DRarzD83ncZqlRnUwZtB1XjZY4LdOXgxl9jkfCb3bIUx1lYrLL8fXPxh9FzQt+JJp60MW0x0mbl1CvG955Vqmv3DvWodllVYZmLH6Sw2nkjndEZRpc8m9wxiVJS/Mu+jIBV+mwW5F0HrpHw3wwY29CY0C1arTLGxXIiLypoNyquvvoqTkxOgpGN84403cHdXJvWXlJTUu996HaWEhAQuXrxISUkJvr6+dO3aFb2++ly6AoFA0NSUmSy8tvY4p9OLcHXQsGBKTJ3TjgV7ODJvYldeWhFrDzMZGemHu6MWWZbZfS6bZfsS7bGmjjo1k3sGMalHUJXYzE5+LoR6OZKYU8qO01mMjwlg1eFkTmcU4axX8+iwDtXaYIsTj01upXHiRemQlwCFqaB1vnJ7QYNhF+KtMDRFluWK+PArhKVYrTKHEvPYFJfOnnPZ9jAwlUrCWh6GMmt0J0bZ6gNkxMNvL0BprpLTfvxb4NOx8TamiSk0mJHLJ4iLGPGGY+jQoZw8edL+ftCgQZw7d65Km/pQayF+4cIFPv74Y5YtW0ZSUhKy7UgDOp2OIUOG8Mgjj3Drrbe2yXyRAoGgdWA0W3nr13hikwtw1Kl5bXJX2nnXTwR28nflxRujmLf6OLIsM7FHEHvOZfPd3oQKAa5VM7FnEFN6VhXgNiRJYlSkP1/+cYFNcel0D3G3Z1F56PoIvGoIl+no64KDVkWRwUxCTgnhPq1MzBakKP9dA0XqwuooK4BjP4DVAl1uAI/QBuvaQdN6J2uezSwmq8iIXqOiR2jVNKIAyXmlbIpLZ3N8BtlFFVVp23k7MSban2Gdfflo8xn2ns/BZLnkZkTvArIFfDrBuIXg4lueWiVXuXEsSAGfzhXHwmKCQ99A15vBseVP5CwoVeLDnXRq1K3txr0Fs3Xr1kbru1ZC/Mknn+Srr75i3LhxLFiwgP79+xMUFISjoyM5OTnExsayY8cOXn31VebPn88XX3xBv379Gs1ogUAgqA6LVebd9Sc5eDEXvUbF3InRdPS7unCInqEeLLqtO9tOZbJ4wynOZV4iwHsEMqVXcK08TyMi/fh69wXi0wpZ+Gs8RrOVHqHujI6qufKdRq0iMsCNw4l5xKbkt0IhrsS/496K0y82NidWQ1k+HP4OQvsrgi904FXfuOhbsUd873nFG94rzMM+6RSgxGhmx+ksNsWlE5daaF/uotcwrIsvo6P86eDrbI/fdSpPD1pcZlZudlRq5bt4/WxI2A07/gGFacqfuazCgMFPVgjxuDVw8Cs4uhx6ToVut4O2diFuzYEtPlx4w1sPtRLizs7OnDt3Dm/vqo+I/Pz8GDlyJCNHjmTu3Ln89ttvJCYmCiEuEAiaFKtV5oONp/jjbDYatcTLN0XTNah6b1ptkWWZ/RdyWbovgTPlMaeOWjU3lQvwukyG8nLW0SvMk4MXc7mQVYxeo2LGiE5XnPQTE6wI8WPJ+dzUvfYlvlsE9mI+rTC+vbHIPKl4XCUJHNzguhkQtwrSj0PiPuXPLQiip0CXCUqbeqAv94gbWmGM+N5zSnz4gPbeWK0yx5Lz2RSXzq6z2RjLCxSpJOgV5smYaH/6hXuhw6TEfJ9PLRfXqYxKOMnAwgt02Z4HmUNhwtvKAC7+cOr3yoNKEjj5gGsA6C/Z514R4NtFOW77/wsnVkLfB6HzeEXYtzBsGVPcRMaUBiUvL4+lS5fy+OOPA3DPPfdQWlpq/1ytVvOf//wHDw+POvddqyO1cOHCWnc4fvz4OhtxtVitVqzW1nfXLxAIGgZZlvl42zk2n8xAJUk8N7Yz3YPd6v27IMsyBy7msmx/on3Sl4NGzU3dA5nSMwg3R0WA17X/kZG+HLioiIx7BoTh56q7Yh/Rga7IyBxPzsdisTTobP3GRspXPOKya6AycfNapjANae8ncH4b8qi5EDFcWd5xtPJXkAJxq5FOrlNe7/kXsmyB7nfVazgHjQoZmVKjuVVdHzMKyjiXpZxzp9IL+G7fRTIKDTjIpXhbc4h0KmKwv5mursU4RQyEsCgArOmnkFbPqNRXcJGBXIsJq6xFTtiDXJqvTBh2C4Ke9yii2zVQEeYufqC+JETMts8CusPkf8HZLUgH/quI/G3vwNEfkPv9HcIGKSK+hZBfakRGxtVB06KOe0uypT785z//4fDhw3Yhvnr1asaNG4erq/LEdffu3bz//vvMmzevzn3X+Zbp/PnzmM1mOnXqVGn56dOn0Wq1hIeH19mIurJkyRKWLFmC0ajEhWVnZ6PTXT4lmUAgaJvIsswPhzP4NS4HSYK/XxdEexcLGRkZ9errWGoxK49lci5beVSt00iM6uTFhCgv3Bw0lBXmUlZ4hY5qoL2zlc7eepx1KgYEqmtlo4dkRbJayCowc+RMEkHurWdivHvGWTRmEwUWJ0z1OB5tAosRx5MrcTz5M5LViIyK0sTjlLpE/6WhBtrfAqE3ok/cgf7CJgq9+iOX7zdt+lEkUxHGoP6guvKl21hajNlkJjuvsF7nQpNjMWLOS+ajPdmYTUoI1u6Dh3iw7Gt8yMNHZ8BFr0FvlJDKI56KzCZKHJSJzpJBg4faBYuzH1YnX0BCPr0FWZYxmy3k9nkKY34pUO7FbDepYmwDYMi7vH1u3WDYIhzO/Y5j3HJUmacxHlhKoWOny6/XxCRn5GA2mVFbjS3quGdnK+FGI0aMQKvVMn36dKZPn97MVtWeH3/8kTfeeKPSsnfeeYeIiAgAVqxYwWuvvdY0QnzatGk8+OCDVYT43r17+e9//9uoAe02bAcwKSmJ0NBQvL298fOrOc5SIBC0XZbtT2TDmQI0Wg0zRnRkbLT/lVf6C7Is82dCHsv2J3IyXVHZzo56buwWwM29gnF3bLh4y3/cFXDlRn8hJiSLYyn5pBm09GxFv3WShz9YS/AMjwG31mN3gyDLcGEH0p5/KZMAVUBwX+TrZuLq3YHLzlwImgoDpnJpJLK0ewVknIB4H+SoSRB502UnD/qmWdBoc1DrHVr09VHOPEXm/h8xn9qAoaSYCN1wYh0nAxAVEEjflFyc9WokyQkcPMDVH1wDkV0CcAnqhYt92/zgwTVoATLjkX5/EbNGQ6HamS0dn+Ph3uMaxuDAh6DvHXBkKY4dRuLoXT5+WT4Yi5o/DOtMCRqthgAv9xZ13G2O0y1bthAS0vrmjJw7d44uXbrY33fp0qWSA7hHjx6cPn26Xn3XWYgfOnSIwYMHV1k+cOBAZsyYUc0ajY9KpRKZWgSCa5CVh5JZui8RCYm/D2nP+JjAOq1vE+BL9yVwMk0R4HqNmhu7BXJL72A8nFrGk7aYEHdiUwo4nlrADa0pTnzShwBIstyiHt83CTveVSZighL2MPBxiBhRv9AiqwVC+ippIIuzkA58Dn9+DR1GQNdbwC+qyv511GmQkDCa5ZZ3fTSVkh+7npwDPyJlxtuzmpRIToAKCYkFU2LoEewGiYuU8BHXANBWpCCtcS+e3w6bF4DZQJlrOO9Ld9NBG9aw+8DRHQY+VnnZoa/hxCqIngy972u2DCtFBgsSEm6O2obZZllWUpBazeBdfZrV2tDivoN1pLi4mPz8fEJDlUm8Bw4cqPJ5fcNv6izEJUmisLDqc9n8fCV+USAQCJqC32JT+WzneQD+NjCsTgVvZFnmcGIe3+1NIL5cgOs0KibEBHBbn5AWI8BtxAS5A4nEJhcgy3KrihMHrj0RDtB+OJz8DXrcpWTb0NYtj30lVGro9xD0uhfOb4PjK5TJnac3KH/Rk2HI7Eqr2PKIt6TJmgazhd1nMglY9yDqknSQwSKpiXPojaHjjeR4dOXX2HRCvRzpEeqhrNRuUN0GSdwHZgOEDuBCxEzyNlykpLzATaNhtUJhunLDFPuzctybKcNKoaEBsqaYjcpNRdoRSDsGpXnQbjCMf7NhjGyFRERE8OeffxITE1Pt5wcOHKB9+/b16rvOQnzo0KEsXLiQpUuXolYrJ7rFYmHhwoVcf/319TJCIBAI6sKWkxn8a+tZAG7tHcwdfWuXf1mWZY4k5fPd3ov29GdatcQN3QK5tXcInjXk825uugS4olZJ5BQbSSsoI9D9KkSdoOGxWuHkL4oQ6zpFWRbSB6Z+D05eDTeORgedxih/GfGKID+7GYL7VLQpKwBzGQ5a5fLe3OkLZVMpiYc3saawC9tOZ1FqtHCzuQvRkoWEwFH495nM+OiOOOrUvPNbPKBkS6k3g2eBV3uInoIuqQCAEmMj34yoVIpITToIez+BrFPNlmHFnjWltlU1zQYl5KmsACKGKcvUWiV3ell++XvdNV8H4Oabb+bll19m3Lhx+PtXDn9MS0tj7ty53HffffXqu85C/O2332bo0KF06dKFIUOGALBjxw4KCgrYvHlzvYwQCASC2vLH2Sze33AKWYYbuwdy/6DwK3qIZVnmaFI+3+1N4ESqcnHWqiUmxARya5+QGgvqtBQctGo6+7sQl1pIbHJB6xDi/xmlPM52D4HBT4Fne3D2aXve8bRjsOtDRXxpnSB8CDiXC8mGFOF/xS8S/OYoIRKXpts7sQoOfE47n350MEdRZuzWeDZchtykeBJ3/YDD+Y1IpmJOu8ykVNMRP1c9Tn0eIzw6lIEeTvb2JouVAxdzARgQUYf9ZiyGYz9Cr78pYletgZhbgYo84k1W1CikDwR9qtwc7f+vEkq07R0ozoQ+05rEhILSK3jEywogPRZSjyrf3cx45Tx19oX2Q5XzU5IUb75KrWSN8ems3ARewzz33HP89NNPdOrUiXvvvZfOnTsDcPLkSb799luCg4N5/vnn69V3nYV4dHQ0R48e5aOPPuLIkSM4Ojpy3333MWPGDLy8GvFHRyAQXPMcvJjLot9PYpWVcvOPDIm4ogg/mqTEgMcmVwjw8TEB3No7BG+X1pOBpFuwO3GphRxLzmdMPSakNjnW8nCA/CRY96zyWucCnuHgFQ7XP926vWzFWbD3Uzi9Xnmvc4G+D4DD1eWurzN/jUXOSwDZimvqbqYXbSLXFAwn/q6kSNQ5Vd9HA2EsK+X0nrUYj63ANf8kjuUFuPPU3lwXoueBgTF0C3ZHVU3Fx2PJ+ZQaLXg4aelc2yJcRRlKufrss2AohEGV56k5lT8VaHSP+KWoVNBptCJqT6yC2J8g6pIMLRaT4nFuJAoul0d802vKTcIlldEB5QY5oJviHbeF0vS+t9FsbI24urqya9cu5syZw9KlS8nLywPAw8ODqVOn8uabb9pTGdaVemV8DwoK4s03r91YIYFA0PTEJufz5ro4zBaZQR29eXJUp2ov6Je2/9/ei3YBrlFLjOuqxID7tCIBbiM6yB1I4nhyfnObUhVZVjyAvl0UAXIpGr2Spzk/SckqkR6reAgvFeHrX1ZKjHu2V4S6Z3slvMDRs/k86FYrGPIVu9S6iuqgxhL4459wbguYShX7utyoxHA3pge8tox8CXpOpWz/95j2r8LHlKJMHN37qRJLPuCRBh1OlmXOZhax+9BReh+cg85SjA6woiLVszf67lPoPmAU/fSX96hWFPHxuux5bSfzlCLCS7KV70nH0VWaOOiU71hpU3nEL0Wjg+63K975S7/rv7+k3BD1exjcGzbDimy1oi9OZqDpLP4HN0PeSbj1vxXzExy9lHPVPQQCeyje7sDuymTYtvakqhHw9PTkk08+4eOPPyYzMxMAX1/fq56zUy8hvmPHDj799FPOnTvH8uXLCQ4O5ptvvqF9+/YiTlwgEDQ4p9MLeW3NCYxmK33aefLM2C6oa7hYxybn892+BI4lKYK1tQtwG9GBbqgkyCg0kFFQhp9bCymzbbXAjsUQv1YRrHf9T3nMrXVUhOqtnynlws1GyE+E3AsV3nIbtglhabGVl+tdIagnjF1QscxYDDrn+tlqNirCujRXuUHwKp9cZSxRxKrts9JcJT5WLo+v7jgaRr2ivFbr4OQ65bV/Vxj0pBIm0pLwao9x0CzmnezNAPN+nnY/odwIleZUbncV2WzyCos4ePgwKxKduJhdgiRb6Sg74ahzpCRiPO2vv53OgbVLUyfLsr2s/YCIWsSHX9ileHfNZcqN24S3lawqf8GxfMKq2SJjNFvRaZrhCcylIjznPCTtU/b7+R3lGVbuvboMK3mJkLAH0o5iTT3K8+VFtBwvuCipZTLiILi30tY2cbgl3DC2YiRJatDUkHUW4j/99BP33nsv99xzD3/++ScGgwFQsqa8+eabrFu3rsGMEwgEggtZxby66jilJgsxwe7MuSESrbrqBfV4ihIDfrRcgKtVEmO7+nN7n1B8XVuvALfhqFPTwc+F0+lFHE8paBlC3GyEza8pokJSwfWzlFR9JTnl3mJVhUDS6JT0Z39NgSbLcMO7ikDPPV/+/wIUJCvhBsbiyu1/uB8sxvIQF5sHPRyQlPAQn45KO2MJbH0TSnKhLE8R15f21XEUjHq13DY9nN1U9ZE9KDcDl1ZcVGtgwGPKzUXYoBYbXuOgVVMqObFVO4xZt7+AOvmAkoPbRtYZ2DgXoqdAl/HKdl4Bs8XK0eOxZO1bjn/6NnxkSHabj1ajY2CEH07tPqBb546o1HWbmHg2s4jsIiN6jYruIVcI7Tn2I+z+SDlWIX1h9HzQu1Tb1ElXIXFKTZbmEeKX4tVeuTHd+ykk7lXCVk7+WvsMK2ajMrHSI6xCTCfuVfYHYLXKmCUNSdpwOvUerXi9/aIq1nf2aaQNa9uMHz+eefPmMXDgwMu2Kyws5F//+hcuLi51KlZUZyG+YMECPvnkE+677z6WLVtmXz548GAWLFhwmTUFAoGgbiTnlfLKqliKDGY6+7vy6k3R6DWVL/InUpQy2EcSKwT4mGh/bu8bgp9rCxCrDUi3YHdOpxdxLDmfEZHNXKzDWKw8Zk85pMS8jnq1Iiyl3CuHi/+V42ElSRHPNgFtw2xQvH2Xes+NJVCSpYiw1CPK36V0GAmj5yqvNXq4sLOquFZrlcIw2kvipVVqxbOtcwFHD+URvqOH0k5dzWWy592X36YWgMMl50mZWcY5bEDlBvFrleO0+yMlrKjTGOh6c7W5os+n5xK/ex3602sJLTtlL0ZkdvTmqX5O9OnV+6rS5e09r3jqe7fzrHJ+V6IoA/b9RzmmUTfB4P+r/viUo1ZJ6DQqjGYrZSZLgxbmqjfeHeCGd8ozrHwMWacrMqzc8I+KpzSg3IimxULaUWVyZdZJJcZ82PMQeYPSJqgXhA6AwO6k6Dry4qZS3F2dGdO/f7NsXlvk9ttv59Zbb8Xd3Z2JEyfSt29fgoKCcHBwIDc3lxMnTrBz507WrVvHjTfeyKJFi+rUf52F+MmTJxk6dGiV5e7u7vbgdYFAILhaMgrKeHnFMfJKTLT3cWbepGgcdRUX6bjUAr7bm8DhxDzgEgHeJ6RleIsbgZhgd37+M5nY5o4TL8mBX5+vyBQy7o2Kx9+geLPh6mJgNfqq4lznBA/8pkxIrORBv6gI+ksf8avUMPTZquJa51J9OEbMLfW3tQWiVUuoJLDKStYQZ/1fLvcDHgWvCDj+sxIyEbdG+QvsATG3UhA4kO2nszl3YD1DUz+no1V5mqBSqyn174tvv9vwjxlOVAM8Ebg0PvyyuPgpN3x5CUqYRS3Capx0aoxma9NO2KwNIX0g6N8VGVYkVcU8hOyzsOUNyDlX9UbSyQsshor3NmEPZF3MwSydwO1qcogLqvDQQw/xt7/9jeXLl/P999/z73//m/x85TdYkiSio6MZN24c+/fvJyoq6gq9VaXOQjwgIIAzZ84QHh5eafnOnTuJiIioswECgUDwV3KKjby0MpasIiMhno68Nrmr3eMWn6YI8EMJeQCoVBJjovy4o29omxXgNqIC3ZAkSM0vI7vI0HxZX+LXKiLc0QMmLALfzpU/V+vANxK8OzX82FoHZby/jlkdkTc2/PitBEmS0GvUlJoslJmrySWudYToSRA1UXmyEPsT8oWdlFz8k/SzJ3lO9yIGqxp/iws3yMVILj6ooiYSNug21G5V47HrS3pBGeezilFJ0De8GiFelKnEtvuWlxcPHwxUre5dE0phI1PjF/WpD5dmWClKq3h65OyjiHFQxHlAdyWrSWB3cAuu8QakoMyWurBe0/8El0Gv1/O3v/2Nv/3tb4ASjl1aWoq3tzda7dXd+NT5aD388MM89dRTfP7550iSREpKCrt37+aZZ57hlVdeuSpjBAKBIL/UxCsrY0nLL8PfTc/rU2LwcNJxMq2QpfsSOFiea1ilkhgd6ccd/ULxb+MC3IaLXkN7H2fOZRZzPKWAoZ19m8eQnn9THptHTVJipf9Kx1HKn6BZcdApQtxwuawhkkSiQ2c2Oj/IQel6upZtoUhywWBVE+HrzKioQfi7fYpru16NUpTGFpYSHeRWNXQk64ySGcVqgimfgFtgnftv8lzi9UGjU+K+bTi4KxNQvTtV5KSvBYV2IS484o2Nu7s77u4Nk6q0zkL8hRdewGq1MmrUKEpKShg6dCh6vZ5nnnmGmTNnNohRdcVqtWK1Nm/1MIFAcPUUG8y8uuo4F3OK8XbW8frkrmQVlvHPTac5mFAuwCWJkV18uaNvKAHuigC/ls7/rkFunM0s4mhSHtd3vIoKhHUl5xy4h1Z47QY8rvy/hvZ9a8NBo0JGptRornKOFBnM7Dydxab4DE6mF5YvdSLHYwrDO/vyXpQfET627DQBWKFRjvWes1nIyPQL96xsY8IepM2vKZN+Pdohy9Z6je+oVSMjU1RWdR+0aELKY7zrYHNBiREZGVcHdYvb1pZmT0uizkJckiReeuklnn32Wc6cOUNRURHR0dG4uFQ/a7kxWLJkCUuWLMFoNAKQnZ2NTndtV30SCFo7ZWYr725J4HRmKa4OaiZHefD+b8c5klIEgEqCwe3dmdjVBz9XHRgKyMgoaGarm55gRytmk5k/z2eQEV2/AhJ1RZv2J657FmEM7E9R/6eUeNaakGVAvnwbQdNgMWI2mUnNyMJbXYZVljmRVsKOc3n8mVSIyaLEH6sk6B7kwpAID3oEuaBRS2AtJiOj+AoDXB3FBguHL2ZjlaGjq0xGRgYA+rO/4nz4MySsmHy7UTjwWeRSNZRm1HkM2WTAbDKTlplDhnvbFoOp2XmYTWYwltn3ZUshO1tJTzlixAi0Wi3Tp0+vU2aRtky9A4l0Oh3R0dEUFBSwceNGunTpUq8g9fpgO4BJSUmEhobi7e3doDkdBQJB02I0W3n9lzjO55nQaDU4O+r5/IByIdHptAzv7MsdfUMI8mgFpd0bmcFunny8J42MEis6Fw88nBrZCXFmI9K+f4BkRau14uTtqUykrImyfKT/3Q5ugci3fgYqEa/aXLi5pKEpspBn0fP7uVK2nMwkq6h8op9KTYS3E6Oj/Bjexbfxv0fVsO1UJiqNhnBPJ2I6hCh52/d8jBT7I2jUyJ1vQn39/+FwFZUovT3y0GSWoXNyafM6warORaPVEOTr2eK21eY43bJlCyEhtcsvf61Q51/IO+64g6FDhzJjxgxKS0vp168f58+fR5Zlli1bxq233toYdl4WlUqFqoXmchUIBJfHbLGyaP0pjiblI6FMQsouMqKWJIZ18ePOfqEECwFux8NJTztvZxKyS4hLK2Jwx0bMDRz7E+z6UHndcRQMn4N0JVFUmKLE9JpKkTTiSWVzUWq0cDKtCAmJr3ZftC930WsY1tmP0VF+dPRzueqqgFfDvgu5SEgM7OCtXMMPfw+xPyof9n8Yqec9V13x0VmvQUKizGxt8zqh0GBGQsLDSdfitrWl2dOSqLMQ3759Oy+99BIAK1aswGq1kpeXx1dffcWCBQuaRYgLBILWidUq8+SyQyTmlNqXqSQY1tmXO/uHCQFeA92C3UnILiE2Ob9xhLgsw8Ev4OBXyvuuNyt5tmtzMc1vgNSFgnphtcocTylgQ1w6f5zJqvRZn3aejIryY0B77+YvbIPyFOzgBWXex4D25XMduk6Bi7uU71sDTfZ1KK+uWdrS0hc2AoUia0qTYTQaycjIqBL7HhYWVsMaNVPno5Wfn4+Xl5Ji6LfffuPWW2/FycmJG2+8kWeffbbOBggEgmuTc5lFPLXscKVlw7v4cme/UEI8napfSQBATJA7vxxNJTalkWLk934KR5Yqr/s+AL3vr71n0pZD3E08fm4q0gvK2BSXweb4dNILDFU+n9IrmIeub1/Nms3HseR8Sk0Wwh0K6eRbPilU6wiT/nnVXvBLsZW5L23JWVMaCJE1pfE5ffo0Dz74IH/88Uel5bIsI0kSFkvdv2d1FuKhoaHs3r0bLy8vfvvtN3t1zdzcXBwcro0UYgKBoP6czypm6b4Edp/Nti9TqyT+eXcvQr2EAK8NMcFuAFzMLqawzNTwF97Q/kqhl4FPKF7KutAQxXwEV6TMZGH32Ww2xKVzLKmiwJOjVs3Qzj6MivJnc3wGv8Wm4axr+LSDV8ve89l0McUx2/w/VIfSlBs+aFARDuCsV7a9ReYRb2AKy0wAuDkKj3hjMW3aNDQaDWvXriUwMLBBQrvqfLRmzZrFPffcg4uLC+3atWP48OGAErLSrVu3qzZIIBC0TS6UC/A/LhHgALf2Dmba4JblrWvpeDjpCPZwJDmvlOMpBQyMaOA0hsG94a6ldcphbMcWmuImhHhDI8sycamFbIxLZ+fpLLuXV5Kge4g7o6L8uS7C2x6Osas8PKWleYNlWcZyfBWPFC/D3UMPqYfBammUPOUVoSltO2OK0WylzKRso/CINx6HDx/m4MGDREZGNlifdRbiTzzxBAMGDCAhIYExY8bYA/AjIiJYsGBBgxkmEAjaBhezi1m6L9EuCi7l0WER3NQ9qBmsav10C3EnOa+U2OT8qxfipXmw5U0Y+Dh4ld8U1UeEAxQkKf+FEG8wsooMbI7LYFN8Oil5Zfbl/m4OjI7yY2SkX7VVZfXlItRQXWXN5sJqJWvTB4zP+Q6VJOEQfQMMf7ZRRDhcGprStj3iBeXecJVEi3wC0laIjo4mK6vqtexqqNfziz59+tCnT59Ky2688dotJSwQCKqSkF3C0v0J7DqTpaSW/gv3DwoXIvwq6Brkxm+xacQm51+58eUoyoBfnoa8BCjJglv+W7tJmdVhMUNwH8hPAjdxbK8Go9nKnnPZbIxL53Binv0cctCqGNzRh9FR/kQHuqFS1fxo3KF8UmaLqSppKoMtb6CK3QhAfOjtdBj5XIOHo1yKrbJmSRufrHlpfHhzZsJpixQUVMzFefvtt3nuued488036datW5Xy9m5ubnXuv1ZC/K233uKpp57C0fHKGQz27t1LVlaWEOYCwTVKYk4JS/clsPMSAT6oozd+rg6sPKSELdzRL5Tb+ojJfFdD9xAPAM5lFZNfaqpaHrw25F6Edc8oYtzZF0a+Un8RDqDWwOh59V//GkeWZU5nFLHhRDo7TmdSbKgQjzHBboyK9GdwRx8ca+nxtIVl2EIWmhWrFdY9DWmxFBjhW6d7GTbg7kYV4YB9X7X1rCm2+HCRMaXh8fDwqHRzI8syo0ZVzurT6JM1T5w4QVhYGLfffjsTJ06kb9+++Pr6AmA2mzlx4gQ7d+7k22+/JSUlha+//rpORixZsoRFixaRlpZGjx49+Oc//0n//v3rvDECgaD5SMwpYdn+BHacvkSAd/Dmrv5hJOeWsuj3eAAm9QjibwPqnuJJUBkvZx1h3k4kZJdwJDGPoZ1969ZBRjz8+iyUFYBHKNzwLrj6N46xgsuSW2xkc3wGm+MzSMgpsS/3ddUzMtKPUVF+BLrXPZVnhRBvASJUpYLImzBkXeA9/R1c1Hbg6XCvRh/2WsmaYvOIu7WR+PDt27ezaNEiDh48SGpqKitWrGDKlCn2z+fNm8eyZctITExEp9PRp08f3njjDQYMGFBjnwsXLuTnn38mPj4eR0dHBg0axNtvv02XLl0ua8uWLVsaarOqpVZC/Ouvv+bIkSN89NFHTJ06lYKCAtRqNXq9npIS5UejV69e/P3vf2fatGl1yp7y/fffM3v2bD755BMGDBjA+++/z7hx4zh58mSLqwwlEAiqkpRbwvf7E9l+KhNruQC/roM3d/ULJcLXhf0Xcli0/iRWGcZE+/P3Ie3Fo9MGoleoBwnZJRyuqxBPOgjrXwZTCfhGwoS3wNHz6g0yloDG4eq86tcIJouV/edz2BiXwcGLOfZzR6uWGNxRyXrSPdj9sqEnV8JBqxwHg7kZRajFBLYiUF0msLEggvN7MokJcmsS0eikU2ROW/eIF5S2LY94cXExPXr04MEHH+SWW26p8nnnzp356KOPiIiIoLS0lPfee4+xY8dy5swZu6P4r2zbto3p06fTr18/zGYzL774ImPHjuXEiRM4OzvXaMuwYcPsrxMSEggNDa1yDZNlmcTExHpta62PWI8ePfjPf/7Dp59+ytGjR7l48SKlpaX4+PjQs2dPfHzqV1Ri8eLFPPzwwzzwgJK66JNPPuGXX37h888/54UXXqhXnwKBoPFJzivl+30JbLtEgA9o78XdA8Lo4OsCwNGkPBaui8NqlRnSyYcZIzoKEd6A9ArzYNXhlPIYYrl2+1aWlRzhphIlnnvsAtA1UNrIXR/A2c1w3fS6pz28RjibWcSmuHS2nsy0ezEBIgNcGRXlz5BOPjjrG0ZM2TzihuYKTYn/BQ5/p+QGd1K837uSlFLnDZ7ppwYcL5mwarHKqK/ixqYl09ZyiE+YMIEJEybU+PnUqVMrvV+8eDGfffYZR48erRI2YuO3336r9P7LL7/Ez8+PgwcPMnTo0FrZ1b59e1JTU6s4inNycmjfvn3T5BFXqVT07NmTnj171nmwv2I0Gjl48CBz5syp1P/o0aPZvXt3lfYGgwGDoaJYQWFhIaCEx5hMpqu2RyAQXJmUvFKWH0xm++ksuwDvF+7JnX1D6FBemMNkMhGfVshra+Mwmq30C/dk5vD2WCxm6vE7JaiBzr5OqFWQUVBGQlYhQbWtRDr8JVRHv8fa616QtNBAv5/qvEQwG7BqnJDFb7Kd/FIT205lseVkJheyK0JPvJy1DO/sy4guvoR42o6d3GDXMw0ysixTYmzia6RsRXXgc6SjSlEo6/FVyD3/RmGZmdgkZeJprxC3JrFJI1mRy2PlCkrKcGmgm5yWRm5xGbIs46yTWqQeMpuVG4XCwsJKkx/1ej16vf6q+jYajfz73//G3d2dHj161Hq9/HxlorutSGVtqMnhUVRUVO9aOs36jczKysJiseDvXzku0d/fn/j4+CrtFy5cyPz586ss37RpU7098gKBoHbkGmBPhooTuRK2JCgd3GSu87MSIOdwcv9ZTpYvzyiF78+pMVggzEUmxpLD+t/PNpfpbRono4rEIokvVm+ll0816WkAZBmPkvPkOUdcsjAQft/YoLZcd+4IOnMRBw+foSi+tEH7bm1YZDhfCLE5Ks4VSvabVrUEHd1kYrystHMBVU46R3fD0UawIa0E8vPVWEvyWLcuuRFGqIrKaiIy9Wd8C48DcMFnBBeTPSFlHSdyJXLzVHg7yBzatZlDTWIRFBaoscqw9tf1uOmaaNAm5s9EFfn5EudP5rIu93hzm1MFW8q/6OjoSsvnzp3LvHnz6tXn2rVrueuuuygpKSEwMJANGzbUWgtarVZmzZrF4MGDiYmJuWL72bNnAyBJEq+88gpOThVPES0WC3v37q23g7pV3RrOmTPHvjMAkpOTiY6OZtSoUQQHi5y1AkFjkJpfxo8Hk9maoISguLlDn3Ye3Nk3hE5+LlXaJ+WW8tKq4zi4mOkZ4MrcmyLtj8gFDU/Jn8n8b28ikq8nN0yoZtKRbEW1919IaSuwRj6K3O2OxjHEVII69V3AnaE33gV618YZp4VzMaeEzfGZbDuVRX6pCSRwdYOOvs6MjPTl+o4+TRbHm5BTwprMo7g6aLjhhr6NP2BpLuqNr4IqCTy9sV7/NF07jaVr+cfH15/CvSCHKb2DuKEJJ2wvTdtPkcHCoKHdCWuj1Xv/XBdPsjWP6wdEMDqq5c2vS05WbgRPnDhRSa9djTd8xIgRHD58mKysLP7zn/9wxx13sHfv3lrNL5w+fTqxsbHs3LmzVmMdOqTcNsqyzLFjx9DpKu7odDodPXr04JlnnqnXdjSrEPfx8UGtVpOenl5peXp6OgEBAVXa//URhu3xhkajqZLLUSAQXB1p+WV8vz+RzfHp5d48ib7hnkwdEEZn/+pFVlp+GfPWxlNYZqGjnwvzJ8c0WLyroHr6hnvz3b4kjqcUIqnUaNSXTJS0mGHbIji9ASQJlVYPjfVbmZ+ppKJzcEfl0vjZMFoShWUmtp3KZHNcBqcziuzLPZ11DO/ix+goP9p51zwZrLFwddQjSRIGs7Xxr5H5SfDLM1CYCg5uMHYBqqCe9o+NZiuHEwuQJIlBnfya9Jrt4qCl2GjFJEttVisUGaxIkoSHs0OL3EaNRrkOuLq61ivXdnU4OzvTsWNHOnbsyMCBA+nUqROfffZZpXDn6pgxYwZr165l+/bthITULo2uLXPKAw88wAcffNBg2wDNLMRtKWc2bdpkT0tjtVrZtGkTM2bMaE7TBIJrlvQCRYBvis/AWv48vU87T+7uH0aXgJq9nFlFBl5eeYycYiNhXk5ChDcRHXxdcHXQUFhm5lR6EdFB5RcIUxlsnAsJe5SqhcNegM5jG88QW0VN92sjP7zVKnMoMZeNcRnsOZeN2aKcKyqVxID2XoyK9KNPO8/KN0ZNjK2ypskiY7XKV5WB5cqDuSnfM7cgmPA2eFT2eB9LzqPUZMHTWUdH36pP0hqTijL3bXeCisgjrujHS+cR/hVZlpk5cyYrVqxg69attG/fvs5jfPHFF1djYrXU+4idOXOGs2fPMnToUBwdHWs/Y/8vzJ49m/vvv5++ffvSv39/3n//fYqLi+1ZVAQCQdOQXlDG8gOJbIirEOC9wzy4q38YUYGXv/vPKzHyyspY0gsMBLg78PqUmPoVmBHUGZVKokeoBztPZ3EoMVcR4mUF8NscSI8FjR7GvAZhAxvXkPzyGOQ2Xto+KbeETXFKzu+cYqN9ebiPM6Oj/Bje2Q93p5bx3belLwQla0htCwHVbzA3uOEfoHWoNhXmnnM5gJJZqVFvCKrB8ZoQ4m0rj3hRURFnzpyxvz9//jyHDx/Gy8sLb29v3njjDSZNmkRgYCBZWVksWbKE5ORkbr/9dvs6o0aN4uabb7Y7dqdPn853333HqlWrcHV1JS0tDQB3d/fLFqysLn1iTfz888913dS6C/Hs7GzuvPNONm/ejCRJnD59moiICB566CE8PT15991369TfnXfeSWZmJq+++ippaWn07NmT3377rcoEToFA0DhkFJax/EASG06kYykX4D1DPZg64MoCHBRPzKurjpOUW4qPi443psTg5dxGZ0S1UHqWC/HDCXnc0zcI1s6C7LNKnPb4hRDQrfGNcA+BiGEQ2L3xx2piig1mdpzOYlNcOvFphfblLnoNw7v4Mjra356ysyWhU6uQJCVjZanJ0rBCXJbhwGfg5FORqtItsNqmVqvMvvOKEB8Y0fRhS229zL3VKlNsLBfijm3DI37gwAFGjBhhf2+bH3j//ffzySefEB8fz1dffUVWVhbe3t7069ePHTt20LVrV/s6Z8+etU8SBfj4448BGD58eKWxvvjiC6ZNm1ajLe7u7vbXsiyzYsUK3N3d6dtXmXdx8OBB8vLy6iTYL6XOR+z//u//0Gg0JCQkEBUVZV9+5513Mnv27DoLcVDidUQoikDQtFQnwHuEujO1f7uK8IYrUGq0MH/NCc5nFePhpGXBzd3wc6tfCidB/ekV6gHAqfRCis0Szl1uUPI337AIvDs0jRERw5S/NoLVKnM0OZ9Ncen8cTYbo1nJxa2SoE87L0ZH+dE33AudpuUWL5IkCQeNmlKTpWGra5qNsO0tOLMJJJWSj94jtMbmZzOLyCk24qBV0S3Yo+HsqCWOtqI+bbS6ZqHBbK9m3FbSMw4fPtyedrI6auN5vnDhQqX3l+vvclwajvL8889zxx138Mknn6BWKzd4FouFJ554ot5x43U+YuvXr+f333+vEuDeqVMnLl68WC8jBAJB05FZaGD5wUTWH68Q4N1D3Lm7fxgxwe5XWLsCg9nCa2tPcDKtEBe9htcnxxBc2zzWggbFz82BIHc9KfkGjiblc12326DzuGs2c8nVkJpfag89ySysiDcN9XJkVKQ/IyL9WtUTH71W1bBCvDQP1r8EabFKTPiQZy4rwgH2lHvDe4d5NsuNS1sPTbFV1XTSqZt1TsK1wOeff87OnTvtIhxArVYze/ZsBg0axKJFi+rcZ52FeHFxcaX8iTZycnKuOim7QCBoPLKKDCw/kMT6E2n2iWXdQtyZWkcBDkp57oXr4olNzsdRq+a1yV0J92n6rBCCclIOMav0n8y1/o1Diblc18G7aUW4xQylueDk3SrL25caLew6k8Wm+HRikyuKjTjr1Qzt7MvoKH86+bm0yqqweo0aMGEwN0B1zbxE+PV5KEgGnQuMfU3xhl+BveeygaarpvlXbKEpbdYj3saqarZkzGYz8fHxdOlSOVVsfHw8Vmv9zrE6C/EhQ4bw9ddf8/rrrwPKoy+r1co777xTKZ5HIBC0DLKKDPx4MInfj1cI8JhgN6b2b0e3kLoJcACLVeYf609y8GIuOo2KVydG06mGdIaCJuD8Dtj0GqHGEsYafmdfwt1Nb0N+Aix/AJx94G8/Nf349UCWZY6nFLAxLp1dZ7IoKy8DL0lKqM+oKH8GRni36NCT2mCbsHnVHvGUw7D+ZTAUgmsgTHgLPMOvuFp6QRkXs0tQSdA3vOokzqbAoY3HiNsyprhdwxlTmooHHniAhx56iLNnz9K/f38A9u7dy1tvvVXvJCN1PmrvvPMOo0aN4sCBAxiNRp577jmOHz9OTk4Ou3btqpcRAoGg4cm+RICbGkCAgxI3++Gm0/xxJhuNWuLFG6Lq7E0XNCDx62D7IpCt6DsO49czYzDml5FeUIZ/U8bq2zKmOLX8CscZhWVsjstgY1wG6QVl9uVBHg6MivRnZJQfPi5t5+muLXWf7Uaj3mTEKSLcLxrGvQFOtZt0uafcGx4d5N5sHlsne2iKuVnGb2wKbBlTRKaqRucf//gHAQEBvPvuu6SmpgIQGBjIs88+y9NPP12vPussxGNiYjh16hQfffQRrq6uFBUVccsttzB9+nQCA6ufMS0QCJqOnGIjPx1M4tfYVLsAjw50Y+qAMLqHuNf78bosy/x7xzk2x2egkuDZcV3o0655PFwC4PBS2PuJ8rrLDWiHPkOH4ljiUgs5lJDH+JiqRdEajYJyIe7eMlMXlpks7D6Xzaa4dI4m5dsntjlq1VzfyYfRUf5EBbq2ytCTK2H3iJuv0hvco7xaaqcxSkrMWmJLW9gc2VJstP3QFOERbypUKhXPPfcczz33nL2o5NUW96nXUXN3d+ell166qoEFAkHDklts5Kc/k1h3rEKARwW6MnVAO3pchQAHRYR/9ccFfjmaiiTBrDGdGdSh5Xs/2ySyrAjwI8uU9z3uhgGPgiTRM9RTEeKJuU0rxPPLi/m0oBzisiwTn1bIprh0tp/OqjRRr3uIO6Oj/Lmug7fdY9xWcdAo22eoqwg1G+HQN8r3S+ekxOxE3VSnLgrLTJxIyQdgQPvmiQ+HitCUtirEbZM1RYx409JQ1TXrJcTLyso4evQoGRkZVYLTJ02a1CCGCQSC2pFXYuTHg0n8GptmT7EWGeDK1AFh9Az1aBAv3/IDSfz0p+L1fGJ4B0Z08bvqPgX1pCwfzm5WXg98XPFUltMrzIOl+xI4mpjf+JUUL6UgRfnfAqpqZhUZ2BKfwaa4DJLzSu3L/d30jIz0Z1SUX9OG7TQzthuNOk3WLCtQ4sFTjyj56Me/Wa+xD1zIxSpDmLcTAe7Nt89toSklhrYpxCsmawqPeGPQu3dvNm3ahKenJ7169brsNfXPP/+sc/91Pmq//fYb9913X6Uk6TYkScJiafovutVqrfdsVYGgtZJXYuTnQ8n8eiwNg0X5/nfxd2Vq/1C7AJdlud65U22sOpzC13suAPDg4HDGRvuL86050bvBhEWQGQ+dxsIlx6KjrzOOWhWFBhOn0wuabBKtVO4Rl10DK9nTVBjNVvaez2FzfAaHEvOwln/n9Ro1gzp4MzrKj66BbvYbk2vp+6vXSMjIlBjNtdvu/CSk3+coTzm0TsjRU+p9THefy0JGpn+4Z7Pucwetqm77oJVRUGZCRsZFr26x29dS7aoNkydPtmcFnDx5coOHsNVZiM+cOZPbb7+dV199tdmqXy5ZsoQlS5ZgNCrlhbOzs9HpWk9eV4HgaigoM/NrXA6bTudgNCuCI8LbgSndfOkW6IwkmcjMzGyQsbadyeOLfcqElCndfBgUpCUjI6NB+hbUHslUjCbnLCZ/W9VKB3DvCdUci45eOv5MKmT7iUTcpSYIH7IY8c5LBmRyDDrkJvp+yLLMhZwydpzLZ+/FAoovCT3p5OvIkAgP+oe5lcdIG8jKaphzorVhMpRiNpnJysknI+Pysd2arHhcdy9EZSzE4uRH4eCXsOhCq/2eXXFci5V9ZzMxm6x0dqdZfzdKCpV9kF9c2iZ/vzJyCzGbzFjKilvs9mVnK5N2R4wYgVarZfr06UyfPr2Zraodc+fOtb+eN29eg/dfZyGenp7O7Nmzm7UEve0AJiUlERoaire3N35+4lG5oG2TX2pixaFkfjmWhsFsAUlNVLALU/uH0TusYUJQLmX7qUy+PZSFRqvh5p7BTBvUrk1OZmvxlOYi/foG5F5EHrcQQvpetvmgLhaOppdyNs/aNL+LxmLo/TekonR8QzspscSNSF6Jka0nM9kUn8HFnJLypRL+Hs6MjPRlVKQfQaKwlB1vj1I02gK0Dk6X/z6c2YS0+22wmiAwBvXYN/GuZWaU6jh4MRczKvw9HOjXJazpwqSqwaQrRaNNwoy6TWoFE8lotBrCAnzw8/NobnOqxeY43bJlS5WCkK2JV199lREjRnDdddfh4NAw4VZ1FuK33XYbW7dupUOHJiqbXAtUKhWqVlhEQiCoDfmlJlb8mcQvx1LtKcg6+7ly94Aw+rbzbBRxvOdcNu9tPA3AhJhAHry+vRDhzUFBKqx7RgkTcPREcvK6YsGcXu28kDhPfFohBrOMo66RJyM6uMJ1jwPQWN8Qk8XK/gs5bIrL4MCFHMoLwqJTq7iugzejo/zpEeLRrGKvpeKo0yAhYTDLNV8nTaWw71NFhLcfAiNeRtJencjYdyEXCYn+7b3RaJp3QqyLXlu+D6xIktTmfssKDWYkJNyddC1WC7VUu+rK7t27Wbx4MWazmX79+jFs2DCGDx/O4MGDcXSsnwOgzkL8o48+4vbbb2fHjh1069YNrbbyLN0nn3yyXoYIBILKFJSZWHkombVHUu2z/Tv6uXB3/zD6hTeOAAc4lJDL27/FY5VhRBdfHh/Woc1duFoF2Wdh3bNQkq0UULnx3VqlBwxyd8DfTU96gYHjKfn0DW++tHFXy7nMIjbFZbD1VAYFpRU5oDv7uzIm2o/rO/niohcT1C6HPY/45dIXah1h/EI4txX6PnTV1VGtVpl955s/baEN282oLCv51Bv95rQJkWXZnkdcZE1pfDZs2IDZbGbv3r1s376dbdu28eGHH2IwGOjXrx87d+6sc591/gVbunQp69evx8HBga1bt1a6QEuSJIS4QHCVFJYL8DWXCPAIX2em9g+jf3uvRhXFx1PyeeOXOMwWmUEdvHlqdGfhZWwOUo/C7y8qBVS8IuCGf4Bz7dK/SZJEz1APfj+ezuHEvMYX4gUpoNYrBV4a4LuZX2pi26lMNp5I53xWsX25h5OWkZF+jI7yJ9TL6arHuVZw0NRQWbOsALJPV5So9+mk/DUAZzOLyCk24qhV0y3Yo0H6vBr0GhUqCayyksKwLQnxUpMFa/kjIpE1pWnQaDQMHjwYX19fvLy8cHV1ZeXKlcTHx9evv7qu8NJLLzF//nxeeOGFNvOoQSBoCRSWmVh5OIU1h1PsAry9jzNTB4QxoJEFOMCZjELmrzmBwWylTztPnh7bBbUQ4U1PzjklHMVsgIAYGLcQHOqWr7ZnqCe/H0/nUEJe49h4KTsWQ9J+GPY8RN5Qry4sVpmDF3PZFJfO3vM5WMqFhUYt0b+9F2Oi/OkV5im+j/Wg2sqaBSnw6/NQmAYT3wf/rg06pq2aZq92Hug0za8TJElCr1VTarRQYjTj5dx2kjvYUhdq1VKbz4nfEvj3v//N1q1b2bZtGwaDgSFDhjB8+HBefvllunfvfuUOqqHOQtxoNHLnnXcKES4QNBCFZSZWHU5h9ZEUe9GR9j7O3N0/jIERjS/AARKyS3h11XFKjRZigt14YUJki7iAXpN4hEP7YYo3fPQ8qEesbvdQdyQJEnJKyCoyNG7JdltVTbegOq+akF3Cxrh0tpzMIK/EZF/ewdeZ0dH+DO3si5t43H5V6MvPY3tBn7RYWP8SlOaBsy9oGj6/9x5bWEozFvH5K046RYhfWtipLWAr5iPK2zcNjz32GL6+vjz99NM88cQTuLi4XHWfdRbi999/P99//z0vvvjiVQ8uEFzLFBnMrD6cwqrDyZSUXxzaeTsxtX8YAyO8mywkJCWvlJdWHqOwzEwnPxdeuSlaeFaaA6tVic1VqRTvMoC6fo+a3Ry0dPR14XRGEUcS8xgV1UhZriwmxasKtS7mU1hmYsfpLDbGpXM6vci+3N1Ry/AuvoyK8qe9j3NjWHtNUqmgz9nNsGUhWIxKGMr4t8C5YVNcpuWXkZBdgkqCvuGeDdr31eCkU5NN26uuWWAvby+EeFPw888/s337dpYtW8bcuXPp1asXw4cPZ/jw4Vx//fU4OdU9bK7Ov/IWi4V33nmH33//ne7du1eZrLl48eI6GyEQXEsUG8ys+osAD/N24p4mFuAAGYVlvLwylrwSE+28nZg/uStOOhFn2KTIMuz/L+QlwOj5ihCvpwC/lF5hHpzOKOJwYwrxwjSQraDRg1PN3k+rVeZQYh6b4tLZcy4bk0UJPVGpJPq182RUlD99wz3RqsVTmIbGQasGWaZPzjrYuEFZ2G4wjHxZKV3fwOw9r4SldA12b1GTB203JG3OIy6qajYpU6ZMYcqUKQDk5+ezY8cOli9fzk033YRKpaKsrKzOfdb5yB07doxevXoBEBsbW+kzkVlBIKiZEqPiAV95OJni8lLLYV5O3N0/jEEdmlaAA+QWG3llZSyZhQaCPBxYMCWmRV04rwmsVti5GOLWKO+T9kPYgAbpumeoJz8cSOJwYl7jlbu3lbZ3C6p2omZyXimb49LZFJ9BdpHRvrydtxNjov0Z1tkXD6e2E6/bEnHQquhhOszwspXg4wzdboOB0686M0pN7DmnhKUMaN/82VIuxal8gmZJGxPihSJjSpOTnZ3Ntm3b2Lp1K1u3buX48eN4enoyZMiQevVXZyG+ZcuWeg0kEFyrlBjNrDmSwspDKRQZlB/NMC8n7uofyuAOPs2SlaSgzMTLq2JJySvDz1XPgindhCBqasxG2LIAzm1TROz1sxtMhAN0CXBFr1GRV2LiQnYxEb5XH8tYhQKltD1uFWkVS4xmdpzOYlNcOnGphfblLnoNw7r4MjrKnw6+zsJx00Q4aNUc1fbgiKUHEYNvgJhbG22swjITJ1LyARgY0XLiwwH7k762FppSWB6aIjziTUO3bt2Ii4vD09OToUOH8vDDDzNs2LB6T9SEeghxgUBQO0qNFtYcSWHFoWS7AA/xdOTu/mFc37F5BDgoQmnequMkZJfg6axjwc0x+Lo24mQ+QVWMJbD+ZUg+CGqtEiYQMbxBh9BpVMQEu3PwYi6HE/MaR4jnKxM1rW7BHCsPPdl1NhujWcnQoZKgV5gnY6L96RfuJSYANyVFGeDggYNGjSyp+NxhGpOjr6cxj8CBC7lYZeWJh79bw08CvRraamiKzSMuJms2DY899hjDhg0jJiamwfqslRC/5ZZb+PLLL3Fzc+OWW265bNuff/65QQwTCForpUYLa46msOLPygL8rv5hDGlGAQ5KLuHX1pzgdEYRrg4aFkyOIdBdlANvUkpz4dcXIDNeKaQy9g0I6dMoQ/UK87AL8Vt6N3xZ6Ryvnpx3L2D9USf+OFARqhji6cjoKH+Gd/HFuzEztgiqJyMOfpsDIf3QX18+8VdSKks2Zg5tW9rCAS3MGw6XhKa0MY+4PWuK8Ig3CdOnT2/wPmt15Nzd3e2PEd3d3RvciKvFarVitVqv3FAgaERKjRZ+OZbKikMpFBqUH8dgD0fu6hd6iQCX7cUXmhqj2cob6+KITcnHSatm/sRoQjwdxLnT1OQlIeWcBQd35PFvgW+kEiveCPQIcUdGJjY5nzKjuUE80mUmC3+czWZTXAbHUiRgGABOWhVDOvsyKtKPLv4u9muG+H41Mee3I21ZoGS0yTmL1qxkppGRKTWa0GsaxxFgNFs5eDEXGZn+7Txa3HF30KiQkSkxmFqcbVdDfqkJGRkXvbpFb1dLtu1KzJ49u9Zt65OwpFZC/IsvvuC1117jmWee4YsvvqjzIA3NkiVLWLJkCUajMvknOzsbnU7EtwqahzKzlc2nclkXl01R+SRMf1cdk2N8GBjuhkqSycrKbFYbzVaZf+1M5s+kQnQaiZmDg3GlhIyMkma165pE8kXbdzZWJz8sshdkZDTaUHpZxkUDeaVGNh05T59Q13r1I8sypzNL2XEuj/2JhfbiMJIE0f7ODIlwp3eIa7nQLyUzs7QBt0JQK2QZh1OrcI79BpAx+vemcMDTUFCGSrZgMFtJSsvA6NI418ojKUUUlRrwdNLgRgkZGS3rO2AuK8ZsMpOVW0BGI55zTU1mXhFmkxlzaVFj/pRcNdnZytOSESNGoNVqmT59eqN4lxuDQ4cOVXr/559/Yjab6dKlCwCnTp1CrVbTp0/9nmzW+lnG/Pnzeeyxx+qVI7GhsR3ApKQkQkND8fb2xs/Pr7nNElxjlJksrDuWxorDyeSXmgCJMB9X7uwXwtBOvi2mCqDVKvPextMcTS/FyUHHKzdG0SPUo7nNurbIOKGUgffuoLz3G99kQ4/rVspPh5LZeqGECX061GndzEIDW05msDk+k5R8m7BSEebjzJiOzoz0K8EzMBwcW06+6GsSqxl2fYAUvxY0GuToKTheNwNHlRKO4ep0AUupCRd3T/y8GydH+6kThWi0Gq7vEoC/fyOly7wK/NMsaLS5SDqHNqUXTCSg0WoIC/DF7//bO+/wOKqzb9+zVb0Xy5Isd0vuvQI2trHpBkLvkPB+IYaEmkBChwB5CQlviBMIEAKEYjqm2Lgb994tF7mpWFbvK22b8/1xtqnZlixpd+W5L82l3ZkzZ86enZ35zXOe8zxJ7XvQ7grchtMVK1aQltbxbnKdiW+Qkr/85S9ERkby3nvvERsrr3sVFRXcddddnR81RQj/DKefCTqdTsv0qdFlNNidLNxTyJfbCjzZAFOipQvKtEFJASPAQf5u3/jpMD8dKkWv0/G7izMZlRFYYcW6PXmbYPGTMmbznH9AVEqXHn7OqDQW7Cpk/8ka9p+sZXDPqFOWtzqcrHe5nuzMr8R96Q8zGpjSP4EZWUkM6RmFUrANvn8IYnrBDR90wSfRaJXlL8lkPYoCk+5DGfqzRuEkQ4x6lHoHVofolHulqgo2H6tAQXHlQgi8+3GY2YCCQoNdDcj2tZdaqwMFhZhwU0B/rkBuW1t49dVXWbx4sUeEA8TGxvLCCy8wa9YsHn744TbX2Sbvfi3clMa5TIPdyaI9J/liW75HgCdHhXDjuHQuzAwsAQ5ShL+z5ig/7i1CUeDhiwYG5CSqbk3OMljxorRY9hgGIV0/xyYu3MT0QUks3lfEF9vyGdxzcLMyQggOFNWwLLuYnw6WNIq1PDQ1mplZSUzul9B4op87dOEZZtTU6ESyrpAx6Kc9Br3Pa7bZ7JtdsxPIKamlos5GqFHPsNSYTjnG2RLaDaOm2Byqx01MiyPeNVRXV1NS0tzVtKSkhJqamhb2OD1tEuIDBw48rRgvLy9vV0M0NAIVq0MK8M+3+gpwMzeM68WFgxIxBGg2wI835fHNDplw5f7pA7hgYKKfW3SOsfcrWPt/MnNmv+lw4e9lqEI/cPXoVJZkF7HpaDl55RbS46SLYVmtlZUHSli2v4i8cq9Pb1KkmelZSczITKZHdCth6FyhC31jiGt0IQ4bGFz+3qmj4aZPwNxyiMoQgxShDZ0UMWSjK1rK6IzYgA1RGWaWcqc7RU1xp7fXKRDeidFwNLxcffXV3HXXXbz66quMHz8egI0bN/Loo4+eNqpga7RJiD/77LMBGTVFQ6MzaE2AXz82nemZSQErwAG+3JbPx5tyAbjngr5cNDjwfDa7LULA1v/IBWDIVTD5N52WyfBMSIsNY2LfeNYfLmP+5jwm9Ytnyb4itufKuM8g445P6RfPjKxkhqVGnz7MZrVbiPfs3MZrNOfoalj7Glz2KsT2lutaEeEgs2tC5wlxTzbNvoHr9ua2iDd0I4u4b1ZNzWOha3jjjTd45JFHuPnmm7HbpS4wGAz8/Oc/55VXXmlXnW0S4jfeeGO3muSgodESNofKor1SgFfUyQkmSZFmrhubzoysJIwBLMABfthdyLtrjwFw28QMrhyhCaUuZd83XhE+5k65+PkmKYRgRFoM6w+XsepgCasOeodWs1IimZGVzPkDEjzZB8+IKs01pcsRAnZ/DhvmuV5/Bhc8etrd3Mls3G4MHUlhVT255RZ0CozNCNxJu24h3p1S3GtZNbuesLAw/vGPf/DKK69w+PBhAPr160d4ePsnQZ/xt6c9bWl0d2wOlcX7TvLZlnzKXQI8MdLM9WPTmJGVHPACHGDF/mL+uVJeHK4bm8b149L93KJzkAGz4OAi+X9o+4YqO4pKi41VB0tYsq+I42WNQ1VePzaN6VnJpMa0I6GTqkK1dHvSXFO6CNUJ6/4Ge7+W77OugPMePKNdzS53Eauj40XoRpc1fGhqdED7KYeZvQl9hBDdQtN4smoGcL93V8LDw88qrb0v3SJqiobG2WBzqCzZV8RnW/Moq5UCPCHCxA3j0oNGgAOsyynltaUHAbh8eAq3Tczwc4vOIRw26f+tKK7oKPNA5x+fTYdTZcvxCpbuK2Lz8QpPAimjXsGg01Fvd2I26Lh6dBoR5nZa0ixl4LTJzxjZowNbr9EiNgssfQbyNspzbMK9MPz6Mx5pcVvErZ1gEd94VPqHj+8TuG4p4LWIq6rA7hSYOimxUVfizqqpWcS7jrq6Ol5++WWWLVtGcXFxs0RFR44caXOdZ/ztBXNWJA2NlrA5VJZmF/HpFq8Aj48wcf3YdGZmJQfspKOW2Hq8nP/98QCqgJlZydxzft9uYfEJChqqYdFjkDEZRt0q1/lBhB8rrWNpdhErD5S44tpLBiRHMNPlehJuMnD/x9vJLbewcHch141t54iJwQxTfgPWGr89cJwzWMrhh0eg7LDs9+lPQJ8L2lSFxz+6gy3i1Q129p2oBmBigEdkcvcByMgpwXR9bw1fH3GNruEXv/gFq1at4rbbbiMlJaVD7rPaY5TGOYfdqbIsu4j5m/Mo9RHg145JY9bgHkF3gd5TUMUfv8/GqQrOG5DA/dP7n36inUbHUFsiRVLFMajMhczLITSmyw5f02Bn1cESlu4r4nBJnWd9TJiRCwclMTMrmV7xjZOw/WxMKn9dcogFO08wZ2Rq+873kCi/u92cM5gi5BIaCxe/BElZba6isyZrbjlWjiqgd0I4yVGtRNcJEHQ6BbNBh9WhYrE7iCb4xas7akpUqCbluoqFCxfy/fffM2XKlA6rU/v2NM4Z3AL80y35lNRYARlj+bqxwSnAAQ6crOG5b/dhdwrG9o7loYsGaiK8q6jMhe8fgdoiCE+ES1/pEhHuVAXbcys84QgdTul6otcpTOgTx4ysZMZkxLYa1/78AYm8v/44ZbU2VhwoZvYQzbUkoDGYYNYLYKtrdzIos6FzJmu6/cMnBLhbiptQkx6rQ+02scSrNYt4lxMbG0tcXMee75oQ1+j2OJwqy/YX8+nmPIpdAjw2XFrALx4SnAIc4GhpHc8s2Eu93cnwtGgeuyQzaPzZg56SA/DDo9BQJaOGXPZqp/tK55VbWJpdxIoDJZ5oPgB9E8OZkZXM1IGJRIee/oZs1Ou4elQqb68+ypfb8rkoK7ntD28ndoDeJEPnmcJOV1qjrez5EmqLYeIv5fuQKLm0E3MnWMRtDpVtuRUATAzgsIW+hJn0VFrs3SZyihY1pet5/vnneeqpp3jvvfcIC+uYa5/27Wl0WxxOleX7i/l0Sx5F1VKAx4QZpQAf2sNjJQpG8issPPXNHmqtDjJ7RPLEZYOD+vMEFQVb4ccnwG6BxEFwyZ+k20AnUGd1sPpQCUuzizlw0pu1LSrUwLSBSczISqJvYuvxo1tj1uAefLwplxOVDWw4Wsbkfgltq2Dd61CWIz97r4ltPr5GK6iqDE24+3P5Pn0cpI4562pDOiGz5s78ShrsKvERJvq14xz0B57smt0kqU91vRY1pat59dVXOXz4MMnJyfTu3RujsXHfb9u2rc11dgshrqqqNplUw4PDqbLyYAnzN+dTVNMAQEyokZ+NTuPiockewRqs50xRdQN/+GoPFRYbfeLDefLyLMwGJWg/T9BRmY9it0DPUYiLngdTuBRQHYSqCnYVVLE0u5gNR8qwOWXdOkVhbEYsMzKTGNs71jP60Z7v3WxQuGRoDz7bms8XW/OZ0Dv2zCcdCYHiiiEuIlM69LOf09gtKMv/CLnrABDj/wd6jOyQ/jXrFQSCepujw64TG46UIRCM6x2LECIoIquFGPUIBBarvVtcL2sa7AgEEWZdwH+eQG/fmXLVVVd1eJ1BKcTnzZvHvHnzsNnk8GxZWRkmk8nPrdLwN05VsO5YFQv2lFJS65rEEqLn0sHxXNg/FrNBR1V5mZ9beXZUWOy8uPQ4JbV2ekabuH9yEpaqciyn31Wjo4ifgGnMA9hSxkBlHVB32l3OhKIaG6uPVLLuaBXlFodnfWq0mfP6RjO5TzTRIQbASUVZ6Vkfb2JPI59vdrI3v4LVe4+TmXRmw6xKQwVxDTUIdJRbdGAtPuu2nOso9eVErXsRQ+URhM5E7bhfY0uZDCUlp9/5DKivrcFhd1BZY6G4+Oy/L1UI1uw/icPuYGC00iF1dgkOKw67g8KScoqjA//B4XSUVVtw2J3Y6qopLrb6uzmnpKxM3nsvvPBCjEYjc+fOZe7cuX5uVdt5+umnO7zOoBTi7i8wPz+f9PR04uPjtYyf5zBOVbDyYAmfbs6nsFpawOOjQvnZqFQuGdoDs7F7uGxU1dv529I9VFgFafERvHj1UBIizP5uVvdHCNj/nQwZFxIt1yXN6ZCq621O1h4uZWl2MfsKqz3rY8JDuGBgAjMyk+ifFNEpoSiTgNnD6lm09yQrj1q4YGjvM9vxZBGKwQiRPUhK0ZL5nDVlh1HWPgl1pRCRiJj1PDHJQzv0ED2sJgzGk6A3dsi98sDJGuqcEBlm5vyhvYNmnk18dCWG4gZMYRFBrxlUVWATORiMCn1Sk4kJC2xjpNtwumLFCtLStGy8vgSlEG+KTqdDpwuOC4FGx+FUBT8dLOGTzdLXFSA61Mg1o9K4bHiKxy+yO1BrdfDMt/vIr6gnIcLMH68eRlKAhwvrFqgqbHoDdn0KBxfCla/LxD1nVaVg74lqlmQXsS6n1OO3q1cURvWKZUZWEhP6xHeJuLlmdBqL9xWxNbeS3PJ6eiecQZrmGldGzeg0FO26e/bUnJAiPKYXXPInlKieHX6IULMBBQWbU+2Qe+Xm4xUoKIztHUeIKXhkRJirHxrsIug1Q41VjvoqKESFmgL+8wR6+84Up9PJX//6Vz799FNyc3M9DxhuysvL21xn8PyCNDRcqKpgVRMBHhVq4JpRaVw6LIVQU/cR4CCtps8u2MuRkjqiQ408P2dowMfs7RY4HfDT/8LBH+X7fjPOSoQXVTewLLuY5fuLPJOHAXrGhDAzK5kLM5O6fISjZ0wok/rFsy6njC+35fPQrEGn38nlH66ltu8g+k6FmU9D6tizioxyKkI6OHxhsIUtdOOerGmxOU5TMvBxZ9UMM+kxaNGyuoxnn32Wt99+m4cffpgnnniCP/zhDxw7doyvv/6ap556ql11akJcI2hQVcFPh0r4ZFMeBZX1gAzbdPWoVC4f3rPbCXCQIcJe+H4f+0/WEG7W89ycIaTHaeHiOh17Ayx7Fo6vA0UH0x6DgbPbXE2D3cn6w2UszS5iV36VZ32oUS9dT7KSyewR6dcsqNeOTmNdThmrDpVy66QMkiJP85BX7bWIa7QDVYVt70HmZRDhco/oN71TD+keHeyI8IUnKuvJLbeg00mLeDARZuq4fvA3WlZN//Dhhx/y1ltvcdlll/HMM89w00030a9fP4YPH86GDRv49a9/3eY6NSGuEfCoqmB1TimfbMolv0IK8AizgatHp3JFNxXgIKO/vLxwP7vyqwg16nn2yqHtClWn0UasNbDocTi5W8bKvuhZmb7+DBFCkF1Yw7LsIlYfKvWESlMUGJ4WzYysZCb1jQ8Y16kByZEMS4tmd34V3+4s5Ofn9Tn1DkOvgeQh0HNU1zSwO2Gvh+UvwLE1cGw1XP0v0Hf+bdidWdPqUFFVcVZJvzYdldbwYalRRJiDS0K47xXdIY64O4Z4lBZDvEs5efIkw4YNAyAiIoKqKmlgufzyy3nyySfbVaf2DWoELKoqWJNTyiebc8kr9xHgo1K5fEQKYUHkm9hWVFXw6pKDbD5WjlGv8OTlgxnUI9LfzTo3WPmyFOGmCJlSPGX4Ge1WWmtleXYxy/YXeVymAJKjQpiZlcT0zKSA9eu/eEgPdudXsfdE1ekL9xgmF422YSmXD3gl++UD3shbukSEA41yDNicKiG69j8Ebjwqo1+M7xN/1u3qaryuKcEvxN1ZNaPOIImXRseRlpZGYWEhvXr1ol+/fixevJjRo0ezefNmzOb2uRZ2XyWjEbSoqmDt4VI+2ZRHbrkMzBdu1nP1qFSuGNGzWwtwkJ//9eU5rDlUil6n8IfLshiWFu3vZp07TLwXak7Chb+H+H6nLGpzqGw4Usay7CJ25FWiuiKihRh1TOmfwMysZAanRJ2VBbIr6OVydyqoqEcI4VdXmW5J+RFY+BjUFkk/8NkvdunDjNln4m+D3dnu0Ziqejv7TsjoPhODzD8c8Nw7uodripZV0x9cffXVLFu2jAkTJnD//fdz66238s4775Cbm8uDDz7Yrjq1b1AjYFBVwbrDZXy8KdcjwMNMeq4alcqVI3oSHmTDoO1BCMFbq4+wNLsInQK/nT2IMRnBd8MLOmwWb6r26DT42dvSl6QFhBAcKq5laXYRPx0soc7qvakPTY1iRmYyU/onBJXLVEpMCIoiLYVV9fbWQ6HVFsvRgtjep31I0XCRtxmWPg22OnluXfKnLvev1+kUzAYdVod6Vtk1txwrRxXQJyE8YEd3TkWoST6QdAuLeL3bNUWziHclL7/8suf1DTfcQK9evVi/fj0DBgzgiiuuaFed3V/ZaAQ8qirYcKSMjzblcrzMK8DnjEzlypE9g84P8Wz474bjfLerEIDfzBzA5P5tTD2u0XYKd8LiJ+HCP0CvCXJdCyK8os7GigPFLMsu9jwoAiRGmpmeKdPNp0SHdlWrOxSzQU9SpJmiaiv5FfWtC/ETO2DFH6V/+BWvdWUTgxNVhc1vSxGeMgJmvdBpkVFOR4hRj9WhnpU1eKPLP3xC3+A0DoQa5b2kO6S4907WPHfuj4HIpEmTmDRp0lnVERAxb+bNm0fv3r0JCQlhwoQJbNq0yd9N0ugCVFWwLqeU38zfwUsL93O8zEKoSc9N43vxzp3juHlCr3NKhH+6JY9Pt8jQcPdO68f0zGQ/t+gc4Nha+P4RaKiCPZ/L5D0+2J0q63JKee7bfdz57ibeXXuM3HILRr3CtEGJPH/VUN6+fSy3TswIWhHupmeMbL87IlGLVBfI/9Fa6MIzQqeT4nvYdXDpn/0mwsE7YbO9IQytDifbjlcAMCEI/cPBO1mzvhtYxGus3T9qSkFBAbfeeivx8fGEhoYybNgwtmzZcsp9rFYrf/jDH8jIyMBsNtO7d2/+/e9/d1ib3BlCAfLy8njqqad49NFHWb16dbvr9LvKmT9/Pg899BBvvPEGEyZM4LXXXmP27NkcOHAg6DNfabSMEIINR8r5eFMuR0tlevBQo54rR/Zkzsie3frC0hrf7jzBB+uPA3Dn5N5cOizFzy06BziwCFb9CYQKGVNkLGeXJfxwSS3LsotYeaDEY3kCyOwRyYysZM4fkNDtXKVSY0LZnltJQcUZCPEoLXRhqziskLcJ+pwv30ckwuT7/NsmvBM222sR35VfhdWhEh9hol/iGSR+CkDCTN0njnh39xGvqKhgypQpXHjhhSxcuJDExEQOHTpEbGzsKfe7/vrrKSoq4p133qF///4UFhaiqmcfP3/37t1cccUV5OXlMWDAAD755BMuvvhi6urq0Ol0/PWvf+Xzzz/nqquuanPdfv8G//KXv3DPPfdw1113AfDGG2/w/fff8+9//5vHHnvMz63T6EiEEGw8Ws5HGxsL8CtG9uSqc1SAAyzZV8S/fjoCwA3j0vnZGE3kdDo758OGf8jXAy+Gqb+lqkFl5Z4ClmUXe85PgLhwE9MzZdSTgIvh7rSDztCqP3tbSI09A4t4lVuId3z2x26BpRx+/AMU75MPdp0cH7wtmD0W8fYJ8Y1HpCVwQp/4oJ3M67aI250Ch1MN6kQ41fXdO2rKn/70J9LT03n33Xc96/r0OXVo1UWLFrFq1SqOHDlCXJx0n+rdu3eHtOe3v/0tw4YN48MPP+SDDz7g8ssv57LLLuOtt94C4P777+fll18OPiFus9nYunUrjz/+uGedTqdj5syZrF+/vll5q9WK1erNSFdTUwOAw+HAbrd3foM12oUQgs3HK5i/uYAjLoETYtRx+bAeXDkixSPAz8XvcHVOKa8vy0EIuGJ4D64fnXJO9kOXIQS6Le+g7PoYAMeQa9mcfB3Lv89my/FKnK6wJwa9woTecUzPTGREWjR6V9STgPpuSg6gX/Qooudo1BnPnHV1PSJNCCHIK69r+XOqDvQVx0AInGFJEEh9EQhUHEO/5A8y4o45EqcxKqD6yKRXEEJQZ7W1+Tx2z+MRQjCmV1Rg/Q7agAEV4XI/q7ZYg9qaXGmxIYQgzBBg16VWcDjkg0NNTQ3V1dWe9WazucWwfwsWLGD27Nlcd911rFq1itTUVH71q19xzz33tHqMBQsWMHbsWP73f/+XDz74gPDwcK688kqef/55QkPPznVw8+bNLF++nOHDhzNixAj+9a9/8atf/QqdTj7M3X///UycOLFddfv1LCwtLcXpdJKc3NgXNjk5mf379zcr/9JLL/Hss882W79s2TISErRJbYGGEHCkBtYV6Siql0LGqIPRCSpjEwShZaWsXr7Hz630HznVsOC4HlXA8DiV5MpyFi7c5+9mdW+EYGDRJhIqq1hsns37a/pgcWz1bO4RKhgSJ8iKFoQ4yji55xAnA/QU1TutnFdyAkpOsK0ylZrQs/PbrrZBVZWemuoqvv3+B/RNjJ6J1XsYXHICmyGCDRuyEcrBszpedyKm7jBDTszH4Gyg3hTP7vhrqN9eANsL/N00D4X5OqqqFdZu2EzNQXH6HXw4UQfHC/WYdJC/cx2FuzupkV1AbbUep4DvFi0mupU5yYGOEJBfJO8dG9esIjsIPkdpaSkAgwcPbrT+6aef5plnnmlW/siRI/zzn//koYce4ve//z2bN2/m17/+NSaTiTvuuKPFYxw5coQ1a9YQEhLCV199RWlpKb/61a8oKytrZFlvD+Xl5fTo0QOQiXzCw8MbucnExsZ6jMNtJageBx9//HEeeughz/uCggIGDx7MjBkzSE3VJg8FCkIItuVW8snmfHIq6sAEyeE6Lhnag6tGpHTbobS2sDO/iv/8sJ/IKMH5A+J5YHr/gI81HezUNDhYk1PKvyyp6Op2cECfiTEceoUamTowgemZiWQEmuvJadAt341ydBVTYwpQZ7RuKToTVFXwVclmbA6VMVNGeCZveo+1BaUuGjHyFi4Z074wXd0R5eBCdGu/hQgzJI8hfOZzXBgSeHH/s5ccoiynjCHDM7h0eNvmoHywIZfo0hOc1z+eKy4a0Ekt7BrmF22husHB5AuGB93v3Y3F5uDtXDlp8erLxmEOkCy9p6KgQD6U7tu3r5Feay0JjqqqjB07lhdffBGAUaNGsWfPHt54441WhbiqqiiKwocffkh0tPwN/uUvf+Haa6/lH//4x1lbxZu6ZHWUi5ZfhXhCQgJ6vZ6ioqJG64uKijxPHr40HcJwD28YDAaMRk3c+RspwCv4cGMuh4pqARky67LhKVwzKo3oMO07AsgurOblRQdxqDCxbzwPz8oMal/FQEZVBTuPFFC09gPeqp2CTZX9rDMPZnKfOGZkJjEmIzZ4+v/YGijOhnG/kH7h4+6GYz9B7lr0tScgNuOsqk+LDeNoaR1FtQ4yEpv8Xmc+DcfXQtJg9Nr1VlKcDWtela8HXARTf4fOEJjmyVCTEUVRcKhKm++XW3IrURSFSf0Tg/5eG2Y2UGN1Ym9HPwQKDfVOFEXBqFeICAuOeO4Gg5SbkZGRREWdPnpQSkpKM+t5VlYWX3zxxSn3SU1N9Yhw9z5CCPLz8xkw4OweIu+8806PBm1oaOCXv/wl4eFy4rKv23Rb8asQN5lMjBkzhmXLlnkc3FVVZdmyZdx3n/9nmWucGW4B/tHGPA4WyaEZk0HHZcNSuGZ0ausxic9BcopreWbBXqwOlVG9YvjtxZoI7wzyKywsyy5m494crit5nX7OfC43F7Et/Q5mZiUxbWBS8D0YHlkFy54F1QlxfaH/DIjrIyO+HF8LOz+Bab87q0OkxoZytLSOgkoL0CRWtN4AfaeeVf3djqQsGHEjGMww5q4OmTTbWbjDF1odbZusWVBZT155PTqdwpiMU0esCAZCTQbAGtRJfTzJfLrx6PKUKVM4cOBAo3UHDx4kI6N1Y8OUKVP47LPPqK2tJSIiwrOPTqcjLe3sgiA0tcLfeuutzcrcfvvt7arb764pDz30EHfccQdjx45l/PjxvPbaa9TV1XmiqGgELkIItudV8tHGXA6c9ArwS4el8DNNgDcjt8zCU9/swWJzMjglit9fmoXJoInwjqLO6mD1oVKWZRex/2QNcWoZv6z9J8mUYoqKZ8Yld3LXwJH+bmb7OLwclj0vQy32nwl9p3m3jbpFCvFDi2Hs3TJcXjvxxBL3DWHodICikzGxNaC+QvaH2/1kwi8DWoC7cae1b2sc8U1HZbSUYalR3SKvQ+hZRo8JBKobun9WzQcffJDJkyfz4osvcv3117Np0yb+9a9/8a9//ctT5vHHH6egoID3338fgJtvvpnnn3+eu+66i2effZbS0lIeffRR7r777rN2SzlbH/NT4fdf1Q033EBJSQlPPfUUJ0+eZOTIkSxatKjZBE6NwEEIwQ6XAN/vEuBGvcKlw1K4dkyaJsBboLCqnie+2UNNg4MBSRE8dcVgz41Ro/2oqmBXQRXLsotYd7gMmyt9d0+1kEecb5MSWUtYfF90l70KMel+bm07ObRUZrMUKgycDVMfayyKk4fIrI2FO2H/dzC2/UaMtJaS+uQshS3vwKhbYfCcdtfdLag4Doseg/AEuPRVMJiCQoSDb0KftgnQjUdc2TSDNIlPU8JMUvYEtUX8HMiqOW7cOL766isef/xxnnvuOfr06cNrr73GLbfc4ilTWFhIbm6u531ERARLlizh/vvvZ+zYscTHx3P99dfzwgsv+OMjnDEB8S3ed999mitKECCEYGd+FR9tPE52YWMB/rPRacSGawK8JUpqrDzx1R4q6mz0ig/jmTlDul0ymK7mZFUDS7OLWL6/mJIar29eelwoV/esZNrR/2C0N0Bsf5nR8CysxH7l4I+w8mUpwgddChc82rJletwvoK4Y+l54VodLc8USz/e1iGcvgNpisLYvIkC34cR2WPyk7AchoL4cIpvPZQpUPBbxNrimVNXbyS6Uc7Em9AnOtPZN8WTXDGKLuDe9ffe1iANcfvnlXH755a1u/89//tNsXWZmJkuWLOnEVnU8mhrQOC1CCHblV/Hxplz2npAXZaNe4ZKhKfxsTBpxmgBvlUqLjSe+3k1xjZWU6BBemDO0Ww8ndib1Nidrc0pZtr+IPQXeOLThZj0XDExkZlYyA2L1KJ/cBPZaSB4KF7/k17TiZ0X1Ca8Iz7oCznuodfeQlOEdckh3Up9Kix2LzUFY9TEo2gs6vXwQOFc5sAh+egVUhxyBmPUChAWXMDUb2p7ifvPRclQBfRLCSYoKjkmBpyPU6E5zH7zZNbt7Vs1zDe1b1Dglu/Or+GjTcY/wMeoVZg/pwbVj0oiPaDnskIakpsHOk9/s5URlA4mRZl64eqg2atBGhBDsPVHN0uwi1uaUekSEosCo9BhmZCUzsW98Y1/7ab+Hfd/AjCfBeHZ+gX4lqqe0gJcehMm/PnMfbaddWmzbEb0jzGQgJsxIpcVOQUU9Aw58LTf0uSDohGeHIARs+Tdskz6o9J0GF/5eTs4MMtwW8bZM1tzo8g+f2Ld7uKWAb5r74LSIN9idnlGKKE2Idwu0b1GjRfYUVPHhxlz2FFQBMtOgW4AnaAL8tNTbnDy9YC/HSuuICTPy/FVDSYrsHhalrqC4poHl2cUszS6mqLrBs75nTAgzMpOZnpXU+Dysr4TQGPm61wRIHx80vruNsNXJNOluf/bMS4E2WKIPLoZN/5KRPIZd264mpMWGUmmxc6KknAE5y+TKc9U3fOObsFNmYWXUrTD250E7abWtkzWtDifbcysBmNC3+zyEBbNrypGSWv68+AB55dJ1bGR68Eex0dCEuEYT9hRU8dGmXHbnewX4rME9uG6sJsDPlAa7k+e+28uholoizAZeuGooqTFBbJntIhrsTtYfKWNZdhG78qtwZaIm1KjnvAEJzMxKJislsnESBbfFMnsBXPl3r4ANRhFemgNLn5af6Zp/gTmi7XU4GqCuRIYyHDwH9G13g0qNCWVPQTVKzmKwW2Sfpoxse1u6A4MuhoMLYfz/QOZl/m7NWeEV4mcmQHfmVWF1qCREmOibEN6ZTetS3K4pDUFkERdCsGDnCf6z7hgOpyAmzMhDFw1kWFrgJY7SaDuaENcAYO8J6QO+M08KcL1OYdaQZK4bk05ipCbAzxSbQ+XlhfvZU1BNqFHPc3OGkBHffW5iHY0Qgv0na1iWXcRPh0qp97k5DkuL5qKsZCb1i285woyqwtrXpBsKQP6m4I2Msv8HWPNXcNogIkmK6fYI8YEXw9Z35f45S2HQJW2uIjU2FIQgIe9HMAFZc4Lzwaa92BvA6Bq9iu0NN34MpuDMwOhLW33ENx6RbikT+sZ3WAbBQMDtmlIXJEK80mLjtaWH2Hq8AoBxveP4zYwBwZcHQaNVNCF+jrPvRDUfbTreSIBfNDiZ68amaa4UbcSpCl5dfICtxyswGXQ8feVgBiRH+rtZAUlZrZXl+4tZll3cKFRecpSZ6ZnJzMhKIvlUk8McNlj5IhxeIUXilAdgyFWd3u4Ox94gHyYOLJTve02UPsjtTZFuMMGw62HjG7DjIxgwu82uFKkxYaAofB15C4P75MiQiecKJ3bA0mdg+pOQNkau6wYiHNrmI66qgk3H3GELu49bCrgT+gSHa8rW4xW8tvQglRY7Rr3C3ef14bJhKd3qwUijmwhxVVVR1bYlKTjXyS6s5uNNeezIrwRAryjMHJzMdaNTPbPjtT49c1RV8H/LDrH2cClGnY4/XJpJVo9IrQ99sDlUNh4tZ/n+YrbnVaK6fE/MBj2T+8UzMyuJISlR6HTyJtNq39ktKEuegoKtoDMgpv0e+l0oLeSdiRAoy59HpAyHrCtlUpezoTIXZekzUHEUFB1i7N0w4iZZ79l8lszLUbZ/AJW5iGNroPd5bdo9JdqMQLDVkoRjypXy+zgXzuNDi1HckVF2foRIGdmtRgJMehAI6m3O016XsgurqbDYCDPqGZzSva5jZr3i6gdHwH4um0Plgw3H+WbnCQAy4sJ4ZNZAMuLDEUIg3H57QUSg9nUgEJRCfN68ecybNw+bzQZAWVkZJpMWjeJMyCmt5+vdJewprANAp8D5/WK4fHA8iREmaKimuKH6NLVo+CKE4P3NJ1mRU4lOgXvOT6On2UZxcbG/m+Z3hBAcK29gzdEqNhyrbjQcPCAxlPP7xjC+V5Qr2YiV0tKSU9an2GqJWvM8hopDCH0INeN/iz1yCHRBXxsLtxB1cDEcXIx997fUjb4XZ3SvdtcXsf5vmEsOoppjqJnwEI7EoVBS2iFtDU2fQdiBL3BseIeq0AFtEpSKKlAdDurscOD4CeLDu/kQuBCEZn9KWPZ8AKw9J1I74tdQcupzMdiorXfgsDuoczgoKio6pVV12e5iHHYHWT3DqCjrmHMyUGios+CwOyivtgTkNfpElZU31hWQWyHzI8wYGMsNI5MwOesoLq7zc+vaT1mZdHW68MILMRqNzJ07l7lz5/q5VYFBUApx9xeYn59Peno68fHxJCUl+btZAc3Boho+3pTH1lzpZ2YyGZmRmcT1Y9NO7QKgcUqEEPxn3XFWH6/FaDTy8EUDuGBgkCaP6UAqLTZWHixhWXYxx8strrUKyTHhTM9MZEZmkiedepuwR6KEhoEtHnHxy8QmZXVou1tkwz/AXg9DroYLHkbZ/BaG6iOErnoMMeJGGHXbmYWzUx1QV+pNAjP7SZR1ryMm/oq4jg4NOOlOlGMLMdQcw6yvgoSBZ77vvm/4f/pVfKtOxmYYQVJSTMe2LZBw2lB++jPkLAGDETH8RsLG30PY2Y52BCCRNicG41EAYuISMJ8is+++knwMRgPTh6aRlNS9rmc11GIwFiB0hoDSDUIIFu8r4u3V+VidKnGRofx6en/GdxPXILfhdMWKFaSlpfm5NYFFUArxpuh0OnRBGlKqszlUVMOHG3M9Ez30isL0zGRuGJdOj2hNgJ8tH2/K5esdJ1BQmHthf6ZlJvu7SX7D7lTZfKycZdnFbDlegarK4VOTXsekfvHMzEpmRFqMx/WkXZjD4ZI/QX0FSmxGB7X8FKgqHFwksykOnA3DfiZjaq99DY6tQdnxIRxdBec/BKljmu/fUA15m+D4Wvk/qif87C25LSwWZj5Fpzg/hMfLBEDx/VASB535fqoKez5nXEMOe3UpFFQ1MCqjm15b7fWw8HdQuFO6A533IMrgK/3dqk4j1KSguM42mxNCzS1/rwWV9RRUNqDX6RjbO77b3VvDQ4woKDTY1YD5bDUNdv6+PId1h6XVeFR6LA9eNLBbJcsLlL4ORLqFENdozqGiGj7alMuWY1KA6xS4MDOJG8alkxKthdLrCL7eXsBHG3MB+MX5fbh4aPCku+5IjpTUsiy7mJUHi6mu92arG5gcyUWDkzhvQCIR5rO41BRnS7E04kb5PiSq67JlFu+TItwcKTMqAkQkwuw/wtGfYO3/QVU+rP4LXP++zEBZlQ/H18GxNXByt8yM6aauRMYKN3VBJJ3MdmTCPLEdqvLRmcLYphtDvG+q++6GIQQiksEYBhc9K2PPd2N0OgWjXsHuFDQ4nETTssuRO1rKsNQows/mdxughPnEEVdVcXaGgQ5gd34Vry45QFmtDb1O4Y7JGcwZkdqx7RJCPnjWFMqHTks5WErlhO6KY9K4MP3JdiUB0zh7ut+v7Bwnp1i6oGw6Kme86xSYNkgK8Ha5Ami0yKI9hbyzRg7z3jKhF3NGpvq5RV1LVb2dVQdLWJZdxJESr99iTJiR6ZlJzMxKJj2uA6JN5G+FxX+QN5HwROg/4+zrbAt5G+T/tHFSZPvS5wLoORo2vy1fu7dvfgcOL/eWi+0NGVMgYzIkDfZPQpgzFf/ZMhRkdfqFWE+EcKKyGwtxRYGpv4XRt0FM+339g4kQox6704H1FCEMNx6R947ulE3TF99QqA0OJ2Em/8ggh1Pl4025fLY1HyFksrJHZ2fSP+kMw5aqKjRUQkOVfKC0lMll2/tyIrsvepMMjdoaR3+C0gPQY1i7P49G+9GEeDfhcEktH23MbSTApw5M5IbxvbRkMh3MigPF/GPlYQCuGZ3KDeOCNHZ1G3Gqgq3HK1iWXcTGo+U4Xa4nBr3C+D5xXJSVzKheseg7ypJzeAUsf0H6VqeOgV6TOqbetpC7Uf5Pn9DydnMEnPdA43V9LpA3x4zJconq2alNPCW+sdYzJsu29ZoIoS1k5Ksrk1Z8kLHDT9Q0Ci3ZLchZJj/j9CflA5HeeM6IcJAitKbBQUMrIQyrLHb2n5ST9buLb3JTzAYdOgVUIdPc+0OIF1bV88qPBzhUVAvARYOTuef8voTqnFBTJK8fiQNlmFZLmUxadngZqD7fm6JrPNp2KpqK8NjeEJ4AhbvkttG3Q9KQjvlwGm1GE+JBzpGSWj7elMuGI40F+PXj0kmL7R7xbwOJdYdLeW3JQYSAS4elcOfk3t0+pmtumYVl+4tYvr+YSovds75fYjgzBydzwcBEokI6OLLGvm9kghshoO9UuPCJrh82tZRD6UH5ui1uC/0ulEsgoNN5b97H18lF0Uk3m4wp0HuKV4ge+F6W7TGUpN5ZwCaKa6xYHU7MhtYn9gUFQsD2/8rRC5AjHO1x3QlyZHSi1rNrbjpWjiqgb2J4t80joSgKoSY9dVZnowRinYIQ0rXNbbnuMYwV+4t5c8VBptcs4DbnNvqH1xOZY4CcJvsaw2Rm21brbiLCjaEQFi9d4wBMEZAwAAZfCYlZEBoj3bG6+f0qGNGEeJBypKSWTzbnsd41uUNR4IIBidwwLr1jXAI0mrH1eAWv/HgAVUh/+/93Qd9uK8JrrQ5WHyxhSXaRx2oDEB1qZNqgRGZkJdOnM9JeCwHbP5DuHSBvIlMe9I87R57LGp6YCR0d1aQrueARme7++Fq5lB6Svusnd8POj+A2V2bS7G/l/6w5RIcaCTdLsVJY2UDvYE5x7rTD6le9SZOGXy8zkJ6DhBjcae5btqR6smn26Z5uKW5CjfLcbu2B5JSoTqivhPoKsFY1nqS942OZ0basqaoGpxDk2BOIqS7nebWWUJOO5JgQjLomMkxvlOesW4S35FYy4ZcwYBboDXK7EN0m8dS5iCbEg4yjpXV8sinXM7taUeD8AQncOK6XJsA7kT0FVbz4QzYOp2Byv3h+M2OA3yf5dDSqKtieV8my7CI2HCnD7pSuJzqdwriMWGZkJTO2dyxGfSeK4uJ9XhE++nYYe7d/LTjRadCrFbeUYEFR5DB34kAYe5cc+naL8oge8iHH3gCDLoVjq6HvNBRFoWdMKIeKajlRWR+8QryhGpY8JSehKjqY8msZhvIcxR2ysCUBanU42Z5XCcDEvkH84HkGSHcUmzevgb1eCuv6CnnOZPi4wW3/L+RvhorjcntT0idIa7elTE7GboE6zJSUV6BzHidSgbgIE7FhJm/EpNAYmDhXHtcUIeurrwBzFBxaDDs+lJZ1gNTRcln4qGzTHd9qIjzI0YR4kHCstI6PN+eyLscrwM/rLwV4r3jtR9iZHCqq4blv92FzqIzJiOWR2YM6zg86ACiorGd5dhHL9hdTVuu1vGTEh3HR4GSmDkwkJqyL3EKSh0hrj94Iw67tmmO2xqBL5OJ0nL5sMBGZDEOvkYs7Q58xRIr0MXd6HnzSXEI8P1gjp1QXwsLfQmWuHOaf+bT0jz+HcbumWB3NLeI7ciuxOVQSI82dM9rVlagq2Gqke1lDpRTXfad6Nk+r/Z642u30+hFwljXfP+sKl7guh6I9zbcrOgiJlmLZPXLWUjMu+B1fVA3kv1tOEhVewZCQUq67YBRxGb0gJKb1kT5zlAx3uvltqC2S6+L6ymtj+nj5G7VZ5PyZk7uD31hwjqMJ8QAnt8zCR5tyWZsjs5spCkzpn8BNmgDvEo6V1vHUN3uptzsZmhrN45dmdq5FuIuw2BysOVTK0uwisgtrPOsjzAamDkpkZlYy/RLDu8b1xt4AjgZpFQIYeVPnH7Mt6LvxZbLp9+vz3j3HJD9YJ2w2VEoRE54IF78MCf393SK/E3IKi/hG10T/8X3iAtPlzmFzWYrLpWtIQxUMnOXdvuktyN3gsmpXNp7YCDDuF2CthrpSJld+j8XhxFAXAiGu37feJF3Qak563bRa4oJH5eiRTgeVeXBiG4QlSP/s8AQ5EVqnp7imgb8sPsjeEycBGJE5kHunXXJmISHry+GnV6RLSngijPs5DJjdWLj3HAUHCuXxNSEe1HTjO0xwk1tm4ZPNuazJKfUYrab0T+Cm8elkxAe5tSJIKKis58lv9lBrdTAwOZKnLh8c1JPWVFWw50QVS/cVse5wmccqplNgVK9YLhqczLjecZgMXfig0VANix4H1Q6XvxY4Q6zVhfKmqu/m6d1PQWqsjLZUEKwW8aQsmPVHGSEiontlh2wvXh/xxiJVVQWbj3Vx2EIhpB+02yXE7RaSdbm3zIY3pLtUQ5XXNaMpLnHNzo+bbzNHSmFcmeudqAvoXA8aqvvmet6Dch6FokDZYRldJ9xHXIclSJHe9HoQky6XJqzNKeX15YeoszoJNeq5d1o/Lsw8TRbPmpPerLvhCdI1T1Fg6LVyxKopqWPgwA/NQxVqBB2aEA8w8sotfLypsQCf3C+em8b3Cl4/zSCkuLqBJ77aTaXFTp+EcJ65cjChpuAU4UXVDSzLLmb5/iKKqq2e9WmxoczMSmbaoETiI84gRXtHU1cKPzwC5UflDbP6ROBYLRf/QYrxi1+CniP93Rq/4A57WlBpQQgRmFZSX4SAXfOlpdCdTTR9nH/bFGCYW4macqCohkqLnTCTnqE9zyJZlju2dX1F4wmNQ3/mLbPu71JcW8pbjm0dnSpFd2viOixeiuuyHFjxx9bbcv7DcrI3QPF+2P2ZR1Sv21/PTwWCi8YM5vJJw8Hgc/2L7yeXdtBgd/Kvn46wZJ90JxmQHMGjswedOolebQlseQcO/ghXvg49hsr1o2879cF6jpL/y3Lkg0pIdLvarOF/NCEeIOSVW5i/OY+fDpU0EuA3jEunb+IZBvjX6BDK62z84es9lNbaSI0J5bk5Q4js6PB8nUyD3cm6w6Us2VfMnoIqz/pQk56pAxOZkZXEoORI/4mryjz44VGZ6S0sHi77s/SBDARqS6RVTFEgro+/W+M3UmJCUBSoszqprncQHRbAvwGnQ4a73P+dtFxe917XZV8NIkIMLfuIb3BFSxnbOxZDU9c7h83Hau3jFuLrQrbmr3BklVzfUmzrXpPAWiuzOe7+rPn2qJ5SXBfthW8faP0DTP0tZF4mX5/cDRvf9LFYxze2Ykcke/dLyoQZT3rellYc5khRIRWGxMYi/CzIKa7llR/3c6KyAUWB68akcdP4Xs370421Vj5o7PrU+0BSsMUrxE9HeDzEZsgJmyd2NPKB1wguuoUQV1UVVT3DwPYBRkFFPfO35PHToVLPMNnEPvHcOD6dvi4LeLB+tmCkut7OE1/tobCqnuTIEJ6bM5ioEENQfAdCCLILa1iaXcTaw2XUu6xeCgoj0qKZkZXExL5xHvcaIQTC/dTXlZQeQln0O3ljj0pFXPoKRKZIa1ogkLteRjNIGowwRQZOu7oYo04hIcJEcY2VvPI6IgNV2NpqUZY+I4foFR1ixM0y8sQ5+r2dCrNBhxAqDkslavkxj9XavmsbFzVUMKL3/d5r3eo/oxxe0Wosa5F1pRSQdaUoR1c3jygS21taaQt3wsetz/sQbp9rgBPbUVa+5BHUIizBK67DEqSl2t2+pCFwxd9O/YFbOQdCjDoEgjqr46yv7aoq+GbnCT7YcByHKogPN/PQRQMYlhrt2t6kfqcdshegbHtfutUA9BiOmPD/ZObdtrQnZRRKxXFEwVboff5ZfY7OJhjuof4iKIX4vHnzmDdvHjabfIosKyvDZOriZB9nyclqGwv2lrLhWBWuBIWMSovgqqGJZMSFgFpHcXHdqSvR6FAsNid/Wp7L8fIGYkIN/Oa8ZFRLFcWnyKkQCJTV2Vl3rIo1R6ooqvEO9SZHmjivbzSTe0cTH24EBFXlLUQI6EIMpdlErX0BxVGPI7oP1ZOeRNTrob7Yr+3yJfLACkwOO5boLOqLA6dd/iDODCfKHew7fpIEQ4O/m9MMXV0xkWv/iKEmD6EPoWb8Q9iTxsK59r2pThRrFTrXojRUobNWorPVYhlys2cSbta+13ilag3RO8CZI0c47E7BtEorigIG410UF6ko9joiT2RjrK9qdBhHTD9UczTGsmyUty9qtTm1o3+Ftc9MAIxFu4hc8xwiJBo1JA41NA41JNbz2m7oier+vgypMPPvrX/OGjvUnP13a6+vw2F3UFJRTfFZnCuV9Q7eWn+CvSflvXpMeiR3j08h3Ghttd6oVU9hLJWRWJyRadQNvQ17ylhAafN5a4zKwtyzBGv4AOwBfs6Xlcl7z4UXXojRaGTu3LnMnTvXz60KDIJSiLu/wPz8fNLT04mPjycp6TQTIQKEgsp6Pt2Sz6qDJahCoDMYmNg7jpvGpdMvSXNB8RcNdievLthHQY2DuMhQXrp6aEDHZbc6nGw8Us7S7GJ25lchkE9zkWFmpvSLZ0ZWEoNTogLPrzfUiRIWDdFD0M/6I4mmAJv34LSjVGSDwUjk4JlEJgbHdaWz6J9Sy/5SK7XCFHjX2JL9KGufco2s9EDMfonYhAH+blXH0Si2daXX77qhCib+yiOuleUvyPTnrRBx/v+T4RuBWrMBgQqKAYPBCIqO/JAMdlsUBpuK6P/TAzKCkdtVwuB1RxIXPIrebbku2IrywyPydUiMdJNwW7DD4onOGA3u307ChTDkQtAFzhyb5JNODMYK9KaQdp/Xm46W87flx6husBMeYuIX5/dh1uDklq+5QngjEg2fg7K5BDHmTvSDLsV0Nv2SNAuGzSJw71Re3IbTFStWkJaW5ufWBBZBKcSbotPp0Pkj814bKKyq55NNeaw8UOyxgI/vHc/NE9LpnxTp38ad49gcKi8u3M/+kzWEmww8f9VQMhIC76FICMHBolqWZhfx08ESLD7pmYelxjAzK4nJ/RICe1JpdCpc+TcIT0Lp6pT1Z0LhHimAQmNREgf5J6NnAJEWF4aCwonKhsC7xu6aL8VpfH+4+GWUQI+M0jS2te9/azWc95BXrC15Go6sbL2ucT/3RhgyNpkIGBIt+yQ0FqoLUL5/SJ7TljKSqqsoQl5LFIDzH+afe9PJttTwu2G1KAde8tZjjmwUNUSJSvH+HnoMg5vny+0+kURafOwPtPMGiAgxoqBQb1fbfF5bHU7eXXuM73cVAtA3QU7IbNFwU3EMNv4L+lwAg1zZXAddAv0uRAmUCFFdRMBdPwKIbiHEA5mTVQ3M35zH8v1FHgE+tncsN4/vxYBkTYD7G4dT5U+L9rMzr4oQo45nrhxCvwCbHFteZ2PF/mKW7S8ir9wbSi4p0sz0rCRmZCbTI7qF8FaBws5PIDodek+R76MD2BqS60rO0WtiQAqIrsYbOSUAQxhO/Z2MsTz2bv+FvfTEtq5ovjRUwbTHvOJ66VNwdHXrdU34JbhHiMyua5DiOgejekKMKwlMfTmsfFHG37eUyqhDvoy/RyakAek3/91Dnk06BWyKmQZDHKk9+1FLKPtPyrCAg4aNg0F/8058bClknhtjCBh7nGEnBR7ueOr1bUxxf7ysjv/98QC5ZdJfcc7Intw+qXfzkK91ZbD1Xdj/vZy8Wn5EpqTX6eTSkeer6qq/vlwm+9EIOjQh3kkUVTfwyabGAnxMRiw3T+jFQE2ABwSqKvjLkoNsOlqOUa/wxGWDyUoJjAlpNofK5mPlLNlXxPbcCs85ZDLoXK4nyQxLjUYXyBk+hYCNb0ghrjfB9e9DVIq/W3VqBl0iLYHJQ/zdkoDAHUu8sKoBpyr8m1FWdcLh5dB/phS3pjCYfF/HH8dmcUUHaUVcz3jaK66XP3dqcT35fq+oDomR/82R0modEi0fJEJj5YTILe+6LNel0pJqMIPDFW50+A3eUHwF2+C7B5sfS2+S1mvFZ0Qsrh9Mf8Jj2T5UbuCp74/QOyGc168Yxfp9RQhxiH6J4STGxwNdFEPcz7hHDettZybEhRB8v7uQf685it0piAkz8sDMgYzJiG1c0GaBXZ/AzvnSxQeg93kw/n8678H+xDb4/mEZJebm+c2TdGkEPJoQ72CKqhv4dHMeS/cXo7rU05iMWG4cn05mj8AQeRpShP99RQ6rD5Wi0yk8fmkWI9Jj/NomIQSHS+pYml3EqgMl1Fq9qdUze0Qyc3Ay5w9IIMwUBD9b1Skzwx1YKN+P+3ngi3CQ4QrP4ZCFTUkIN2My6LA5VIqqG+gZc4p4yJ2JrQ6WPivTidcWw6hb2rZ/Q5WMS+2Obd1UXM/+o1fArHzx1OL6/IelmAYprhWdFNNNF6HCwUVSZNeVyjj58f2lO0r1icbi+sT21sP26fRSoLuJ7S2zRLrD9rmjipgjm4uw0BgY4J1UabbIKB3uOOIbXWELJ3RVEp8AIcwlxC02x2lKQpXFzv8tO+RJeDQmI5YHZg4gJqyJa92xNfDTn73RY5KHyFGOlOEd2vZmJA8BnUFmka0+Id3/NIKKILijBwfF1Q18uiWPJdleAT6qVww3je8VMFZWDYkQgnfWHGXJviJ0CjwyayDjesf5rT2VFhurDpawZF8Rx8u8IVriI0xMz0xiRlayx0UgKHBYpWg6vlaKlKm/lZZmjaBDp1NIjQnlaGkdBZX1/hHitcWw8Hdy+N1gli4aIIf/60q8sa19/zdUwaV/9grTn/4MR39q/RjWGm/c8dBYObkxNAZC41z/Y+V/vUnGbHaLa4R0ubJUSEv20Gu8ca5P7IBvf9P6MetKvK+j0qQ7SSNx7crmGBLT2JoaFnf6ZC+tEOKT0KfB7mR7XiUAE/r47/rnD0LP0DVle24Ff1lykEqLHYNe4a4pfbhieErLEzJDoqUIj06T7kF9pnaNddoYCsmDoXCXtI5rQjzo0IT4WVJc08BnW/JZsq8Ip0uAj0yP4eYJmgAPVP67MZcFO08AcP/0AZw/oOsneTmcKluOV7B0XxGbj1d4Ht6MeoWJfaXryaj0mMB2PWkJay38+HsZO1hvgpnPeH3DA51dn0mR02uS/3yOA5CebiFeUc+43l188Ipj8Okd3vdX/J9MXQ+w9rUzF9dh8VIotWS5NkdIsV9+RIrpyBQppi1l8n2/6dB/hqzndOK65qT3dWQPSJ/QQqp01+tQH7eGiES44JE2dEz7cPtGW+0qO/MqsTlUkiLN9DnHsjb7uqa0lDXW7lT5YP1xvtpeAECvuDAemT2ocT8V7ZXnp/vBq8cwmYk3bVyjCaxdQs/RUogXbPPOD9AIGjQh3k5KaqzSAu4jwEekR3PT+F4M6amlmg1UPt+az6eb8wD4f1P7MnNw8mn26FiOlUrXk5UHSqiqt3vWD0iOYGaWdD0Jtiyejdj3tRThpnCY/WLwpId32GDzW9Kaf+2/253iujvi9hP3y4TN/T80fh/lY+2LSIaIpJbFtVvkVhdKMZ0yXFoq60qlwO47zfuAeGIHfPHz1tuQMtLnmEnSNcRXWIfHe63YUT29ZSN7wKX/2/7P3gl4hLjDyYYj0tVifJ+4wAtz2sm4XVNUIbOMuvsF5Hn+yqL9HC6RscEvGdaDu6f08ZapzJPXiiOrpLEhbbx8kALImNyln8NDz1Gw9T/Sxck3VKJGUKAJ8TZSWisF+OK9XgE+PE0K8KGpmgAPZL7bdYL31h0D4PZJGVw+vOepd+ggahrsrDpYwrLsYnKKaz3rY8KMXDgoiZlZyfSK7yYW2BE3S+ti1pWQ0N/frTlzCndIER6eCHF9/d2agCLN5Y6SX+GHzFbDrnOJaiFFuMEs09nXl0tLdcpwr7hOHQ2pY+R+J/fAe6ewDEb28Arx8AQ5vN9IXPu4hvjGJo/qCde/12kft7Nxu6aowpvW/lzzDwcIMXiFd4PdSYhRjxCCpdnFvLnqMFaHSoTZwG9mDmCiu3/qK2Dre5C9QM6BURQ5cTgQ4qMnDZa/jfoKqDiqXcOCDE2InyGltVY+35rPj3tP4nBKAT40NZpbJmgCPBhYll3Em6uOAHD92DSuG5veqcdzqoLtuRUszS5m49Eyzzmj1ylM6BPHjKxkxmTE+jcKRUdRmSeH8/UG6ct6/kOn3yfQyN0g/6dP0KxJTUjzWMQ7ObOmqsqJjHWl0n/aUiZF8EhXevTSQ/DRDbKMEM33VxSvEHdbxN2RRJq6hvhOoItKhbsXdeYnCxh8BWit1UG4Wc/QnueeC6VOpxBq1FNvd2KxOdHr7MxbcZi1OaWANK49eNFAEiLMMkzk7s9gx0dybgDI8Kbj/ydwRs4MJukak79FuqdoQjyo0IT4aSirtfJZMwEexc3jMxiWpgnwYGDNoVL+tuwQAFeMSOHWiRmddqy8cgvLsotYfqCEijpvuvm+ieHMyEpm6sBEokOD2PWkKYW7YNHjckh22uPBG3s7zx0/fIJ/2xGAuCdoVtTZsNgcbY/aI4ScPGkpkyI7Mlm6dwBUHIcVL7r8sctkpBFfRt3q9Qk3hXsjUuj0UlD7uoYk+YScjEyBO75tOZJIU86hBy+dTsGoV7C77mVjM+Iw6IP0N3uWhJikEN9yvIKvtxdQUmNFp1O4fWIGV49K9c7PsVbDtvdlttGEgTDxl94HvkBi1G1yRLLHUH+3RKONaEK8FcrrbHy+NY9Fe056LlpDekZx84ReDE+L8W/jNM6YzcfKeWXxAVQBM7OS+cV5fTvcH7LO6mD1oRKWZhdzwJUcAyAq1MC0gUnMyEqib4AlCeoQjq+HJU/JG1TNCRk3NxgnOVbmQVW+DAEWiDdYPxNuNhATZqTSYqegot6biEwIsNVKcW2K8PrJVhfChn/IjJEWl9uI0zsfglG3yqgSIC3WJfu929yhAN3W62ifkavwJPjZOy1HEmmKTuedqKnRCLNBj90pw/ZN6HtuRUvxJdSoowJ46yc5UpoSHcKjswcxICkCSg9C4iBZMCJJWr9DY6U7VKAaG4JlPo5GM7qFEFdVFVVVT1/wDCivs/HltgIW7T2JzSnrHJwSxU3j0xmeGo2iKB12LI3OZVd+FS/9kI1TVTm/fwJzp/UFhCdCydmgqoJdBVUsyy5m/ZEyz7miUxTGZsQyIzOJsb1jMbqsTd3unDm0GGXVn6QFs9dExIynwRAi3QuCjdwNMjV3j2EIQ2hwfoaOxm6R361JPkAOiLCSUvYNxpULECGupDN1pfIhDBAjb4ZxLnEtVJSWopmExEB4PMIc6e3j0DiY9YLXuh0a29zn1l1W0TUecte+p3ZhNuqosQoMOoVR6dHd79p0hoSZ9AjkvWBmZhL3nN+X0KocxHdvwontiCtfh2SXdXnoz7w7nqP9dbacq+fZmRCUQnzevHnMmzcPm03eBMrKyjCZTKfZ69RU1Tv4PruMFYcqPBbw/gmhXD08kcHJYSiKjZKSktPUohEoHCqx8OcVeVgdKiNTI7hlRAylpWf//RXV2FhzpIq1Ryspt3iTQaRGmzmvbzST+0QTHWIAnFSUlZ718QKRkEPfEr7rXQCsvaZSO2IulFcD1f5tWDsJz99LiMNOXXQmDcXF/m5O5+ITUUGx1mDOXYWuoRxdQwW6eu9/xWGhftDPsAyViXNi9VamNqwgLNeAI6zxbUM1hmOtqcHi7junSsiQO1BDY1FDYlFD4lBDYqT1241vP4cOAAHUqTI2uEanojjthFrLGZ9gxZK3hzpTOMIYLkeEziGGJBgprlS4fmQSkxLqEYufwJknEzkJnZG6ozuwKkl+bmXb0JfnYM5bjTOmN9aMC/3dnEaUlcnf9oUXXojRaGTu3LnMnTvXz60KDBQhWpr1Ehzk5+eTnp7O8ePHSUtLa1cdlRYbX2wrYNGek1hdVs3MHpHcPL4XI9Kiz7mwTt2BI6V1/OGrPdTZHIxIi+HJy7IwGdo/nFhvc7L2cCnLsovZW+gVmxEmAxcMTGBGZhL9kyLOjXNl+wcoW/4NgBh6LUy8V1oqg53aYhl1ICTI533YLZC/1esSYilDsZRKgWspRWReLofZAWpOonxyU6tViUGXeWJbf7P1GCUr/kGPlDQunzjUxzc7Xo6EaAQNj36+i7jcH5lr+KbxfBVDiIypbopETPkNpIyQ60sPyuRcpgi5mKNc5SLk/9DYxg9ZwYS1GrZ/iLL3K1Bd7lP9ZyLG3i3nGQQbe79EWfc6pI5BXPpnf7emEfn5+WRkZJCXl9duvdZd6RaPwDqdDl0b/bYqLdIF5fvdhdgcUoAPSpY+4KN7xZwboqobkldu4ZkF+7DYnGT1iOLJywc3ihF7pqiqYO+JapZmF7HucCkNdnmO6BWFUb1imZGVxIQ+8Wcl8IOS5KEyWcXoO1BG3Rp4E91cvq/oXZe26hMykkBDVcvL5Pug93kQ1cN/bT4dTjuUH/W6g7gTzdS5lr7TvJkWbXWw9KlWq1Lqy70+ruEJ0HeqDNnomyrd5Z+t+Pj794yP5t+hV9HHEM6VA0Z14ofV6HCcdsj+Vkag6TGMm8b3okhJINKaimKr9UYCcTTIpa4UBdV7npQelJMVW+Oi5+R5BJC7Eba84xXppkg5YdYULv+njfNmfrTXy8UUIaN+dAVuu6OiyNffPSgTOYEMfznhXkgcSIBd1c4c9xyXoj0oqqPr+vUMaKtGO5foFkK8LVRZ7Hy5PZ/vdxVidQnwAckR3DKhF6N7xWoCPIg5WdXAE1/voareTr/EcJ6+ckibRXhRdQPL9xezLLuIomqrZ33PmBBmZiVzYWaSDGl1rpI2Bq7/AKK6wFqkqmB1CeaweHkjByjNgUOLWxbWtlqY+bScVAUy5N3qV1s/Rp2f3IeaRhLxFdeWMnlDHXqNLFtfAV/e03pdvn7TYXEyprA7kkjTxDPhPkPtBpMUUWdAWpwU5Scq61FVEXwZX89FVBVylsKWf0NNoXyInvN3xvaOg94/B1xJjFSn/N1Ya2U2UlsdxPvETo/pBYPneMvYaqUl2f3a7DMRvbYISg603qaLnvMK8ePrYJnr/NOb5O/bI94jYMSNMlENyAnAJ7Z5Bb45yvvaGN76BEpbHRTvh6I9ULxPZsP82dsyjryiyDj1uz+DCb+E9PGBZ1hoK7G95QhFfYX8vNoEzqDgnBHiVfV2vtzWRIAnRXDzhF6MydAEeLBTWmvlia93U15no1dcGM/OGUqE+cxO7wa7k/WHy1iaXcSu/CrP+lCjXrqeZCWT2SPy3DxHbBZY9ScYe5c35Fx7RLiqgq3GRzRXy1Bg7kgbJ3bArk9d2yq9otptwZrxlDfNeM0J2DW/9WM1eL9DolKlxTsk2ruYo7yvozt4iNQ3kog7akhdqfyfmAUDZ8lydaXw4bWt12P0iT4TGue1VruTzPgmnvHNNqk3wtX/7NjPBCRHmtHpFKwOlXKL7dx+GA10hIDc9bDpLa+1NyweBs5uOeuiTu/9PbREz5GtC7qmnq29JsHFL7sEvVu013hFu6+7h8Nr6MBp84awdDPoUu/r4n2wqpUspYoCUx+DQRe7yu6H7R9AdYFMQd+0jUV7pRAHGHixXLqLtVZRpGU/Z5l8cNGEeFDQ7YV4Vb2dr7cX8N2uEx73ggFJEdw0oRdjNQHeLai02Hjy6z0UVVvpER3Cc3OGnDZWtxCC7MIalmUXsfpQKfV2JyCvY8PTopmRlcykvvHtcmvpNtRXwMLfSQtXxTG49l15w1JVeVN1i2prtfd1xhSIcYWcO7YWNv5Tim5rTfMY0b7i2loj/VBbwhwprXZuYntLa5mvuPYV2WafsHUJ/WH2HzumP+z1TazXZVLIuzM0Wsrh45vk8H5LDLjIK8RDY6VvvTmySTZHlwU7zidRiN4At37RMZ+hnRj0OlKiQiiorCe/ol4T4p2JEHJxi0OnXf4+VCeoDhCu/6pTLuGuhzOQluMVL8jMoiDPr5E3w5BrwNgJvvxN758Rid6H69OReakUwfY6H0t7jdcq7w4fCDLiTq+JjcvZaqWYF0JmRnVTXQDH1njfR6ZA8mA5UpQ8tHESnu4iwH3p6RLiBdtg7N3+bo3GGdBthXh1g0uA7yz0iKx+ieHcPCGDcb01Ad5dqGmw89Q3e8mvqCc+wsQfrxpK/ClEQmmt1eN6csInU2ByVAgzs5KYnplEUtQ5NvnMYZXi0tfFo/Qg7P7cW8adrOfgYlj5UnNR7SY8wSvEhSpjdPtiivCKZt9JfgkD5cTAlqzWTcPZxfSSk0Q7CoetsWtIWJx3olpDFXxzn9xuq2u+b/+ZXiEeEg1Ol5XPHOmyYPu4hiRlevfTG+Dni6UFO0hIjQ2loLKegop6RqbH+KcRQngFqd7kFVK2OvnA11SkCtf/2N5eF4rqQig75CqnNhe3vSZ5R31KD8HRVS2Uc+07eI73ey3cCTs+blJO9ZYfe7f3XMnfCitfbNxWdzmhyuy0g+fIsid3wXenyFY78V75YAry4fnkHjnxeOi1rgfWAI6nrnM9jLrdzlojbYxcmuKwSUHuO4KUOAjOe1D+9pKHeB9SzhXcfuLF++SIZjDmdjjH6HZCvMYlwL/1EeB9E8O5eXwvxveJ0wR4N6Le5uTZb/dxtLSOmDAjf7x6WIsi2uZQ2XCkjGXZRezIq8QdRjzEqGNK/wRmZiUzOCWqe/m91pVBWY6P1bqJL/W4e7wZ2HKWtj7sCzDmTq/YMIV5RbgxrLlFOtzHGtZjGFzxmmtbjLzZtiY8I5Mh64qz/NBNcDqgvlyKa2OI15faWgtLn/EKb2tN4/36z/AKcVMEVOV5h7eNoY3FtW+qdJ0ebvxYWrvPxPrY0SLcLVJ9RaWvCKsrk+5BjUSqjxDsOcorbIuzoaqgkfA8z1pIqLWUsOytkPU/XivksTVwcrdPXT7/hRMm3+9NOZ/9HRxe1oL4dL2e/ZL3QW7Hx7Djw+Yi1c3Vb3izbu5bABvfaL1vLv+rHLIHyNsAa15rvWxkD68QLzsM2z5ovWzaWO9vo75CuoS0hq/LlOo49fwE1RsaFcX1IKozyHNMZ5CjKTqDXAw+hgdTGAy5SmZZDE9ovf7ugsEEhiZCOzqt413OgomoFDkKoDrk3ADfEQCNgKTbCPGaBjtf7zjBtztOeAR4n4Rwbp7QiwmaAO92WB1OnvtuHwdO1hBhNvDcnKGkxniHJ4UQ5BTXsiS7iJ8OllBn9bo2DE2NYkZmMlP6JxBqCmDXE3uDvPG6BVvFMSjY2noEkGm/91qN8jZK3+7WqDnpFeIh0VJUmaPkZCtfsi6HPhd436eOkW4S5qjTz8gPjYHQToiwoarSj1x1eofB7fWw/u+eMH3UlcoybgHdbzpMf8Ir5vI3N65Tb5IC21EvRwiKs70CcPQd8iEiMsVr0QTpetNQKUVgIxHqkP05zMcHfNdncsi8qUhVnfLY0//gLbvu767jNxGpqipdAW780Ft2ydNy0ltTkermnhVecb3+dTi8ovV+vesHGd0C5Gc68EOjzaMb7KTVWwk/bgDbrV4hXrAV9nzZer1j74bQWFRVYC3LQ5e7BacqcKqimfvuvkMnsEaHoAA9CstJqa5oHsHCteJYfjkNlnIUBWIrbCQ5daAYEDo9KFKkCp1cV1xuxaZUo9NBpD2c6JhMdHoDit6AzmBEr9OjGAzodEaUUB9hF5sBQ672il6dXi6KSxD7TpRNGARTf+ctozN4y+n0ENvHW7bHUJklVKdrXk6nlxMQ3aSMgP+3qvX+9UGNzsAx8Tc4VYGjwS7/u/ra7lRP+d7hFDhUVb53yvUOVfVs85ZVvfuoAofz1O/ddQUqwpXkze4U2JwqdvfikO+dHdz2V68fwUB3dtrO4up/SuOHpnuCgm4hxL/cns+aE3nU26TY6p0Qzk3j05nYJ757WTk1ALA7VV76YT97CqoINep5ds4Q+iTIG1dFnY0VB4pZll1MbrnFs09ipJnpmTLdfEp0aGtVdx4Om1cwR6V4Bc/JPdJC2JKwdljh0lfkbH6Aon2w9m+tH6O+wvs6Ihni+7fsRx0S7c0YB9Kv+87vpZj7/iHZpsgU6VttCm9scdOboO64FPLNRKVDWsTdVkpVhf3ftVxOdcr05W6faZDRTWx1UpQIp3wQ8fUbT8z0Tuhyi864PrIup11af5qi08vth5fLpaXtt30thbaiwMc3Swuvr4+pG19/cJBh2soOt/xdhMU3FuJHVsrIDS1hCm/8vuJo62WbxmxXHZ7sli2iOkDnemAyukLI+VpWfa2rvqo4trd86PIRh7Y6B9sOlhNqMnGl6+HQ5lCpixmGva+g3gF1DgWLXaXOrlBnF9TaVTZ/e4yT1gKq6+30cMSR7LwWFR1ORS//o0d1vc5fX4NVkVE3wtW+hImHUdGhKq5y6HAKPaqiw7bGiVD2uRrcD3i+9X5Y6QR2ud6EAbe1WtR4qAyDfj0mvQ6jXsGoPw+j57UOg16HSa/I/0VWjLoDcrtBh0GXicmgw6DTYTLIfTwi9kQ9TvWYj0hVcKoqdmdD6wLZKbCrajNR21wgy/cBrHc1XGw7XtH5Qtw9AqURFHQLIb5g+wlCY5PIiA/j5vG9mNhXE+DdFacq+PPiA2w9XoHJoOOpKwbTJyGcdTmlLM0uZuvxcs/NyKhXmNJfRj0Znhp9dueE6pTCWHXIyXiWcun2YCmXwrDvNGk9Azi0VFqjWxNIk+6D4dfJ14U7Tm1NzFnmFeKtuTsoinShsPgMdcekSzFbVyJFcyM3BAdkXg4TfynLWsrhv9c0rrOmED53TfTJvAym/la+ttfDV/+v9fb2my7DBwIgTh06EODYam90kZqTpy5bsr/5uvKjLZf92TvSNzQkBj6+QSbsaYnYPo3dN8JipZ+3x0rpY92MSG68b8oIuc7jJuBjBW3q8zpwtnSNaCSAXXUbmsxpGH07DL6qiVXVZz9fzn9Yun40dVdwt8dXuE99VC5nwogb5OKD0WLjv/mbUBT47tODVFrsrtFHEzD2NBXKZCkn9KlUh2UQG24kOtRIqEGOSAkhRWSmK+W4KkCIaEB45i6qrgcFgeu1/EMI4frfeBuu1/Kt8NRhd0qx63C2bPGU253U46Q7oNcpGPUKep2CQafzhNB2941vH6mu96qrQzVh3zqKQqMHNPngJh/IjHrF+16vw2iQ7/smhnPF8J5d10hVBUTzeTYaAUVACPF58+bxyiuvcPLkSUaMGMHrr7/O+PHjz3j/1NhQ/ueSTCZpArxr8U2OAFKo2i2N/T8bWUDTvMPZ1YXS97aloXrVCekTZNxjgJKDkL8J1elk5b4TxBRVcSUq4zOiqFu+kEdrR3PYIV0U+jkOcaVxE33iQkiLNmF0CNjpgO2u44y72zuZJXcDrPmrFIItieZxv/AmSln+QssWVTcl++Hil+Tr/E2ntlIe+8krxENiTt3H7jBb4A0f2BQhpJ+zr0VcdbYuUsGbxAOgtJW4v+4heF8xpze6YvD6iFRF57UMH18H6+d5Q/a56T/DKxYPLPSuP/pT8+NO+KVXSG58U06ySxgkoyy4o4uUHZbnXVORqtPLc8zXR/TqN12fpwWR2nTods681vusKVN+c+ZlB1955mXd/ulnQhdORIsONZIUaaa4xkphlXeis0GvEB1qJDbMRHSoFNgxYa4l1ER0mJGYUCMxYSaiQgwY9IEVqUJVpdXZ7pRuFdI9wfXaoXqFu6piczR/7SvqW3qt0ykYdAoKrgcMlyuE+6FBCHC6Hh7cItgjjl3vBQKZ+FnI+Z/u9cJbj3s/bz1uC7u3nfV2B2qAqmuPoDXoMOgU+V+vw6zXYdArnpEGs8H1Xq/HoFfke53iEsA+glgv1zV6r3ePVDQWy+76jTpd99EQG/4p3csueLSxe2GQ0VZ9+Nlnn/Hkk09y7NgxBgwYwJ/+9CcuvfTSVssHAn4X4vPnz+ehhx7ijTfeYMKECbz22mvMnj2bAwcOkJSUdPoKgOfnDKVXrwCbmOIx4zTJbtVQJYfcW5tZnzzEKw5KDkhLXlOR6i6bdaU3g+CxtVIMCrVxGbfv6KS5jf0/c9c3KeczeWv2S17f220fwL5vWijnKnvdf6R7AMCOj2Drf1rvk6v+KcNIgYxEsOEU8Y4v/4tXiBfvRWx6i9IaK73q7fTClRjtgBxkNoenEheTyvTMJC7T5ZOwcx/UIJemFO7yCvGdH5/aClt6sPVtTfGdtd9rIhz80fveHUEjJAp0RmlhdpM62kek+opK139fF5Kw+MYitakV1leoh8XDZX9poZxOvjZHyfNz63/kMvp2GWHBXZeik/7ibn/r3Z97Q/dF9ZTh9SbfJ4+lqvD2DHmeORpkPHBfegyToQrdOKxS0HvSpPuE7QuNa/x7GdrEUu+mLRPRgixqgvBYKJtbdD0WTLwiDR9rpq8wcz8nqz6WTVVtbiH2WJOb7NvICu16ff24dA6X1BIZYvSI7hBXdllfa7Sv1quzOqizOiiorG/mE+7ez/ezt7SeFvdrWVAqTbzK7W5hrXqFtfu1QxXYHS6fYNdrh+oS0j6vHU61kaB1C/UA1bRdil4nBa1ep2BwiV2jXlrfDa7/JoP877bOu118jDrp4qPXye/NY5VXVe+5IFTPuS3PV3l+2p0qVoegrkHe8wQCxV3G57x2okNVDPLcVJ3ohc1Tn/tkdZ/zdsWIQzHI35TqwKg2gBA4hUARuNx/ZNusmLAqJjmiojoxO2vxPiipjR6mrJhoUKQRSiecRIoaFM/5K/+7z1orZiw6ea9WhEqsqPAYvdxl3Ps2KCHU6iI9ZRNUr/HjkoatjLSfYM1nX/Jl6KkffnvFhXHrxAz0rocQX/uE55gKhJsNZPbouig8bdWH69at46abbuKll17i8ssv56OPPuKqq65i27ZtDB06tIUjBAaKEC1dGruOCRMmMG7cOP7+978D8geYnp7O/fffz2OPPXbKffPz80lPT+fE2o9JSYhrMrnJKcVRps+TkFtMNC2nOuVsc18L17q/y2QITUWq6pQWt6v+4S27+Ek4sb25SAXpU/uLJd6yix6XVsPW8J1ctfTZU1th7/zeG5Jr1f/C/u9bL3vrl15hu/b/Tu0OceOHXoviprdg+39bL/uzd2SsZpCiffPbTYbIfcTlrD96IwwcXCyTsrQ2CWrcz2VKZkAUbOfEF49hqWocZcB9YVD6XEDiiEvQ64DVf2keBcOXlBEyOocQsPtTGZ7MF3Okd/9Bl8qoGEJIAVp5XArFETdKS7ZOJxPRVOXjUQpNf04DZ3tdDwp3uqzUpyjrflgq3NX4QaBp2QEXycmQIH263T7FLf2cB8zyfvdF++DENoRQqVn9JhabQ7ZGgENn5PO+f6TamACqyi/2/xzw0UCisR56J/U5yg3JqELwm7zfYFIbPE2wK0ZqddFU66Op1MXxU9hMThp6oqqQ5ChgRP1mQDQSeu5L0Q7jKPIMvQBIdp5koq15JAr3jWiXcQRHDDIqQIKzhPNtP/nc4BqX3W0YxkGjPP9i1XJmWJeiiJbL7jUOZa9RXrij1CouafihWb1uDhgy2W6SETnC1VquaviqxXIAhwwD2GSaCIBZNHB9ffPERO42HTH0Y435fAAMws6tlubRO9xtOmbozQrzDM/6u+vebrUf8vTp/BhyiWf9nXX/xoR7BMd1w3ftWqhPYUHoVZ6yd9T9mzBR32K9JbpEPgvzurPcZnmPKLXKVaZx2XJdHB+Gef20b7F8QLxa1qhOd9lqJYp/h//Cs+1Gy0ekOAsblXW3u14J458Rcz3brrd8Qi9nLr5nrrstDgz8NfJhz/pr6z+ln+Nwi2UBXo543KNQrq7/gkxHtqeffD8bwCuRv8WmyN/9FfXfMMK+o1FdvmVfjXiEOp28jl/a8B3jbJtbFWl/jXiQSp18sJzVsIjzbGt8yjT+7l6P+DVFejmidqF1GTMalnrLNGnHvPC55Lt+c+dbV3Fpw/fNyriP86/wX3LYIK/5k6xrubrhS5/P1rgt74TdQ7ZRGl/G2TZxk+WjRuV8eT/sTnaY5OTuEbbt3GH5T7Mybj4Ju8nzO8qy7+OeujdbLftl6LWe31E/Rw5za19vtey3oVd6fkfpjlwerG3dtW5xyMUscv2Okp2F/K7m5VbLrjBP59vQOYC89jxZ/WyrZdeZp/B56PUAhKs1PF/9RKtlt5jG8VHYrQAYhY0/VTV3PSvQp/Fq5Bm6pJ2GwSlR/Ona4acv2AJuvZaXl0da2plFtWmrPrzhhhuoq6vju+++86ybOHEiI0eO5I03ThFVyc/41SJus9nYunUrjz/+uGedTqdj5syZrF/f/OZrtVqxWr3ZuKqq5EW+fun/Uh7ePBSYGt6D2pDBnvfhGz9DX3WsxbaoITHUps7xvA87uAlDWctD9sIQSs0xbz1hRUUYykpa/pDYqPYpG1pZh8GiesSpUBTXDH85u7/2aI4U74DJForB1MtjyRQ6Q6Ph+PrcPI+rh4EU9EkXNKpLRgzQg06H7UQRGKXA1IVkoht4h9cCq+hdkQZkWWdJrYzQARAxGmV8f6+4VnQIX7eEagVqXWVjp8Cs81qfqW0B3H1hGghjn2ylz4BaPPWW5pWgO+m98Zr0OiJCDISb9FJ8H/+JquPNXRwccQMQ5kiEKQrT8ZVy5aGNcmlC9TUfe1wwQjf8FWPBBtj6JdD8gaU64UIwVgMQsuVjb90tUK3r5XE/MW//AvORH1stW0MqwuWHbN79LeaDC1ovK5IR0fLGadq3kJDsz1stW6smoMbJhxrjwWWE7v4vFpuT4pqm7jP17K/ZRI5eRoK4oqGVxDQuSuu3k60fCMDbzmncYP/GZ6sVqCWSAiIBYUzmpF7efJOd+xhp/6FZfW6OGMxYXA8vJmcOo+1LWi17zGDCYpAixqAeY6RtWatl8wx6LAY5iSlOPcEw28pWyxbqwWKUo0IRagmDbatbLVusd2IxyuyWZlHJQGvrIezK9DYsRtcIkrDQ39r8XHRTqWvAYpL9axB2+li3tFq2WmfBYvJafDIatrVatk5Xi6V+tOd9asMuHyHeGKtShaXBG0knqWEfEVhaLGtTUrBYvWXjrAeIE5UtllWVhEZlo605xIuWr6EKUVhs3rIR1sPEiBYm5gIGQrHYvWVDbMeJVI+3WNaBAYvDW9ZgKyBMzWuxLEC9vUherwHFVkiIeqLVshZHMTZFXseF/SRGZ1GrZesdxVgUGaPeYS9B52ztXgIN9mIsOulvb7OXIpzlnm1Npa3FUYLFZeG0OUpxOqpojXpHCRad/M01OMqxOWpbL2svwaKPdB2jgnpHfatlLfYyLHr52eucFdTYW3fZq3OUNylrb72svRKLQZatdZafsmytvcpTtk4to8Z2qnrbUNZWhaXeW7a6UdnG98AaW43nd2QSVVRY1RbLCaDKVu/9zQkLZVbFs61p2Qqb1fM7MggHxVadz3a530Z9eqPzvDXSY0I9FnHfY/i+MFsdHPPRM22hsFD+ZquqqoiK8lrVzWYzZnPz3B9t1YcA69ev56GHGsfcnz17Nl9//XW72txlCD9SUFAgALFu3bpG6x999FExfvz4ZuWffvppt+lDW7RFW7RFW7RFW7RFW4J4efrppztEHwohhNFoFB999FGjdfPmzRNJSUltUKZdj999xNvC448/3uhpp7y8nD59+rBnzx6io6M79FjTpk1j5cqVHVpnZ9bbWXXX1NQwePBg9u3bR2Rkx4ZcCrY+1vq38+vW+jj46u3M/oXg6ovOqlc7hzu/Xq2PO7feqqoqhg4dytGjR4mL887backafq7hVyGekJCAXq+nqKjxsElRURE9evRoVr61IYz09PRGQx0dgclkOmM/pkCot7Pqrq6WLhipqannfB9r/dv5dWt9HHz1dmb/QnD1RWfVq53DnV+v1sedW6+7T+Pi4s6of9uqDwF69OjRpvKBgl/jSJlMJsaMGcOyZV6/TlVVWbZsGZMmTfJjy2Du3LmnLxRA9XZ23Z1BsPWx1r+dX7fWx8FZb2cSbH0RbH0cbP0QbP0LwdcXgdDH7dGHkyZNalQeYMmSJX7Xk6fD71FT5s+fzx133MGbb77J+PHjee211/j000/Zv38/ycnJp9y3urqa6OjoZs7/Gh2H1sedi9a/nY/Wx52L1r+dj9bHnY/Wx51Le/r3dPrw9ttvJzU1lZdekjk81q1bx9SpU3n55Ze57LLL+OSTT3jxxRcDPnyh333Eb7jhBkpKSnjqqac4efIkI0eOZNGiRacV4SBdVZ5++mnNx6gT0fq4c9H6t/PR+rhz0fq389H6uPPR+rhzaU//nk4f5ubmotN5HTsmT57MRx99xBNPPMHvf/97BgwYwNdffx3QIhwCwCKuoaGhoaGhoaGhcS4SWLmGNTQ0NDQ0NDQ0NM4RNCGuoaGhoaGhoaGh4Qc0Ia6hoaGhoaGhoaHhBzQhrqGhoaGhoaGhoeEHglqIz5s3j969exMSEsKECRPYtGmTv5vUbaipqeGBBx4gIyOD0NBQJk+ezObNm/3drKDlp59+4oorrqBnz54oisLXX3/daHttbS333XcfaWlphIaGMnjwYN544w3/NDYIeemllxg3bhyRkZEkJSVx1VVXceDAgUZlTp48yW233UaPHj0IDw9n9OjRfPHFF35qcfDxz3/+k+HDhxMVFUVUVBSTJk1i4cKFABw7dgxFUVpcPvvsMz+3PDh5+eWXURSFBx54oNH69evXM336dMLDw4mKiuKCCy6gvr7eP40MMp555plm52dmZmajMlr/nh0FBQXceuutxMfHExoayrBhw9iyZYtn+5133tnsO7j44ov92GL/E7RCfP78+Tz00EM8/fTTbNu2jREjRjB79myKi4v93bRuwS9+8QuWLFnCBx98wO7du5k1axYzZ86koKDA300LSurq6hgxYgTz5s1rcftDDz3EokWL+O9//0t2djYPPPAA9913HwsWLOjilgYnq1atYu7cuWzYsIElS5Zgt9uZNWsWdXV1njK33347Bw4cYMGCBezevZtrrrmG66+/nu3bt/ux5cFDWloaL7/8Mlu3bmXLli1Mnz6dOXPmsHfvXtLT0yksLGy0PPvss0RERHDJJZf4u+lBx+bNm3nzzTcZPnx4o/Xr16/n4osvZtasWWzatInNmzdz3333NQrhpnFqhgwZ0ug8XbNmjWeb1r9nR0VFBVOmTMFoNLJw4UL27dvHq6++SmxsbKNyF198caPv4OOPP/ZTiwMEEaSMHz9ezJ071/Pe6XSKnj17ipdeesmPreoeWCwWodfrxXfffddo/ejRo8Uf/vAHP7Wq+wCIr776qtG6IUOGiOeee67ROq2/209xcbEAxKpVqzzrwsPDxfvvv9+oXFxcnHjrrbe6unndhtjYWPH222+3uG3kyJHi7rvv7uIWBT81NTViwIABYsmSJWLq1KniN7/5jWfbhAkTxBNPPOG/xgU5Tz/9tBgxYkSr27X+PTt+97vfifPOO++UZe644w4xZ86crmlQkBCUj3k2m42tW7cyc+ZMzzqdTsfMmTNZv369H1vWPXA4HDidTkJCQhqtDw0NbWQ90Og4Jk+ezIIFCygoKEAIwYoVKzh48CCzZs3yd9OCkqqqKgDi4uI86yZPnsz8+fMpLy9HVVU++eQTGhoamDZtmp9aGbw4nU4++eQT6urqWkwfvXXrVnbs2MHPf/5zP7QuuJk7dy6XXXZZo/sbQHFxMRs3biQpKYnJkyeTnJzM1KlTtWtyGzl06BA9e/akb9++3HLLLeTm5gJa/3YECxYsYOzYsVx33XUkJSUxatQo3nrrrWblVq5cSVJSEoMGDeLee++lrKzMD60NIPz9JNAeCgoKBCDWrVvXaP2jjz4qxo8f76dWdS8mTZokpk6dKgoKCoTD4RAffPCB0Ol0YuDAgf5uWtBDCxbxhoYGcfvttwtAGAwGYTKZxHvvveefBgY5TqdTXHbZZWLKlCmN1ldUVIhZs2Z5+jgqKkr8+OOPfmplcLJr1y4RHh4u9Hq9iI6OFt9//32L5e69916RlZXVxa0Lfj7++GMxdOhQUV9fL4QQjSzi69evF4CIi4sT//73v8W2bdvEAw88IEwmkzh48KAfWx08/PDDD+LTTz8VO3fuFIsWLRKTJk0SvXr1EtXV1Vr/dgBms1mYzWbx+OOPi23btok333xThISEiP/85z+eMh9//LH45ptvxK5du8RXX30lsrKyxLhx44TD4fBjy/2LJsQ1WiQnJ0dccMEFAhB6vV6MGzdO3HLLLSIzM9PfTQt6WhLir7zyihg4cKBYsGCB2Llzp3j99ddFRESEWLJkiX8aGcT88pe/FBkZGSIvL6/R+vvuu0+MHz9eLF26VOzYsUM888wzIjo6WuzatctPLQ0+rFarOHTokNiyZYt47LHHREJCgti7d2+jMhaLRURHR4s///nPfmplcJKbmyuSkpLEzp07Pet8hfjatWsFIB5//PFG+w0bNkw89thjXdnUbkNFRYWIiooSb7/9tta/HYDRaBSTJk1qtO7+++8XEydObHWfw4cPC0AsXbq0s5sXsBj8Y4c/OxISEtDr9RQVFTVaX1RURI8ePfzUqu5Fv379WLVqFXV1dVRXV5OSksINN9xA3759/d20bkd9fT2///3v+eqrr7jssssAGD58ODt27ODPf/5zsyFqjda57777+O677/jpp59IS0vzrD98+DB///vf2bNnD0OGDAFgxIgRrF69mnnz5mkRas4Qk8lE//79ARgzZgybN2/m//7v/3jzzTc9ZT7//HMsFgu33367v5oZlGzdupXi4mJGjx7tWed0Ovnpp5/4+9//7okCNHjw4Eb7ZWVledwrNNpGTEwMAwcOJCcnh+nTpwNa/54NKSkpLfbfqaJT9e3bl4SEBHJycpgxY0ZnNzEgCUofcZPJxJgxY1i2bJlnnaqqLFu2rEV/RY32Ex4eTkpKChUVFfz444/MmTPH303qdtjtdux2e7OZ+Xq9HlVV/dSq4EIIwX333cdXX33F8uXL6dOnT6PtFosFQOvjDkZVVaxWa6N177zzDldeeSWJiYl+alVwMmPGDHbv3s2OHTs8y9ixY7nlllvYsWMHffv2pWfPns3Cch48eJCMjAw/tTq4qa2t5fDhw6SkpNC7d2+tf8+SKVOmtLn/8vPzKSsrIyUlpbObF7j42yTfXj755BNhNpvFf/7zH7Fv3z7xP//zPyImJkacPHnS303rFixatEgsXLhQHDlyRCxevFiMGDFCTJgwQdhsNn83LSipqakR27dvF9u3bxeA+Mtf/iK2b98ujh8/LoSQQ9BDhgwRK1asEEeOHBHvvvuuCAkJEf/4xz/83PLg4N577xXR0dFi5cqVorCw0LNYLBYhhBA2m030799fnH/++WLjxo0iJydH/PnPfxaKorTq56zRmMcee0ysWrVKHD16VOzatUs89thjQlEUsXjxYk+ZQ4cOCUVRxMKFC/3Y0u5D06gpf/3rX0VUVJT47LPPxKFDh8QTTzwhQkJCRE5Ojv8aGUQ8/PDDYuXKleLo0aNi7dq1YubMmSIhIUEUFxcLIbT+PVs2bdokDAaD+OMf/ygOHTokPvzwQxEWFib++9//CiHkffCRRx4R69evF0ePHhVLly4Vo0ePFgMGDBANDQ1+br3/CFohLoQQr7/+uujVq5cwmUxi/PjxYsOGDf5uUrdh/vz5om/fvsJkMokePXqIuXPnisrKSn83K2hZsWKFAJotd9xxhxBCiMLCQnHnnXeKnj17ipCQEDFo0CDx6quvClVV/dvwIKGlvgXEu+++6ylz8OBBcc0114ikpCQRFhYmhg8f3iycoUbr3H333SIjI0OYTCaRmJgoZsyY0UiECyHE448/LtLT04XT6fRTK7sXTYW4EEK89NJLIi0tTYSFhYlJkyaJ1atX+6dxQcgNN9wgUlJShMlkEqmpqeKGG25oJrK1/j07vv32WzF06FBhNptFZmam+Ne//uXZZrFYxKxZs0RiYqIwGo0iIyND3HPPPee8AVURQgj/2OI1NDQ0NDQ0NDQ0zl2C0kdcQ0NDQ0NDQ0NDI9jRhLiGhoaGhoaGhoaGH9CEuIaGhoaGhoaGhoYf0IS4hoaGhoaGhoaGhh/QhLiGhoaGhoaGhoaGH9CEuIaGhoaGhoaGhoYf0IS4hoaGhoaGhoaGhh/QhLiGhoaGhoaGhoaGH9CEuIaGxjnHnXfeyVVXXdXpx5k2bRoPPPCA533v3r157bXXOv24ALfddhsvvvhilxzrscce4/777++SY2loaGh0J7TMmhoaGt0KRVFOuf3pp5/mwQcfRAhBTExMp7Zl2rRpjBw50iO+S0pKCA8PJywsrFOPu3PnTqZPn87x48eJiIjo1GMBlJaW0rdvX3bs2EHfvn07/XgaGhoa3QWDvxugoaGh0ZEUFhZ6Xs+fP5+nnnqKAwcOeNZFRER0iThticTExC45zuuvv851113XZZ8zISGB2bNn889//pNXXnmlS46poaGh0R3QXFM0NDS6FT169PAs0dHRKIrSaF1EREQz15Rp06Zx//3388ADDxAbG0tycjJvvfUWdXV13HXXXURGRtK/f38WLlzY6Fh79uzhkksuISIiguTkZG677TZKS0tbbVtT1xRFUXj77be5+uqrCQsLY8CAASxYsOCsjuF0Ovn888+54oorGq3/xz/+wYABAwgJCSE5OZlrr73Ws01VVV566SX69OlDaGgoI0aM4PPPP2+0/969e7n88suJiooiMjKS888/n8OHD3u2X3HFFXzyySettktDQ0NDozmaENfQ0NAA3nvvPRISEti0aRP3338/9957L9dddx2TJ09m27ZtzJo1i9tuuw2LxQJAZWUl06dPZ9SoUWzZsoVFixZRVFTE9ddf36bjPvvss1x//fXs2rWLSy+9lFtuuYXy8vJ2H2PXrl1UVVUxduxYz7otW7bw61//mueee44DBw6waNEiLrjgAs/2l156iffff5833niDvXv38uCDD3LrrbeyatUqAAoKCrjgggswm80sX76crVu3cvfdd+NwODx1jB8/nvz8fI4dO9amz6+hoaFxTiM0NDQ0uinvvvuuiI6Obrb+jjvuEHPmzPG8nzp1qjjvvPM87x0OhwgPDxe33XabZ11hYaEAxPr164UQQjz//PNi1qxZjerNy8sTgDhw4ICn3t/85jee7RkZGeKvf/2r5z0gnnjiCc/72tpaAYiFCxee8TGa8tVXXwm9Xi9UVfWs++KLL0RUVJSorq5uVr6hoUGEhYWJdevWNVr/85//XNx0001CCCEef/xx0adPH2Gz2Vo8phBCVFVVCUCsXLmy1TIaGhoaGo3RfMQ1NDQ0gOHDh3te6/V64uPjGTZsmGddcnIyAMXFxYCcELlixYoW/bAPHz7MwIED23zc8PBwoqKizuoY9fX1mM3mRpNWL7roIjIyMujbty8XX3wxF198sccdJicnB4vFwkUXXdSoHpvNxqhRowDYsWMH559/PkajsdXPERoaCuAZMdDQ0NDQOD2aENfQ0NCAZiJTUZRG69zCVlVVAGpra7niiiv405/+1KyulJSUszru2RwjISEBi8WCzWbDZDIBEBkZybZt21i5ciWLFy/mqaee4plnnmHz5s3U1tYC8P3335OamtqoLrPZDHhF9qlwu9N01YRUDQ0Nje6AJsQ1NDQ02sHo0aP54osv6N27NwZD51xK23OMkSNHArBv3z7PawCDwcDMmTOZOXMmTz/9NDExMSxfvpyLLroIs9lMbm4uU6dObbHO4cOH895772G321u1iu/Zswej0ciQIUPa9Bk1NDQ0zmW0yZoaGhoa7WDu3LmUl5dz0003sXnzZg4fPsyPP/7IXXfdhdPp9NsxEhMTGT16NGvWrPGs++677/jb3/7Gjh07OH78OO+//z6qqjJo0CAiIyN55JFHePDBB3nvvfc4fPgw27Zt4/XXX+e9994D4L777qO6upobb7yRLVu2cOjQIT744INGYSFXr17N+eeff0bWcw0NDQ0NiSbENTQ0NNpBz549Wbt2LU6nk1mzZjFs2DAeeOABYmJi0Ok65tLa3mP84he/4MMPP/S8j4mJ4csvv2T69OlkZWXxxhtv8PHHH3us188//zxPPvkkL730EllZWVx88cV8//339OnTB4D4+HiWL19ObW0tU6dOZcyYMbz11luNrOOffPIJ99xzT4d8bg0NDY1zBS2zpoaGhkY3o76+nkGDBjF//nwmTZrU6cdbuHAhDz/8MLt27eo0Nx0NDQ2N7ohmEdfQ0NDoZoSGhvL++++fMvFPR1JXV8e7776riXANkPHmWwAAAJdJREFUDQ2NNqJZxDU0NDQ0NDQ0NDT8gGYR19DQ0NDQ0NDQ0PADmhDX0NDQ0NDQ0NDQ8AOaENfQ0NDQ0NDQ0NDwA5oQ19DQ0NDQ0NDQ0PADmhDX0NDQ0NDQ0NDQ8AOaENfQ0NDQ0NDQ0NDwA5oQ19DQ0NDQ0NDQ0PADmhDX0NDQ0NDQ0NDQ8AOaENfQ0NDQ0NDQ0NDwA/8fNErf2P4oX9kAAAAASUVORK5CYII=",
       "text/plain": [
        "<Figure size 800x300 with 2 Axes>"
       ]
@@ -1623,12 +1736,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 30,
    "id": "e49f767c-ee45-4cbd-b91d-5923a31c7a69",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T03:36:19.768343Z",
-     "start_time": "2024-01-28T03:36:19.614540Z"
+     "end_time": "2024-01-29T07:15:01.975259Z",
+     "start_time": "2024-01-29T07:15:01.746332Z"
     },
     "scrolled": true
    },
@@ -1649,13 +1762,13 @@
        "open           0.000000\n",
        "open64         0.000000\n",
        "opendir        0.000000\n",
-       "read          72.648899\n",
+       "read          22.903629\n",
        "readlink       0.000000\n",
-       "write          1.905793\n",
+       "write          1.834860\n",
        "Name: size, dtype: double[pyarrow]"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1666,22 +1779,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 31,
    "id": "ec3d64c9",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T03:39:23.867727Z",
-     "start_time": "2024-01-28T03:39:23.769965Z"
+     "end_time": "2024-01-29T07:15:02.074199Z",
+     "start_time": "2024-01-29T07:15:01.978985Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(0, 1940246350)"
+       "(0, 65742275)"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1692,33 +1805,78 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 32,
    "id": "ea849078",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T03:40:54.924615Z",
-     "start_time": "2024-01-28T03:40:54.849751Z"
+     "end_time": "2024-01-29T07:15:02.154472Z",
+     "start_time": "2024-01-29T07:15:02.077610Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0           NPZReader.__init__\n",
-       "1                Dyad.__init__\n",
-       "2                     readlink\n",
-       "3                    Dyad.init\n",
-       "4            Dyad.get_metadata\n",
-       "                ...           \n",
-       "96            ucx_recv_no_wait\n",
-       "97           dyad_dtl_ucx_recv\n",
-       "98               dyad_get_data\n",
-       "99             dyad_cons_store\n",
-       "100    dyad_consume_w_metadata\n",
-       "Name: name, Length: 101, dtype: string"
+       "0                    DLIOBenchmark.__init__\n",
+       "1                       FileStorage.get_uri\n",
+       "2                                   opendir\n",
+       "3                     FileStorage.walk_node\n",
+       "4                                 __xstat64\n",
+       "5                      FileStorage.get_node\n",
+       "6     ConfigArguments.derive_configurations\n",
+       "7                  ConfigArguments.validate\n",
+       "8                  DLIOBenchmark.initialize\n",
+       "9      ConfigArguments.get_global_map_index\n",
+       "10              ConfigArguments.reconfigure\n",
+       "11             DyadTorchDataLoader.__init__\n",
+       "12     TorchFramework.is_nativeio_available\n",
+       "13                     FileStorage.__init__\n",
+       "14                                    mkdir\n",
+       "15             FileStorage.create_namespace\n",
+       "16               TorchFramework.init_loader\n",
+       "17                TorchFramework.get_loader\n",
+       "18                DYADTorchDataset.__init__\n",
+       "19                 DYADTorchDataset.__len__\n",
+       "20                 DyadTorchDataLoader.read\n",
+       "21                 DyadTorchDataLoader.next\n",
+       "22              TorchFramework.trace_object\n",
+       "23                   TorchFramework.compute\n",
+       "24                            <module>.iter\n",
+       "25                           <module>.yield\n",
+       "26                     DLIOBenchmark._train\n",
+       "27             DyadTorchDataLoader.finalize\n",
+       "28                TorchFramework.checkpoint\n",
+       "29                        DLIOBenchmark.run\n",
+       "30                                   open64\n",
+       "31                               __fxstat64\n",
+       "32                                  lseek64\n",
+       "33                                    write\n",
+       "34                                    close\n",
+       "35                       NPZReader.__init__\n",
+       "36                            Dyad.__init__\n",
+       "37                                 readlink\n",
+       "38                                Dyad.init\n",
+       "39                        Dyad.get_metadata\n",
+       "40                                     read\n",
+       "41                           NPZReader.open\n",
+       "42                     NPZReader.get_sample\n",
+       "43                  FormatReader.preprocess\n",
+       "44                          NPZReader.close\n",
+       "45                     NPZReader.read_index\n",
+       "46                                dyad_open\n",
+       "47                             Dyad.produce\n",
+       "48             DYADTorchDataset.__getitem__\n",
+       "49                                     open\n",
+       "50                                    fcntl\n",
+       "51                                    lseek\n",
+       "52                  Dyad.consume_w_metadata\n",
+       "53                       Dyad.free_metadata\n",
+       "54                                  __xstat\n",
+       "55                                    fsync\n",
+       "Name: name, dtype: string"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1729,24 +1887,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": 33,
    "id": "b9ceb5ee",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-27T16:39:53.151364Z",
-     "start_time": "2024-01-27T16:39:53.094219Z"
+     "end_time": "2024-01-29T07:15:02.998511Z",
+     "start_time": "2024-01-29T07:15:02.156809Z"
     }
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "634.4538822499621"
-      ]
-     },
-     "execution_count": 118,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "NameError",
+     "evalue": "name 'mean' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[33], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mmean\u001b[49m\u001b[38;5;241m/\u001b[39m \u001b[38;5;241m3152.028777\u001b[39m \u001b[38;5;241m*\u001b[39m \u001b[38;5;241m1e6\u001b[39m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'mean' is not defined"
+     ]
     }
    ],
    "source": [
@@ -1755,12 +1914,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": null,
    "id": "7a003bb2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-27T16:37:43.231265Z",
-     "start_time": "2024-01-27T16:37:43.075202Z"
+     "end_time": "2024-01-29T07:15:03.020639Z",
+     "start_time": "2024-01-29T07:15:03.020621Z"
     }
    },
    "outputs": [],
@@ -1770,200 +1929,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 114,
+   "execution_count": null,
    "id": "1abadbb1",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-27T16:37:43.361174Z",
-     "start_time": "2024-01-27T16:37:43.234328Z"
+     "end_time": "2024-01-29T07:15:03.023658Z",
+     "start_time": "2024-01-29T07:15:03.023640Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>name</th>\n",
-       "      <th>cat</th>\n",
-       "      <th>pid</th>\n",
-       "      <th>tid</th>\n",
-       "      <th>ts</th>\n",
-       "      <th>te</th>\n",
-       "      <th>dur</th>\n",
-       "      <th>tinterval</th>\n",
-       "      <th>trange</th>\n",
-       "      <th>hostname</th>\n",
-       "      <th>compute_time</th>\n",
-       "      <th>io_time</th>\n",
-       "      <th>app_io_time</th>\n",
-       "      <th>total_time</th>\n",
-       "      <th>filename</th>\n",
-       "      <th>phase</th>\n",
-       "      <th>size</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>35</th>\n",
-       "      <td>dyad_fetch_request_cb</td>\n",
-       "      <td>C_APP</td>\n",
-       "      <td>0</td>\n",
-       "      <td>638415</td>\n",
-       "      <td>1917347184</td>\n",
-       "      <td>1917365181</td>\n",
-       "      <td>17997</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>1917.0</td>\n",
-       "      <td>corona171</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2096960</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>58</th>\n",
-       "      <td>dyad_fetch_request_cb</td>\n",
-       "      <td>C_APP</td>\n",
-       "      <td>0</td>\n",
-       "      <td>638415</td>\n",
-       "      <td>1918851200</td>\n",
-       "      <td>1918870204</td>\n",
-       "      <td>19004</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>1918.0</td>\n",
-       "      <td>corona171</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2096960</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>81</th>\n",
-       "      <td>dyad_fetch_request_cb</td>\n",
-       "      <td>C_APP</td>\n",
-       "      <td>0</td>\n",
-       "      <td>638415</td>\n",
-       "      <td>1919025811</td>\n",
-       "      <td>1919032256</td>\n",
-       "      <td>6445</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>1919.0</td>\n",
-       "      <td>corona171</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2096960</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>104</th>\n",
-       "      <td>dyad_fetch_request_cb</td>\n",
-       "      <td>C_APP</td>\n",
-       "      <td>0</td>\n",
-       "      <td>638415</td>\n",
-       "      <td>1919224203</td>\n",
-       "      <td>1919233275</td>\n",
-       "      <td>9072</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>1919.0</td>\n",
-       "      <td>corona171</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2096960</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>127</th>\n",
-       "      <td>dyad_fetch_request_cb</td>\n",
-       "      <td>C_APP</td>\n",
-       "      <td>0</td>\n",
-       "      <td>638415</td>\n",
-       "      <td>1919505055</td>\n",
-       "      <td>1919515041</td>\n",
-       "      <td>9986</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>1919.0</td>\n",
-       "      <td>corona171</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2096960</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                      name    cat  pid     tid          ts          te    dur  \\\n",
-       "35   dyad_fetch_request_cb  C_APP    0  638415  1917347184  1917365181  17997   \n",
-       "58   dyad_fetch_request_cb  C_APP    0  638415  1918851200  1918870204  19004   \n",
-       "81   dyad_fetch_request_cb  C_APP    0  638415  1919025811  1919032256   6445   \n",
-       "104  dyad_fetch_request_cb  C_APP    0  638415  1919224203  1919233275   9072   \n",
-       "127  dyad_fetch_request_cb  C_APP    0  638415  1919505055  1919515041   9986   \n",
-       "\n",
-       "     tinterval  trange   hostname  compute_time  io_time  app_io_time  \\\n",
-       "35        <NA>  1917.0  corona171          <NA>     <NA>         <NA>   \n",
-       "58        <NA>  1918.0  corona171          <NA>     <NA>         <NA>   \n",
-       "81        <NA>  1919.0  corona171          <NA>     <NA>         <NA>   \n",
-       "104       <NA>  1919.0  corona171          <NA>     <NA>         <NA>   \n",
-       "127       <NA>  1919.0  corona171          <NA>     <NA>         <NA>   \n",
-       "\n",
-       "     total_time filename  phase     size  \n",
-       "35            0     <NA>      0  2096960  \n",
-       "58            0     <NA>      0  2096960  \n",
-       "81            0     <NA>      0  2096960  \n",
-       "104           0     <NA>      0  2096960  \n",
-       "127           0     <NA>      0  2096960  "
-      ]
-     },
-     "execution_count": 114,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "analyzer.events.query(\"name == 'dyad_fetch_request_cb'\").head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": null,
    "id": "0be81363",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-27T16:37:43.593738Z",
-     "start_time": "2024-01-27T16:37:43.365044Z"
+     "end_time": "2024-01-29T07:15:03.026435Z",
+     "start_time": "2024-01-29T07:15:03.026419Z"
     }
    },
    "outputs": [],
@@ -1973,504 +1959,106 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": null,
    "id": "0d86fd38",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-27T16:37:43.647967Z",
-     "start_time": "2024-01-27T16:37:43.602863Z"
+     "end_time": "2024-01-29T07:15:03.028645Z",
+     "start_time": "2024-01-29T07:15:03.028626Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "name\n",
-       "dyad_dtl_ucx_send    873.510256\n",
-       "Name: dur, dtype: double[pyarrow]"
-      ]
-     },
-     "execution_count": 116,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "size/ time"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": null,
    "id": "86617ba5",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-27T16:37:06.323906Z",
-     "start_time": "2024-01-27T16:37:06.285590Z"
+     "end_time": "2024-01-29T07:15:03.030872Z",
+     "start_time": "2024-01-29T07:15:03.030854Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "name\n",
-       "dyad_dtl_ucx_send    147.190225\n",
-       "Name: dur, dtype: double[pyarrow]"
-      ]
-     },
-     "execution_count": 88,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "size/ time"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "c16aecd3",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-01-28T03:42:40.459861Z",
-     "start_time": "2024-01-28T03:42:39.640360Z"
+     "end_time": "2024-01-29T07:15:03.032330Z",
+     "start_time": "2024-01-29T07:15:03.032313Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>name</th>\n",
-       "      <th>cat</th>\n",
-       "      <th>pid</th>\n",
-       "      <th>tid</th>\n",
-       "      <th>ts</th>\n",
-       "      <th>te</th>\n",
-       "      <th>dur</th>\n",
-       "      <th>tinterval</th>\n",
-       "      <th>trange</th>\n",
-       "      <th>hostname</th>\n",
-       "      <th>compute_time</th>\n",
-       "      <th>io_time</th>\n",
-       "      <th>app_io_time</th>\n",
-       "      <th>total_time</th>\n",
-       "      <th>filename</th>\n",
-       "      <th>phase</th>\n",
-       "      <th>size</th>\n",
-       "      <th>index</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>NPZReader.__init__</td>\n",
-       "      <td>reader</td>\n",
-       "      <td>2</td>\n",
-       "      <td>618610</td>\n",
-       "      <td>0</td>\n",
-       "      <td>22</td>\n",
-       "      <td>22</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>corona171</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Dyad.__init__</td>\n",
-       "      <td>DYAD_PY</td>\n",
-       "      <td>2</td>\n",
-       "      <td>618610</td>\n",
-       "      <td>147</td>\n",
-       "      <td>336603</td>\n",
-       "      <td>336456</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>corona171</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>NPZReader.__init__</td>\n",
-       "      <td>reader</td>\n",
-       "      <td>13</td>\n",
-       "      <td>2332024</td>\n",
-       "      <td>94119</td>\n",
-       "      <td>94141</td>\n",
-       "      <td>22</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>corona173</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Dyad.__init__</td>\n",
-       "      <td>DYAD_PY</td>\n",
-       "      <td>13</td>\n",
-       "      <td>2332024</td>\n",
-       "      <td>94262</td>\n",
-       "      <td>404873</td>\n",
-       "      <td>310611</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>corona173</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>NPZReader.__init__</td>\n",
-       "      <td>reader</td>\n",
-       "      <td>7</td>\n",
-       "      <td>618617</td>\n",
-       "      <td>103126</td>\n",
-       "      <td>103148</td>\n",
-       "      <td>22</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>corona171</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                 name      cat  pid      tid      ts      te     dur  \\\n",
-       "0  NPZReader.__init__   reader    2   618610       0      22      22   \n",
-       "1       Dyad.__init__  DYAD_PY    2   618610     147  336603  336456   \n",
-       "0  NPZReader.__init__   reader   13  2332024   94119   94141      22   \n",
-       "1       Dyad.__init__  DYAD_PY   13  2332024   94262  404873  310611   \n",
-       "0  NPZReader.__init__   reader    7   618617  103126  103148      22   \n",
-       "\n",
-       "   tinterval  trange   hostname  compute_time  io_time  app_io_time  \\\n",
-       "0       <NA>     0.0  corona171          <NA>     <NA>         <NA>   \n",
-       "1       <NA>     0.0  corona171          <NA>     <NA>         <NA>   \n",
-       "0       <NA>     0.0  corona173          <NA>     <NA>         <NA>   \n",
-       "1       <NA>     0.0  corona173          <NA>     <NA>         <NA>   \n",
-       "0       <NA>     0.0  corona171          <NA>     <NA>         <NA>   \n",
-       "\n",
-       "   total_time filename  phase  size  index  \n",
-       "0           0     <NA>      0  <NA>   <NA>  \n",
-       "1           0     <NA>      0  <NA>   <NA>  \n",
-       "0           0     <NA>      0  <NA>   <NA>  \n",
-       "1           0     <NA>      0  <NA>   <NA>  \n",
-       "0           0     <NA>      0  <NA>   <NA>  "
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "analyzer.events.sort_values(\"ts\").head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": null,
    "id": "3181e9d5-7203-48a9-9937-6e0e11062aa2",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "name\n",
-       "__fxstat64                      16.374204\n",
-       "__xstat64                        0.361658\n",
-       "close                           13.684002\n",
-       "cpu-gpu-transfer                 0.000000\n",
-       "lseek64                          0.204211\n",
-       "model-compute-backward-prop      0.000000\n",
-       "model-compute-forward-prop       0.000000\n",
-       "open64                          15.335467\n",
-       "opendir                          1.125259\n",
-       "read                           570.389110\n",
-       "real_IO.iter                     0.000000\n",
-       "real_IO.yield                    0.000000\n",
-       "Name: io_time, dtype: double[pyarrow]"
-      ]
-     },
-     "execution_count": 101,
-     "metadata": {},
-     "output_type": "execute_result"
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-01-29T07:15:03.035694Z",
+     "start_time": "2024-01-29T07:15:03.035674Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "analyzer.events.groupby([\"trange\",\"pid\",\"tid\", \"name\"])[\"io_time\"].sum().groupby([\"trange\", \"name\"]).max().groupby([ \"name\"]).sum().compute() / 1e6"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": null,
    "id": "fcc4be8e-889b-4112-a2c4-11b546f9c6d5",
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-01-29T07:15:03.037918Z",
+     "start_time": "2024-01-29T07:15:03.037898Z"
+    },
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "name\n",
-       "__fxstat64                     1274819\n",
-       "__xstat64                        12515\n",
-       "close                          1274797\n",
-       "cpu-gpu-transfer                     0\n",
-       "lseek64                        2639837\n",
-       "model-compute-backward-prop          0\n",
-       "model-compute-forward-prop           0\n",
-       "open64                         1274822\n",
-       "opendir                          12523\n",
-       "read                           2549801\n",
-       "real_IO.iter                         0\n",
-       "real_IO.yield                        0\n",
-       "Name: io_time, dtype: int64[pyarrow]"
-      ]
-     },
-     "execution_count": 102,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "analyzer.events.groupby([\"trange\",\"pid\",\"tid\", \"name\"])[\"io_time\"].count().groupby([\"trange\", \"name\"]).sum().groupby([ \"name\"]).sum().compute()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": null,
    "id": "5932c31e-931d-4c99-b75c-abe0e53f029a",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/WS2/haridev/venvs/dlio_profiler_venv/lib/python3.9/site-packages/dask/dataframe/shuffle.py:1032: FutureWarning: Series.fillna with 'method' is deprecated and will raise in a future version. Use obj.ffill() or obj.bfill() instead.\n",
-      "  mins = mins.fillna(method=\"bfill\").tolist()\n",
-      "/usr/WS2/haridev/venvs/dlio_profiler_venv/lib/python3.9/site-packages/dask/dataframe/shuffle.py:1033: FutureWarning: Series.fillna with 'method' is deprecated and will raise in a future version. Use obj.ffill() or obj.bfill() instead.\n",
-      "  maxes = maxes.fillna(method=\"bfill\").tolist()\n"
-     ]
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-01-29T07:15:03.040355Z",
+     "start_time": "2024-01-29T07:15:03.040335Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "timeline = analyzer.plots._create_timeline( analyzer.events).compute()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": null,
    "id": "759b786c-b9e9-45bb-9fda-ad987350e39d",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>phase</th>\n",
-       "      <th>index</th>\n",
-       "      <th>size</th>\n",
-       "      <th>io_time</th>\n",
-       "      <th>app_io_time</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>trange</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0.0</th>\n",
-       "      <td>2</td>\n",
-       "      <td>57203</td>\n",
-       "      <td>3286277758</td>\n",
-       "      <td>20981624</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1.0</th>\n",
-       "      <td>2</td>\n",
-       "      <td>78084</td>\n",
-       "      <td>4536723584</td>\n",
-       "      <td>25873271</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2.0</th>\n",
-       "      <td>2</td>\n",
-       "      <td>79012</td>\n",
-       "      <td>4498540005</td>\n",
-       "      <td>25894710</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3.0</th>\n",
-       "      <td>2</td>\n",
-       "      <td>83955</td>\n",
-       "      <td>4835225564</td>\n",
-       "      <td>25658236</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4.0</th>\n",
-       "      <td>2</td>\n",
-       "      <td>85769</td>\n",
-       "      <td>4902985343</td>\n",
-       "      <td>25478400</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>23.0</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>30128731</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>24.0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>24.0</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>30003118</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>25.0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>25.0</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>10868765</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>78 rows × 5 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "        phase  index        size   io_time  app_io_time\n",
-       "trange                                                 \n",
-       "0.0         2  57203  3286277758  20981624            0\n",
-       "1.0         2  78084  4536723584  25873271            0\n",
-       "2.0         2  79012  4498540005  25894710            0\n",
-       "3.0         2  83955  4835225564  25658236            0\n",
-       "4.0         2  85769  4902985343  25478400            0\n",
-       "...       ...    ...         ...       ...          ...\n",
-       "23.0        3      0           0         0     30128731\n",
-       "24.0        1      0           0         0            0\n",
-       "24.0        3      0           0         0     30003118\n",
-       "25.0        1      0           0         0            0\n",
-       "25.0        3      0           0         0     10868765\n",
-       "\n",
-       "[78 rows x 5 columns]"
-      ]
-     },
-     "execution_count": 104,
-     "metadata": {},
-     "output_type": "execute_result"
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-01-29T07:15:03.042653Z",
+     "start_time": "2024-01-29T07:15:03.042634Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "timeline"
    ]
@@ -2485,9 +2073,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": null,
    "id": "479f5f05-1102-4ec1-bdfe-966b7f2a787b",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-01-29T07:15:03.044490Z",
+     "start_time": "2024-01-29T07:15:03.044473Z"
+    }
+   },
    "outputs": [],
    "source": [
     "fig.savefig(f'{app_name}_posix_io_time.pdf', format='pdf', bbox_inches='tight')"
@@ -2495,33 +2088,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": null,
    "id": "f319b292-e247-41b7-b9e3-7f9592ad1d12",
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-01-29T07:15:03.045954Z",
+     "start_time": "2024-01-29T07:15:03.045937Z"
+    },
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/WS2/haridev/venvs/dlio_profiler_venv/lib/python3.9/site-packages/dask/dataframe/shuffle.py:1032: FutureWarning: Series.fillna with 'method' is deprecated and will raise in a future version. Use obj.ffill() or obj.bfill() instead.\n",
-      "  mins = mins.fillna(method=\"bfill\").tolist()\n",
-      "/usr/WS2/haridev/venvs/dlio_profiler_venv/lib/python3.9/site-packages/dask/dataframe/shuffle.py:1033: FutureWarning: Series.fillna with 'method' is deprecated and will raise in a future version. Use obj.ffill() or obj.bfill() instead.\n",
-      "  maxes = maxes.fillna(method=\"bfill\").tolist()\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAErCAYAAAA8MVAlAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAABMOUlEQVR4nO3dd3xUVd4G8Gd66kx6QggkoRfpAtKRErAgri4iuopiZQHFtsK6wstaYtkXXd2IhXdR1BXXgp3QO6j00ElCaCG9zKRNvef9Y8iYIQFTZjIlz/fzmU8y994585ub9uTMuefIhBACRERERER+Su7pAoiIiIiI3ImBl4iIiIj8GgMvEREREfk1Bl4iIiIi8msMvERERETk1xh4iYiIiMivMfASERERkV9j4CUiIiIiv8bAS0RERER+jYGXiIiIiPyaRwPvsmXL0LdvX2i1Wmi1WgwbNgxr1qxx7H/kkUfQuXNnBAYGIjo6GlOnTsWJEyc8WDERERER+RqPBt6EhAS88sor2LdvH/bu3Ytx48Zh6tSpOHr0KABg0KBBWLFiBY4fP461a9dCCIGUlBTYbDZPlk1EREREPkQmhBCeLqKuiIgIvP7663jggQfq7cvIyEC/fv2QlZWFzp07e6A6IiIiIvI1Sk8XUMtms+GLL75AVVUVhg0bVm9/VVUVVqxYgeTkZHTo0OGK7ZhMJphMJsd9SZJQWlqKyMhIyGQyt9RORERERM0nhEBFRQXi4+Mhl7thAILwsIyMDBEcHCwUCoXQ6XTixx9/dNqflpYmgoODBQDRvXt3kZWVddX2Fi9eLADwxhtvvPHGG2+88eZjt/Pnz7slb3p8SIPZbMa5c+eg1+vx5ZdfYvny5di6dSt69eoFANDr9SgsLEReXh7+8Y9/IDc3Fzt37kRAQECD7V3ew6vX69GxY0fk5OQgNDTUpbVvzyrGsq05jvvtdBqk3noN1EpOfkFERETUWBUVFUhOTkZ5eTl0Op3L2/d44L3chAkT0LlzZ7z33nv19pnNZoSHh2P58uWYMWNGo9ozGAzQ6XTQ6/XQarUurXXh1xk4kmvA1P7x2HqqCOXVFky7NgH3Dkty6fMQERER+TN35jXAC+fhlSTJqYe2LiEEhBBX3N+aLpRV40iuAXIZcOuA9pg91n4R3Vf7LiCrsNLD1RERERFRLY8G3oULF2Lbtm04c+YMDh8+jIULF2LLli24++67cfr0aaSmpmLfvn04d+4cdu3ahWnTpiEwMBA33nijJ8sGAKw7WgAAGJgYjqgQDYZ3jsLIrlGQBPDWxkxYbZKHKyQiIiIiwMOBt7CwEPfeey+6d++O8ePHY8+ePVi7di0mTpyIgIAAbN++HTfeeCO6dOmC6dOnIzQ0FLt27UJMTIwny4bFJmHTiUIAwKTecY7tj4zuhNAAJXKKq/DV/gueKo+IiIiI6vC6Mbyu5o4xITuzivHKmhMID1ZjxX2DoZD/Nt3Z5pOFWLruFJQKGf45fQA6Rga55DmJiIiI/FWbG8PrC9YezQcATOwZ4xR2AWBst2hcmxQOq03gnxszIUl+/f8EERERkddj4G2iAoMRB8+XAwAm9Iqtt18mk2HO9V0QqFbgVEEFvjt0sZUrJCIiTxNCoLTKDAuv5yDyCl6z0pqvWHesAEIA/Tro0E4X2OAxUSEazBqRjLTNWfj457MYkhyB+LCGjyUiIv9RWmXGxuMF2HC8ABfLjZDL7H8T4nQBiNMG2D/W+Tw0QOXpkonaBAbeJrBJAhuO2WdnSOkVd9VjJ/WOxfbMImRc0OPtTVl46dZrIJdzaWMiIn9jtUnYc6YM648VYN/ZUtQdySYJoLDChMIKEzKgr/fYYI0C7XSBiNUGoJ0uALGXgnA7XQCiQjT1hs0RUfMw8DbBvrNlKK0yIzRAies6RV71WJlMhnnjumLuf/bjSK4e647lY/I17VqpUiIicrfzpdVYf6wAm08Worza4tjes10oJvaKw8guUaix2JCvNyLfUIN8vQn5+hrk6Y3INxhRXm1BlcmGrMLKBudvl8tliA3VOPcKOwJxIALVitZ8uUQ+jYG3CWovVhvXI6ZRywfH6QJwz7BELN+eg3/vOINBiRGIDtW4u0wiaiYhBPQ1FgSplVwinBpUY7ZhW2YRNhwrwIn8Csf2sCAVxvWIwYSesegQ8dvsPIFqBSKC1egVX/+qc6PFhgKDEXl6o+Nj/qVbQYURVptAnt6+vSG6QBWGdY7EAyOTEaBi+CW6mjYTeCVJgiQ1/+KBkkoT9pwphYDAxJ4xjW7rpmvisD2zCCfyK/CvTZlYdHNPyGR8i4rIG5RWmZFVWInsokpkXuplK6+xIEStxNju0UjpHYukyGBPl0keJoTA8bwKrD9egB1ZJTBZbQAAuUyGwUnhmNgzFgM7hkGpsP+T1Ni/D2qFDB3CA9EhvP41HpIkUFJlRoHB3htcG4YLDCbkG4wwGC0orzFjzZE8HM8zYOEN3a94XQmRL2hJRmsMv52HNy0tDWlpabDZbDh16hROnTqF0NDQZrf3/dFifHWoCF2jA/HcxKQmPfai3oRFa3JglQQeHhaP4cm6ZtdBRM2jN1pxptSIM6VG5JTU4EypEeU11t99XKfIQIztEoYhHbUIULHXty0pr7FiZ44e27LLUVBhdmyP06oxulMYRiTroAv0TL9RtdmGzOIa/N/PF2Ew2hCkluPR4e3RNz7EI/UQtVRFRQW6devmtnl4/Tbw1qqdyLisrKzZJ1CSBB75ZD8KKox4fHxXjO/R9JXevth3AR//fBahGiX+ddcAhAepm1WLLxJCwCYJKOQy9m77EYPRgtyyGuSW1+BCmf2WW14DIYDIEDWigtWIDNEgKkSNqEsfI0M00AYo3f59YKixIKuo8lLvbRUyCytRXGmqd5xcJkNCWCA6x4Sga0wIOkcHIykyGMfyDFh/rAC/5JTCdulXZKBKgdHdopHSMwZdYkL4veynrDYJe8+WYcPxQuw9Wwbp0tc/QKnAyC6RmNgrFj3iQr3m619cacKr6SdxsqACMshw99AO+OPABF4kTT7HYDAgPDycgbe5XLFyx8Hz5Xj+myMIUivw0awhzRorZbVJeOqLQzhdVIXhnSOx8MaezarFXSw2CUaLDSar/aPRIsFkvfTx0naTteH9xjr77dud2zJZbJAEEKRWoH14IBLCAtE+PBDtw4LQPjwQ8WEB0Cg5/swb2SSBfIMRF0qr6wRb++eGRvSONkSlkDmCcHSIBpEhGntADtE4grE2QNXoP9gVRos91BZUIKuoEtmFlSgw1A+3MhnQPizQHmxjQtAlJgSdokKueuFPebUZG44XYt3RfKdxlMlRwZjUOw5ju0cjWNNmRob5tcZcgOatF4mZrRI+2H4a6Ufs15lc1ykCT0zshiA1vzfJd7h7pTUG3kZ4Nf0EdmQW48Y+7TB7bOdm13K6qBJP/PcQJElg4Q09MLxLVLPbchWjxYZ3tmRjy8lCePI7ITpUg/aXgnBCeCDiw+zBOCpE49c9FZIkUGOxocpsRY3ZBpskEKBSXLrJEaBUtMrrrzRZkVsnzNYG24vlRtiuslpg7dctITwQCeH2f2CUchmKKk0oqTSjuNKE4goTSqrsn9cNElejVMgQGaxGdKgGkcHOgVijkiOnqMox7jb/Chf0xIcFoEtMCLrGhNrDbXRwswOAEAKHc/VYezQfu7JLYLXZz4laKcfILlGY1DsOPdt5T68fNU6N2YbtmUVY38gL0LzduqP5WLY1G1abQPuwQDx3U0+vrr/KZMWG4wWoMFqhVsihUsqgUsihlMuhUcqhVNjvqxQyqBUKx/26x6rkdR/HdxF9GQNvC7X0BOqrLZi54lfYJIF/3tkfnaJbNj7q491n8N+9FxAWpELa3QOh9eCk47nlNXj5p+M4V1Lt2KaQyxCgkkOjVDg+apRyRwCru92x/wrbA1RyaFT2x6uVcpRVmS+FqhpcKK/BxfIa5JbVoNJ05Z5ClUKG+NogHGYPVbX3QzzYsyaEgMkqocpkRbXZZg+tJntorTLbUG22ospk/1httl26XTrWbA+41Sb7436PSiFDgEqBwEtBWKO69PW4dI5rvzaBKoXj6+E4VilHoFrhOF4ut68WWDsE4UJZNS6U1Vw1iKqVcqdQm1Dnn5KmvtthtkooqzajqDYEV5hQXPnb50WVJuhrLE3+5ytWG4CusSHoEh2CrrEh6BQd4rbvD4PRgs0nCrHuaAHOlf72s9MxIggpvWNxfY8Yj/5ct2WSJFB96Wex0mRFpdHq+LzKfOm+2YZKo33b0Yt6GC32C2XkMuDapAik9IrFoMRwxwVovuZUQQVe/uk4SirNCFQpMH9iVwzv7PnOlbokSWDdsQJ8+svZRv8T3FgqhQzK2lDsCMxyKOQyKOUyyC//KLN/VFy62T+XQyGH80cZoFDIoahzvFJhf7xCLoN0aeieTRKwSgKSJGCrs612e937kvjtWKt09ccDgEYph0Ylh1qhgPrS31VNndtv2xRQK+rsV112v+5xSrnXzPXMwNtCLT2Bqw9cwL93nEGXmBC8Mb1/i+sxWyXM//wAzpfW4Pru0XgypXuL22yOn0+XYOn6U6gx2xAWpMJfJvVAz3ahrf5LXggBQ40VF8rtvYkXyqod40Lz9FfvXQwLUqF9mD14tQ8LRFSops4vDglWScBqc75vu7TN1pjjJAFbne0WScBYJ7xepbQmUypkCFYrIZMBpkvDRVzZfmNEBKuREF7by34p2Hqgl91ik1BWZUZxbQ9xnd7iokoTqk02JEYG2XtvY0PROTrYI6tVCSFwIr8Ca4/mY3tmMcxWe3BSKmQY1ikSk3rHoU97ncfeoRBCwGITsNikS7e6nzvfN1vtn1ul3z632CRYbQLmKzxGEoBSLoNSbu+J+y0s/BYa6gYDpfy30OF0XyFztFP3vlwmQ43FZg+uJntwrTJZUWG0/zNZZf4t1Fab7dtrLLYm/7PUPiwQE3vFYlyPGIQH+8e1FeXVZryafgJHcg0AgDuuTcDdQxO94t2yI7l6vL/tNHKKqwDY34np1yEMFquwf/9d+r5r7Pfm1f5GUOMo5DKEBijxVEp39O8Q5rE6GHhbqCUnUAiB2Z/sR255DeZc39llC0ecyDfgL19mQAhg8ZReuDYpwiXtNoYkCXzyy1l8sfcCAKBXOy2evaEHIrzwF71NEigwGJF7qSe49q323PIalFWZf7+BViCX2efZDFYrnT9qFAhSKxF0aVuQRoEg9W/bnD+vP+erEPZf5rVjqI0WCUarDUaLvYe4dnx0jcUGU519tWOqHcdfdqzVJhCt1TjCbG2wbR8eyPF+LVBlsmLbqSKsPZqP7KIqx/Y4XQBSesViQs9Yl4QpIexDYEoqzSirNqOkyozSyz4vrTajrMoMk9W9U/x4M7VSjhCNEiEaJYI1CgRrlAjVKBF0aZt9uxIdIgLRPdY/h6JYbRI+3HUG3x68CAAY2DEMT0/q7rGljAsMRvx7Rw52ZZcAsF/TcdfQjrixTzuoWtDRIkkCFsn+z5jVJl36B03AYnX+J80mfutJrdujWtuhYZMAqyTZe11tDfe+NtQLa73UUyuT2f8BVMgu/bPn6P29cg+x4nd6muv2Rte+q2iySjDXudVeP1P3vtlW+7n974PJVvd4+7EWW/3oN65HDJ6Y2K3ZX4uWYuBtoZacwCO5eiz8+jA0SjlWPjDEpYFg+fbT+PbgRUSGqPHO3QNbJWzoayx4fe0JHDpvX95yav943Dc8ySffuqs2W3GxTgDOLatBeY3lyj1MchkUdXqSnHukLjtOLnN6C6y210khtw8VqA2swRolNEq5X/6xpObLKqzE2qP52HqyyDFkRS6XYWhyBCb1jsWADuEN9rQZLTaUVNnDakmVGaVVJpRWWS59NDtutW/BN5VSIXMa71g7FlKpqHvf/nZw7ecqhRwqpf3nwz6mUu4YUymXyRx/+K0253dGnO5fts/+UXK822KtEzosNucwEaBSIDTgt9AaolYiJECJ4NqPGiVCavddunHREGdbThbi7U1ZMFslxGo1+OuNPVs8NK8pasw2/HfveXxzMBdWm4BcBky6Jg53D02ELpBDfzxFkuydKiarhD05pfjnxkx0ig7GP+8c4LGaGHhbqCUncOn6U9h8ohATesbi8QldXVqX0WLDvM8OIF9vxORr4jDn+i4ubf9ymZfGdRVXmqFRyvHY+K4Y3S3arc9J1JYZLTZszyzGuqP5ThdERYdqMDgpAtVmq1PArTH//njuWoFqBSKD1Yi4wi08SI0gtcIRZGt7iahtOl1UiZd/Oo4CgwlqpRzzxnXB2O5Nn16zKSRJYOOJQqzcfcYxTrdfBx0eHNkJSVFczMWbFBiMePCjvVAqZPjikWEe6wRzd+Dle5hXUGmyYmdWMQBg0jWxLm8/QKXAY+O64q+rDyP9SD5Gd41GnwTXL0ghhMDaowV4b5v9yt34sAD89caeSOTqUURuFaBSYGKvWEzsFYuzJVVYd7QAm04UoqjChJ8O513hMfLLwqvGKdiGB6sREaT22umxyDt1irZfg/KPtSex/1w5/nfdKWQWVOL+Ee55h+/oRT2Wb89BVmElAPvQngdGJmNocgTfEfNC0SEaBKoUqLHYkFte47f5gIH3CracLITZKqFjZBC6xzZ/hbar6ZOgw+Rr4pB+JB9vbcrE2zMGuHQ9dJPVhne3nMaG4wUA7HMzzp/QjfOGErWyxMhgPDS6E2YOT8Ku7GKcLqpCWJDKKdxGBmsYZMltQgNUWDylNz795Sz+u/cCvjt0EaeLK/Hs5B4Ic9FCSIUVRny48wy2Z9o7iwLVCtw5uANu7hvPYSZeTC6XISkqCMfzKpBTXMXA25YIIbDuqD0kpvSKdet/pPePSMKeM6XI1xvxyc9n8eCoTi5pt8BgROpPx5FdVAW5DLhnWBJuH9ie/10TeZBaKcfY7jEY65nJWaiNk8tluGdYErrEhOKN9adwJNeA+Z8fxF9v7IluLejYMVps+HLfBXy9/wIsNvsFXCm9YvGn6xJdFqbJvZKigh2B119/P/FfrgZkFVYip7gKKoUM45qxjHBTBKmVmHtp/O73hy7iRL6hxW3uO1uK+asOIruoCtpAJZZMvQZ/HJTAsEtERBjWORL/e0c/JIQHoqTSjGe/ysDao/lNbkeSBDafKMSjn+zD53vOw2ITuKa9Fm9O74+547oy7PqQTpfGVZ+tMy+/v2EPbwPWHbP37g7vHNUqU7hcmxSB67tHY/PJIry1MRNvTh/QrLd/JEngv3vP4z+/noMQQNfYECy8oSeiQzVuqJqIiHxVh4gg/O8d/fDmhkzszi7BvzZlIauwEg+N6tSovz8n8yvw/rbTOFVgvyAzVqvBrBHJGNY5kp0rPqh2GMPp4qrfOdJ3tZnAK0kSJOn3p/OpMdvsy+xCYGKvmEY9xhVmjUzC/nNlOFdajVW/nsWfrkts0uMrjBa8sSETe8+WAQAm9Y7DQyOToVbKW+01EBGR7whQyvGXlG74cv8FfPrLeaw5kofTRZV4dnJ3RIU03FFSXGnCx7vPYvOpIgBAoEqBPw5KwNR+9nG6Qgj4+eRPfqljeCAAoLTKhLIqk0emjHN3VvHbwJuWloa0tDTYbPapfoqKimA0Gn/3cduyy1FRbUJsqBoxSiMKC03uLtXhzn4R+Nf2XKz65Qx6hMvQMTygUY87V2bE29svoKjSApVChnsHx2FUp1CUlxa7uWIiIvJ1YztqEKmMw7u7LuLohTLM/WQP/jwyAT1ighzHmKwS1hwvwU/HS2C22sfpjkzW4fZ+MQgLVPLvjR+ICJChoMKC/ZkX0Duu9S9cq6io+P2DWqDNzMNbVlbWqHndnvkyAycLKnDfsCTcNrB9K1To7JU1J7DrdAk6RQXjH3/s+7tTxmw+WYi0zdkw2yTEhgZg4Q3dW3VScSIi8g/5eiNS15xATkkVFDIZZo1Iws1922FHVjFW7DqL4kp7B1DPOC0eGpWMLjH8W+NPavPHrBFJuLV/6+cfg8GA8PBwzsPbUnK5HHL51cPjmeIqnCqohEIux4Resb97vDvMHtsFh3MNyCmuxjeH8nDHtR0aPM5ik7B8e45jPs9rEyPwVEo3jy0bSUREvi0+PAivT+uHf23KwtZTRVi+4wy+O5SHwgp70I0JDcB9w5MwqmsUx+n6oeToEOw+XYqzJTUeyT/ufk7O0lBH7VWq1yVHeOzq0vBgNR4anQwAWPXrOZwvrX/FZHGlCQu/PoyfDudBJgNmDOmIRTf3YtglIqIWCVAp8FRKNzw4KhlyGVBYYYJGKcfdQzti2Z8GYnS3aIZdP5V06cK1HD+9cK3N9PD+HpPVhs0nCwEAKb1dv7JaU1zfPQbbThVj39kyvLUxE6/e3texLGjGhXK8vvYkyqstCNYo8HRKd1ybFOHReomIyH/IZDJM7d8e3WJDceBcOVJ6x17xIjbyH52i7YH3fFk1rDbJY0sMu4t/vZoW2JVdgiqTDdGhGgzoEO7RWmQyGeZc3wWBKgVO5Ffg+4yLEELgq30X8Pw3R1BebUFyVDDenD6AYZeIiNyiZzst7hrakWG3jahdYthqE8gtr/F0OS7HwHvJukvDGSb2inX0pnpSdKgG949IAgB8vPssXvzxOD7cdQaSAMb1iMFrf+yLOF3jZnEgIiIiupraJYYB/xzWwMALILe8BkdyDZDLgAk9PTucoa5JveNwTXstTFYJv+aUQiGX4c9jO2P+hK4IUCk8XR4RERH5keQo+8wbDLx+qrZ3d0DHcK9alUwul2HeuK7QBioRFaLGq7f3xQ192vGCASIiInK55Es9vGf8MPC2+YvWLDYJm07YL1ab1DvOw9XUFx8WiOX3DoZGKfeKoRZERETkn5KiLs3UUFJ/hihf1+Z7ePfklKK82oKwIBUGJ3n2YrUrCVQrGHaJiIjIrRIjgiGTAWVVZuirLZ4ux6XafOBdW+diNX+bgoOIiIiosQLVCsRp7RfE55T417CGNp3wCgxGHDhfDsAeeImIiIjasuRLwxr8bRxvmxnDK0kSJEly2rbuaD4kIdC3vQ6xoZp6+4mIiIjaksTIIOzMLsbpospWzUXufi6/DbxpaWlIS0uDzWYDABQVFcFoNDr22ySBnw6dh9VixdD2ASgsLPRUqUREREReIUxhhtVixYncEhQW6lrteSsqKtzavt8G3jlz5mDOnDkwGAzQ6XSIjo6GVqt17N9zphQVFiA8JBCTBnSCWtmmR3cQERERYUCAFsrd+SiqFoiIjGq165sCAty7mJbfBt7LyeVyyOW/fdHWHyuEDDKM7xmDAHWbOQ1EREREVxSnC0SQSokaiw15BhMSI4Nb5XnrZjS3tO/W1r1UaZUZe86UAvDOuXeJiIiIPEEm+22J4dN+dOFamwy8G44VQBJAz3ah6BAR5OlyiIiIiLxG7RLD/jRTQ5sLvJIksO6Yfe7dlF7s3SUiIiKqyx+XGG5zgTcjV48CgwmBagVGdo3ydDlEREREXsUflxhuc4F33aWV1cZ2j0aASuHhaoiIiIi8iz8uMdymAq++xoLdp0sA8GI1IiIioob44xLDbSrwbj5RCKtNoEtMCDpHh3i6HCIiIiKv5G9LDLeZwCuEwNqjtRerxXq4GiIiIiLvVTuO11+mJvNo4E1NTcXgwYMRGhqKmJgY3HrrrTh58qTTMWPHjoVMJnO6Pfroo01+rhP5Blwoq4FGKceY7tGueglEREREfoc9vC60detWzJkzBz///DPWr18Pi8WClJQUVFU5n9yHHnoIeXl5jttrr73W5OfadLwIADCqazSCuLIaERER0RXVBt7zZdWw2iQPV9NyHk1+6enpTvc//PBDxMTEYN++fRg9erRje1BQEOLiGneRmclkgslkctw3GAwAgF3ZxRCqQIzrHgmLxT+uOCQiIiJyh/AAOQJUctSYbThTXIFENy/U5e5s5lVdnXq9HgAQERHhtP3TTz/FJ598gri4OEyZMgXPP/88goIaPvGpqalYsmRJve3FpeWIDTMhe992nJa5vnYiIiIif6KolkNfJcMXa7aiV7hw63NVV7t3zl+ZEMK9r6CRJEnCLbfcgvLycuzYscOx/f3330diYiLi4+ORkZGBZ599FkOGDMHXX3/dYDsN9fB26NABKa+uwSPje2FK33Zufy1EREREvu69bTlIP1qAW/u3w8xhiW59LoPBgKioKOj1emi1Wpe37zU9vHPmzMGRI0ecwi4APPzww47P+/Tpg3bt2mH8+PHIzs5G586d67Wj0Wig0WjqbVcp5JjQux1UKpXriyciIiLyM11iQyE7VojzZUa35yd3t+8V05LNnTsXP/zwAzZv3oyEhISrHjt06FAAQFZWVpOeY2hyBLQBDLtEREREjeFPU5N5NPAKITB37lysXr0amzZtQnJy8u8+5uDBgwCAdu2aNjRhfM+Y5pRIRERE1CYlRdqXGC6vtqC82uzpclrEo0Ma5syZg//85z/49ttvERoaivx8+8IQOp0OgYGByM7Oxn/+8x/ceOONiIyMREZGBp544gmMHj0affv2bdJz9Y7XueMlEBEREfmlAJUC7XQBuFhuxJmSavQPUnu6pGbzaA/vsmXLoNfrMXbsWLRr185x+/zzzwEAarUaGzZsQEpKCnr06IGnnnoKt99+O77//vsmP5dMxqkZiIiIiJoiKdI/FqDwaA/v700Q0aFDB2zdurWVqiEiIiKiupKjgrEru8Tnx/F6xUVrREREROR9kvxkiWEGXiIiIiJqUO0Sw+dKfXuJYQZeIiIiImpQTKgGgWoFbJLAhbIaT5fTbAy8RERERNQgmUyG5EsXruWU+O6wBgZeIiIiIrqi5GjfH8fLwEtEREREV5QUGQTAtwOvR6cla02SJEGSfHewNREREZEnJEYEQUDgdHGV27KUuzOa3wbetLQ0pKWlwWazAQCKiopgNBo9XBURERGRbwmUJNisVhTprcg8dxG6ANfHx4qKCpe3WZdM/N7qDz7OYDBAp9OhrKwMWq3W0+UQERER+ZxHP9mPi/oavHBLb/TrEOby9g0GA8LDw6HX692S1/y2h/dycrkccjmHLBMRERE1VXJUMPL0RpwprcaAxAiXt+/ujMYESERERERXVbsARU5xtYcraR4GXiIiIiK6qmQfX2KYgZeIiIiIrirJx5cYZuAlIiIioqvy9SWGGXiJiIiI6Kqclhj2wWENDLxERERE9LscSwyX+F7gbda0ZOfOncPZs2dRXV2N6Oho9O7dGxqNxtW1EREREZGXqF1i2Bd7eBsdeM+cOYNly5Zh1apVuHDhAuquV6FWqzFq1Cg8/PDDuP322znfLREREZGfSY4KAeCbgbdRyfSxxx5Dv379kJOTgxdffBHHjh2DXq+H2WxGfn4+fvrpJ4wcORKLFi1C3759sWfPHnfXTUREREStKDEyCDIZUF5tQXm12dPlNEmjeniDg4Nx+vRpREZG1tsXExODcePGYdy4cVi8eDHS09Nx/vx5DB482OXFEhEREZFnBKgUaKcLwMVyI86UVKN/kNrTJTVaowJvampqoxucPHlys4txJ0mSIEm+N28cERERkbdIjAxCbnkNThdWoG97rcvadXdGa/JFazk5ObBarejatavT9szMTKhUKiQlJbmqthZJS0tDWloabDYbAKCoqAhGo9HDVRERERH5rki1BKvFiiPnijC8vcpl7VZUVLisrYY0OfDed999mDVrVr3A+8svv2D58uXYsmWLq2prkTlz5mDOnDkwGAzQ6XSIjo6GVuu6/0SIiIiI2pp+yUp8f7wMRTX2Ya2uEhAQ4LK2GtLkwHvgwAGMGDGi3vbrrrsOc+fOdUlR7iCXyzl7BBEREVELJEeHQAYZzpfVwCYAlcI12crdGa3Jrctksga7nfV6vWP4ABERERH5n5hQDYIuLTGc60NLDDc58I4ePRqpqalO4dZmsyE1NRUjR450aXFERERE5D1kMhmSo3xvieEmD2l49dVXMXr0aHTv3h2jRo0CAGzfvh0GgwGbNm1yeYFERERE5D2SooJx9KLBp5YYbnIPb69evZCRkYE77rgDhYWFqKiowL333osTJ07gmmuucUeNREREROQlkiLbQA8vAMTHx+Pll192dS1ERERE5OV8cUhDsy6J2759O/70pz9h+PDhyM3NBQB8/PHH2LFjh0uLIyIiIiLv4otLDDc58H711VeYNGkSAgMDsX//fphMJgD2WRrY60tERETk32qXGAZ8p5e3yYH3xRdfxLvvvosPPvgAKtVvK2yMGDEC+/fvd2lxREREROR9ki4Na/CVC9eaHHhPnjyJ0aNH19uu0+lQXl7uipqIiIiIyIt1qh3HW+SngTcuLg5ZWVn1tu/YsQOdOnVySVFERERE5L1qZ2o4U1Lt4Uoap8mB96GHHsLjjz+OX375BTKZDBcvXsSnn36Kp59+GrNnz3ZHjURERETkRWpnajhXWg2LTfJwNb+vydOSLViwAJIkYfz48aiursbo0aOh0Wjw9NNPY968ee6o0SUkSYIkef8XhIiIiMjbRQarEKRWoMpsxbmSKkcAbi53Z7QmB16ZTIbnnnsOzzzzDLKyslBZWYlevXohJCTEHfU1W1paGtLS0hxLIBcVFcFoNHq4KiIiIiL/EBssx6kqKw5lX0SwpGtRWxUVFS6qqmEyIYRoSQO1Swp3794dPXv2dFVdLmMwGKDT6VBWVgatVuvpcoiIiIj8wnvbTuPHw3n4Q//2uH9EUovaMhgMCA8Ph16vd0tea3IP7x133IHRo0dj7ty5qKmpweDBg5GTkwMhBFatWoXbb7/d5UW6glwuh1zerHU2iIiIiOgyyVEhkEGGs6XVLc5Y7s5oTW5927ZtGDVqFABg9erVkCQJ5eXleOutt/Diiy+6vEAiIiIi8j6don1nieEmB169Xo+IiAgAQHp6Om6//XYEBQXhpptuQmZmpssLJCIiIiLv0zHCd5YYbnLg7dChA3bv3o2qqiqkp6cjJSUFAFBWVoaAgACXF0hERERE3seXlhhucuCdP38+7r77biQkJCA+Ph5jx44FYB/q0KdPH1fXR0REREReqnaJYW8PvE2+aO3Pf/4zhg4dinPnzmHixImOQcadOnXiGF4iIiKiNqRTVDB2ZZXgjL8FXgAYNGgQBg0a5LTtpptucklBREREROQbapcYzvHyJYYbNaThlVdeQU1NTaMa/OWXX/Djjz+2qCgiIiIi8n61K6yd9/IlhhsVeI8dO4aOHTviz3/+M9asWYOioiLHPqvVioyMDLzzzjsYPnw4pk+fjtDQ0EY9+bZt2zBlyhTEx8dDJpPhm2++qXfM8ePHccstt0Cn0yE4OBiDBw/GuXPnGvfqiIiIiMhtokM1CFIrYJMELpQ1rnPUExoVeFeuXIkNGzbAYrHgrrvuQlxcHNRqNUJDQ6HRaDBgwAD8+9//xr333osTJ05g9OjRjXryqqoq9OvXD2lpaQ3uz87OxsiRI9GjRw9s2bIFGRkZeP755zkbBBEREZEXkMlkjl5ebx7H2+SlhSVJQkZGBs6ePYuamhpERUWhf//+iIqKalkhMhlWr16NW2+91bHtzjvvhEqlwscff9zsdmuXFnbXUnVEREREbdm7W7PxY0Ye/jCgPWaNTG5WG+7Oa02+aE0ul6N///7o37+/y4upS5Ik/Pjjj/jLX/6CSZMm4cCBA0hOTsbChQudQvHlTCYTTCaT477BYAAAWCwWWCwWt9ZMRERE1NZ0CNNACIHTRRXNzlruzmjNmqWhNRQWFqKyshKvvPIKXnzxRbz66qtIT0/Hbbfdhs2bN2PMmDENPi41NRVLliypt33dunUICgpyd9lEREREbUpeNaDXK7Cnqhw/yXOa1UZ1tXtneWjykAZ3uXxIw8WLF9G+fXvMmDED//nPfxzH3XLLLQgODsZnn33WYDsN9fB26NABxcXFHNJARERE5GJGiw13/d8eCAGsmDkIYUGqJrdhMBgQFRXlPUMaWktUVBSUSiV69erltL1nz57YsWPHFR+n0Wig0WjqbVepVFCpmv4FICIiIqIrU6lUiA8LxMVyIy7oTYjWNf0ddXdntCYvLdxa1Go1Bg8ejJMnTzptP3XqFBITEz1UFRERERFdLjkqBID3LjHc7B7erKwsZGdnY/To0QgMDIQQAjKZrEltVFZWIisry3E/JycHBw8eREREBDp27IhnnnkG06dPx+jRo3H99dcjPT0d33//PbZs2dLcsomIiIjIxZKjgrAzy3unJmtyD29JSQkmTJiAbt264cYbb0ReXh4A4IEHHsBTTz3VpLb27t2LAQMGYMCAAQCAJ598EgMGDMCiRYsAAH/4wx/w7rvv4rXXXkOfPn2wfPlyfPXVVxg5cmRTyyYiIiIiN/H2JYabHHifeOIJKJVKnDt3zmnWg+nTpyM9Pb1JbY0dOxZCiHq3Dz/80HHMrFmzkJmZiZqaGhw8eBBTp05taslERERE5EbevsRwk4c0rFu3DmvXrkVCQoLT9q5du+Ls2bMuK4yIiIiIfEN0qAbBGgWqTDZcKKtxBGBv0eQe3qqqqgbnsy0tLW1wdgQiIiIi8m/evsRwkwPvqFGjsHLlSsd9mUwGSZLw2muv4frrr3dpcURERETkGxJrx/F6YeBt8pCG1157DePHj8fevXthNpvxl7/8BUePHkVpaSl27tzpjhqJiIiIyMvV9vB6Y+Btcg/vNddcg1OnTmHkyJGYOnUqqqqqcNttt+HAgQPo3LmzO2okIiIiIi/nGNJQ4n2Bt1nz8Op0Ojz33HOuroWIiIiIfFTHiCDIZEB5tQXl1WaEBak9XZJDswKv0WhERkYGCgsLIUnOU0/ccsstLimMiIiIiHxHgEqBdroAXCw3Iqe4CgM6+nDgTU9Px7333ovi4uJ6+2QyGWw2m0sKczVJkuqFcyIiIiJynaTIYOSW1+B0USX6Jega/Th3Z7QmB9558+Zh2rRpWLRoEWJjY91Rk0ukpaUhLS3NEcCLiopgNBo9XBURERGR/4rS2GC1WHH0XBFGtFc1+nEVFRVurAqQCSFEUx6g1Wp96gI1g8EAnU6HsrIyaLVaT5dDRERE5Ld+zSnFiz8dR1JkMN66s3+jH2cwGBAeHg69Xu+WvNbkHt4//vGP2LJli88E3lpyuRxyeZMnpSAiIiKiRuoUEwIZZLhQVgObAFSKxmUvd2e0Jgfef/3rX5g2bRq2b9+OPn36QKVy7q5+7LHHXFYcEREREfmO6BDvXGK4yYH3s88+w7p16xAQEIAtW7ZAJpM59slkMgZeIiIiojaqdonhI7kGnCmu8t3A+9xzz2HJkiVYsGABhwgQERERkZPESHvgzSmuwvWeLuaSJidWs9mM6dOnM+wSERERUT3euMRwk1PrzJkz8fnnn7ujFiIiIiLycZ28cInhJg9psNlseO2117B27Vr07du33kVrS5cudVlxRERERORbOkQEQe5lSww3OfAePnwYAwYMAAAcOXLEaV/dC9iIiIiIqO2xLzEcaF9xrbgKA71gieEmB97Nmze7ow4iIiIi8hNJUfYlhs8UV2Fgx3BPl9P0MbxERERERFfjGMfrJReuNaqH97bbbsOHH34IrVaL22677arHfv311y4pjIiIiIh8U2JkEAAgp6Taw5XYNSrw6nQ6x/hcnU7n1oLcRZIkSJLk6TKIiIiI/F5SZBAEBM6XVsFksf7uEsPuzmiNCrwrVqzA3//+dzz99NNYsWKFWwtylbS0NKSlpcFmswEAioqKYDQaPVwVERERkf8TQkAtk1BtknAo6wI6hgdc9fiKigq31iMTQojGHKhQKJCXl4eYmBi3FuRqBoMBOp0OZWVl0Gq1ni6HiIiIqE346+ojOHJRjycmdMX13a+eHw0GA8LDw6HX692S1xo9S0Mjc7HXksvlXB2OiIiIqJUkRwXj6EUDzpTU/G4Gc3dGa1LrnGeXiIiIiBojyYtmamjSPLzdunX73dBbWlraooKIiIiIyPd50xLDTQq8S5Ys8dlZGoiIiIio9XjTEsNNCrx33nmnz120RkREREStz5uWGG70GF6O3yUiIiKipkiOtg9ryCny7LCGRgdeX5+lgYiIiIhaV3KkPfCe9fA43kYPaeAqZURERETUFLUzNZz28EwNnJiWiIiIiNwiKSoIAHC+rAYWm+c6T5t00RoRERERUWNFh2hw28D2SAgPguTB4bEMvERERETkFjKZDPePSPZ0GRzSQERERET+rc308EqSxAvviIiIiLyQuzOa3wbetLQ0pKWlwWazAQCKiopgNBo9XBURERERXa6iosKt7cuEn0+wazAYoNPpUFZWBq1W6+lyiIiIiOgyBoMB4eHh0Ov1bslrftvDezm5XA65nEOWiYiIiLyNuzMaEyARERER+TUGXiIiIiLyawy8REREROTXGHiJiIiIyK8x8BIRERGRX2PgJSIiIiK/xsBLRERERH7NqwOvzWbD888/j+TkZAQGBqJz58544YUX4OdrZRARERGRC3n1whOvvvoqli1bho8++gi9e/fG3r17cf/990On0+Gxxx7zdHlERERE5AO8OvDu2rULU6dOxU033QQASEpKwmeffYZff/3Vw5URERERka/w6sA7fPhwvP/++zh16hS6deuGQ4cOYceOHVi6dOkVH2MymWAymRz3DQYDAMBiscBisbi9ZiIiIiJqGndnNK8OvAsWLIDBYECPHj2gUChgs9nw0ksv4e67777iY1JTU7FkyZJ629etW4egoCB3lktEREREzVBdXe3W9mXCi68AW7VqFZ555hm8/vrr6N27Nw4ePIj58+dj6dKlmDlzZoOPaaiHt0OHDiguLoZWq22t0omIiIiokQwGA6KioqDX692S17w68Hbo0AELFizAnDlzHNtefPFFfPLJJzhx4kSj2jAYDNDpdG47gURERETUMu7Oa149LVl1dTXkcucSFQoFJEnyUEVERERE5Gu8egzvlClT8NJLL6Fjx47o3bs3Dhw4gKVLl2LWrFmeLo2IiIiIfIRXD2moqKjA888/j9WrV6OwsBDx8fGYMWMGFi1aBLVa3ag2OKSBiIiIyLu5O695deB1BQZeIiIiIu/WpsfwEhERERG1FAMvEREREfk1Bl4iIiIi8msMvERERETk1xh4iYiIiMivMfASERERkV/z6oUnXEmSJK7QRkREROSF3J3R/DbwpqWlIS0tDTabDQBQVFQEo9Ho4aqIiIiI6HIVFRVubb/NLDxRVlbGhSeIiIiIvJDBYEB4eLjbFp7w2x7ey8nlcsjlHLJMRERE5G3cndGYAImIiIjIrzHwEhEREZFfY+AlIiIiIr/GwEtEREREfo2Bl4iIiIj8GgMvEREREfk1Bl4iIiIi8msMvERERETk1xh4iYiIiMivMfASERERkV9j4CUiIiIiv6b0dAGtRZIkSJLk6TKIiIiI6DLuzmh+G3jT0tKQlpYGm80GACgqKoLRaPRwVURERER0uYqKCre2LxNCCLc+g4cZDAbodDqUlZVBq9V6uhwiIiIiuozBYEB4eDj0er1b8prf9vBeTi6XQy7nkGUiIiIib+PujMYESERERER+jYGXiIiIiPwaAy8RERER+TUGXiIiIiLyawy8REREROTXGHiJiIiIyK8x8BIRERGRX2PgJSIiIiK/xsBLRERERH6NgZeIiIiI/FqbWVpYkiRIkuTpMoiIiIjoMu7OaH4beNPS0pCWlgabzQYAKCoqgtFo9HBVRERERHS5iooKt7YvE0IItz6DhxkMBuh0OpSVlUGr1Xq6HCIiIiK6jMFgQHh4OPR6vVvymt/28F5OLpdDLueQZSIiIiJv4+6MxgRIRERERH6NgZeIiIiI/BoDLxERERH5NQZeIiIiIvJrDLxERERE5NcYeImIiIjIrzHwEhEREZFfY+AlIiIiIr/mE4E3LS0NSUlJCAgIwNChQ/Hrr796uiQiIiIi8hFeH3g///xzPPnkk1i8eDH279+Pfv36YdKkSSgsLPR0aURERETkA7w+8C5duhQPPfQQ7r//fvTq1QvvvvsugoKC8O9//9vTpRERERGRD1B6uoCrMZvN2LdvHxYuXOjYJpfLMWHCBOzevbvBx5hMJphMJsd9vV4PACgtLYXFYnFvwURERETUZBUVFQAAIYRb2vfqwFtcXAybzYbY2Fin7bGxsThx4kSDj0lNTcWSJUvqbU9OTnZLjURERETkGiUlJdDpdC5v16sDb3MsXLgQTz75pON+eXk5EhMTce7cOZefwMGDB2PPnj0ubdMX2zUYDOjQoQPOnz8PrVbr0rZ97Vy4o12eX/e3zXPs3nZ98fy6s22eY99r153nF/Ctc+GudvV6PTp27IiIiAiXtlvLqwNvVFQUFAoFCgoKnLYXFBQgLi6uwcdoNBpoNJp623U6ncu/SRUKhVu+8X2t3VparZbn2I3nmOfX/W3zHPP8tkbbPMe+2S7gnvML+N65cOc5lsvdc3mZV1+0plarMWjQIGzcuNGxTZIkbNy4EcOGDfNgZXZz5sxhu27ma+fC186xL54HnmPfbNddfPF7jefYN9t1J187F754jmXCXaODXeTzzz/HzJkz8d5772HIkCF488038d///hcnTpyoN7a3IQaDATqdDnq93q29m20Zz7F78fy6H8+xe/H8uh/PsXvx/Lqfu8+xVw9pAIDp06ejqKgIixYtQn5+Pvr374/09PRGhV3APsRh8eLFDQ5zINfgOXYvnl/34zl2L55f9+M5di+eX/dz9zn2+h5eIiIiIqKW8OoxvERERERELcXAS0RERER+jYGXiIiIiPwaAy8RERER+TW/D7xpaWlISkpCQEAAhg4dil9//dXTJfmEbdu2YcqUKYiPj4dMJsM333zjtF8IgUWLFqFdu3YIDAzEhAkTkJmZ6XTMqVOnMHXqVERFRUGr1WLkyJHYvHlzK74K75WamorBgwcjNDQUMTExuPXWW3Hy5EmnY95//32MHTsWWq0WMpkM5eXlTvu3bNkCmUzW4M1dK0/5kmXLlqFv376OieKHDRuGNWvWAABKS0sxb948dO/eHYGBgejYsSMee+wx6PX6eu18+OGH6Nu3LwICAhATE+OT80+2hldeeQUymQzz5893bHvkkUfQuXNnBAYGIjo6GlOnTr3isvAlJSVISEho8Hu9rfqf//mfej/bPXr0qHecEAI33HBDvd/VJSUlmDx5MuLj46HRaNChQwfMnTsXBoOhFV+Fd8vNzcWf/vQnREZGIjAwEH369MHevXsd+++77756X4PJkyc79p85cwYPPPAAkpOTERgYiM6dO2Px4sUwm82eeDleJykpqcG/UXV/j+7evRvjxo1DcHAwtFotRo8ejZqaGsf+l156CcOHD0dQUBDCwsKaXYtfB97PP/8cTz75JBYvXoz9+/ejX79+mDRpEgoLCz1dmterqqpCv379kJaW1uD+1157DW+99Rbeffdd/PLLLwgODsakSZNgNBodx9x8882wWq3YtGkT9u3bh379+uHmm29Gfn5+a70Mr7V161bMmTMHP//8M9avXw+LxYKUlBRUVVU5jqmursbkyZPx17/+tcE2hg8fjry8PKfbgw8+iOTkZFx77bWt9VK8VkJCAl555RXs27cPe/fuxbhx4zB16lQcPXoUFy9exMWLF/GPf/wDR44cwYcffoj09HQ88MADTm0sXboUzz33HBYsWICjR49iw4YNmDRpkodekffas2cP3nvvPfTt29dp+6BBg7BixQocP34ca9euhRACKSkpsNls9dp44IEH6j2egN69ezv9jO/YsaPeMW+++SZkMlm97XK5HFOnTsV3332HU6dO4cMPP8SGDRvw6KOPtkbpXq+srAwjRoyASqXCmjVrcOzYMfzv//4vwsPDnY6bPHmy09fgs88+c+w7ceIEJEnCe++9h6NHj+KNN97Au+++e8Xf223Nnj17nM7d+vXrAQDTpk0DYA+7kydPRkpKCn799Vfs2bMHc+fOdVptzWw2Y9q0aZg9e3bLihF+bMiQIWLOnDmO+zabTcTHx4vU1FQPVuV7AIjVq1c77kuSJOLi4sTrr7/u2FZeXi40Go347LPPhBBCFBUVCQBi27ZtjmMMBoMAINavX99qtfuKwsJCAUBs3bq13r7NmzcLAKKsrOyqbZjNZhEdHS3+/ve/u6lK3xceHi6WL1/e4L7//ve/Qq1WC4vFIoQQorS0VAQGBooNGza0Zok+p6KiQnTt2lWsX79ejBkzRjz++ONXPPbQoUMCgMjKynLa/s4774gxY8aIjRs3Nup7va1YvHix6Nev31WPOXDggGjfvr3Iy8ur97u6If/85z9FQkKC64r0Yc8++6wYOXLkVY+ZOXOmmDp1apPafe2110RycnILKvNfjz/+uOjcubOQJEkIIcTQoUPF3/72t0Y9dsWKFUKn0zX7uf22h9dsNmPfvn2YMGGCY5tcLseECROwe/duD1bm+3JycpCfn+90bnU6HYYOHeo4t5GRkejevTtWrlyJqqoqWK1WvPfee4iJicGgQYM8VbrXqn0rPSIiotltfPfddygpKcH999/vqrL8hs1mw6pVq1BVVXXFZclrV/dRKu3r8axfvx6SJCE3Nxc9e/ZEQkIC7rjjDpw/f741S/d6c+bMwU033eT0+6AhVVVVWLFiBZKTk9GhQwfH9mPHjuHvf/87Vq5c6dSrQ3aZmZmIj49Hp06dcPfdd+PcuXOOfdXV1bjrrruQlpaGuLi4323r4sWL+PrrrzFmzBh3luwzvvvuO1x77bWYNm0aYmJiMGDAAHzwwQf1jtuyZQtiYmLQvXt3zJ49GyUlJVdtV6/Xt+h3ub8ym8345JNPMGvWLMhkMhQWFuKXX35BTEwMhg8fjtjYWIwZM6bBdzFcwW9/uxQXF8Nms9VbkS02NpZvqbdQ7fm72rmVyWTYsGEDDhw4gNDQUAQEBGDp0qVIT0+v93ZRWydJEubPn48RI0bgmmuuaXY7//d//4dJkyYhISHBhdX5tsOHDyMkJAQajQaPPvooVq9ejV69etU7rri4GC+88AIefvhhx7bTp09DkiS8/PLLePPNN/Hll1+itLQUEydO5Pi8S1atWoX9+/cjNTX1ise88847CAkJQUhICNasWYP169dDrVYDAEwmE2bMmIHXX38dHTt2bK2yfcbQoUMdw22WLVuGnJwcjBo1ChUVFQCAJ554AsOHD8fUqVOv2s6MGTMQFBSE9u3bQ6vVYvny5a1Rvtc7ffo0li1bhq5du2Lt2rWYPXs2HnvsMXz00UeOYyZPnoyVK1di48aNePXVV7F161bccMMNDQ7LAYCsrCy8/fbbeOSRR1rrZfiMb775BuXl5bjvvvsA2M8/YB+r/tBDDyE9PR0DBw7E+PHj610T5BLN7hv2crm5uQKA2LVrl9P2Z555RgwZMsRDVfkmXPY22c6dOwUAcfHiRafjpk2bJu644w4hhH3Ywy233CJuuOEGsWPHDrFv3z4xe/Zs0b59+3qPa+seffRRkZiYKM6fP9/g/sYMaTh//ryQy+Xiyy+/dFOVvslkMonMzEyxd+9esWDBAhEVFSWOHj3qdIxerxdDhgwRkydPFmaz2bH9pZdeEgDE2rVrHdsKCwuFXC4X6enprfYavNW5c+dETEyMOHTokGNbQ0MaysvLxalTp8TWrVvFlClTxMCBA0VNTY0QQognnnhCTJ8+3XFsY4fvtFVlZWVCq9WK5cuXi2+//VZ06dJFVFRUOPZf/ru6Vl5enjh+/Lj49ttvRa9evcTs2bNbsWrvpVKpxLBhw5y2zZs3T1x33XVXfEx2drYA0OBQpwsXLojOnTuLBx54wOW1+oOUlBRx8803O+7XZomFCxc6HdenTx+xYMGCeo/nkIYriIqKgkKhQEFBgdP2goKCRr31Q1dWe/6udm43bdqEH374AatWrcKIESMwcOBAvPPOOwgMDHT677mtmzt3Ln744Qds3ry5RT2zK1asQGRkJG655RYXVuf71Go1unTpgkGDBiE1NRX9+vXDP//5T8f+iooKTJ48GaGhoVi9ejVUKpVjX7t27QDAqUc4OjoaUVFRTm8rt1X79u1DYWEhBg4cCKVSCaVSia1bt+Ktt96CUql09IDpdDp07doVo0ePxpdffokTJ05g9erVAOy/J7744gvH48ePHw/A/vt78eLFHntt3iosLAzdunVDVlYWNm3ahOzsbISFhTnOHwDcfvvtGDt2rNPj4uLi0KNHD9xyyy147733sGzZMuTl5XngFXiXdu3a1XvHp2fPnlf9+e7UqROioqKQlZXltP3ixYu4/vrrMXz4cLz//vtuqdeXnT17Fhs2bMCDDz7o2NbQ71jg978GzeW3gVetVmPQoEHYuHGjY5skSdi4ceMVx/BR4yQnJyMuLs7p3BoMBvzyyy+Oc1tdXQ0A9cbkyeVySJLUesV6KSEE5s6di9WrV2PTpk1ITk5uUVsrVqzAvffe6xTYqD5JkmAymQDYv2dTUlKgVqvx3XffISAgwOnYESNGAIDTdHGlpaUoLi5GYmJi6xXtpcaPH4/Dhw/j4MGDjtu1116Lu+++GwcPHoRCoaj3GCEEhBCOr8FXX32FQ4cOOR5f+1b79u3bOf1bAyorK5GdnY127dphwYIFyMjIcDr/APDGG29gxYoVV2yj9vdv7degLRsxYkS96SBPnTp11Z/vCxcuoKSkxBHWAPvUZmPHjnXMSsKx6PWtWLECMTExuOmmmxzbkpKSEB8f3+SvQbM1u2/YB6xatUpoNBrx4YcfimPHjomHH35YhIWFifz8fE+X5vUqKirEgQMHxIEDBwQAsXTpUnHgwAFx9uxZIYQQr7zyiggLCxPffvutyMjIEFOnThXJycmOtyqLiopEZGSkuO2228TBgwfFyZMnxdNPPy1UKpU4ePCgJ1+aV5g9e7bQ6XRiy5YtIi8vz3Grrq52HJOXlycOHDggPvjgA8eMFwcOHBAlJSVObW3YsEEAEMePH2/tl+HVFixYILZu3SpycnJERkaGWLBggZDJZGLdunVCr9eLoUOHij59+oisrCynr4HVanW0MXXqVNG7d2+xc+dOcfjwYXHzzTeLXr16OQ19oN/UHdKQnZ0tXn75ZbF3715x9uxZsXPnTjFlyhQREREhCgoKGnw8hzQ4e+qpp8SWLVtETk6O2Llzp5gwYYKIiooShYWFDR6Py4Y0/Pjjj+Lf//63OHz4sMjJyRE//PCD6NmzpxgxYkQrvQLv9uuvvwqlUileeuklkZmZKT799FMRFBQkPvnkEyGE/e/g008/LXbv3i1ycnLEhg0bxMCBA0XXrl2F0WgUQtiHMXTp0kWMHz9eXLhwwel3CdnZbDbRsWNH8eyzz9bb98YbbwitViu++OILkZmZKf72t7+JgIAAp5lczp49Kw4cOCCWLFkiQkJCHNmk7nCexvDrwCuEEG+//bbo2LGjUKvVYsiQIeLnn3/2dEk+ofYPz+W3mTNnCiHsY3Sff/55ERsbKzQajRg/frw4efKkUxt79uwRKSkpIiIiQoSGhorrrrtO/PTTTx54Nd6noXMLQKxYscJxzOLFi3/3GCGEmDFjhhg+fHjrvgAfMGvWLJGYmCjUarWIjo4W48ePF+vWrRNCXPn7G4DIyclxtKHX68WsWbNEWFiYiIiIEH/4wx/EuXPnPPSKvF/dwJubmytuuOEGERMTI1QqlUhISBB33XWXOHHixBUfz8DrbPr06aJdu3ZCrVaL9u3bi+nTp9eb0q2uywPvpk2bxLBhw4ROpxMBAQGia9eu4tlnn+X5reP7778X11xzjdBoNKJHjx7i/fffd+yrrq4WKSkpIjo6WqhUKpGYmCgeeughp06zFStWXPF3CdmtXbtWAKiXEWqlpqaKhIQEERQUJIYNGya2b9/utH/mzJkNnt/Nmzc3qQ6ZEEK4vt+YiIiIiMg7cKAJEREREfk1Bl4iIiIi8msMvERERETk1xh4iYiIiMivMfASERERkV9j4CUiIiIiv8bAS0RERER+jYGXiIiIiPwaAy8RUQPuu+8+3HrrrW5/nrFjx2L+/PmO+0lJSXjzzTfd/rwAcM899+Dll19uledasGAB5s2b1yrPRUR0Oa60RkRtjkwmu+r+xYsX44knnoAQAmFhYW6tZezYsejfv78j5BYVFSE4OBhBQUFufd5Dhw5h3LhxOHv2LEJCQtz6XABQXFyMTp064eDBg+jUqZPbn4+IqC6lpwsgImpteXl5js8///xzLFq0CCdPnnRsCwkJaZUQ2JDo6OhWeZ63334b06ZNa7XXGRUVhUmTJmHZsmV4/fXXW+U5iYhqcUgDEbU5cXFxjptOp4NMJnPaFhISUm9Iw9ixYzFv3jzMnz8f4eHhiI2NxQcffICqqircf//9CA0NRZcuXbBmzRqn5zpy5AhuuOEGhISEIDY2Fvfccw+Ki4uvWNvlQxpkMhmWL1+OP/zhDwgKCkLXrl3x3Xffteg5bDYbvvzyS0yZMsVp+zvvvIOuXbsiICAAsbGx+OMf/+jYJ0kSUlNTkZycjMDAQPTr1w9ffvml0+OPHj2Km2++GVqtFqGhoRg1ahSys7Md+6dMmYJVq1ZdsS4iIndh4CUiaqSPPvoIUVFR+PXXXzFv3jzMnj0b06ZNw/Dhw7F//36kpKTgnnvuQXV1NQCgvLwc48aNw4ABA7B3716kp6ejoKAAd9xxR5Oed8mSJbjjjjuQkZGBG2+8EXfffTdKS0ub/RwZGRnQ6/W49tprHdv27t2Lxx57DH//+99x8uRJpKenY/To0Y79qampWLlyJd59910cPXoUTzzxBP70pz9h69atAIDc3FyMHj0aGo0GmzZtwr59+zBr1ixYrVZHG0OGDMGFCxdw5syZJr1+IqIWE0REbdiKFSuETqert33mzJli6tSpjvtjxowRI0eOdNy3Wq0iODhY3HPPPY5teXl5AoDYvXu3EEKIF154QaSkpDi1e/78eQFAnDx50tHu448/7tifmJgo3njjDcd9AOJvf/ub435lZaUAINasWdPo57jc6tWrhUKhEJIkObZ99dVXQqvVCoPBUO94o9EogoKCxK5du5y2P/DAA2LGjBlCCCEWLlwokpOThdlsbvA5hRBCr9cLAGLLli1XPIaIyB04hpeIqJH69u3r+FyhUCAyMhJ9+vRxbIuNjQUAFBYWArBfGLZ58+YGx8lmZ2ejW7duTX7e4OBgaLXaFj1HTU0NNBqN08V7EydORGJiIjp16oTJkydj8uTJjmEUWVlZqK6uxsSJE53aMZvNGDBgAADg4MGDGDVqFFQq1RVfR2BgIAA4esCJiFoLAy8RUSNdHuZkMpnTttoAKUkSAKCyshJTpkzBq6++Wq+tdu3ateh5W/IcUVFRqK6uhtlshlqtBgCEhoZi//792LJlC9atW4dFixbhf/7nf7Bnzx5UVlYCAH788Ue0b9/eqS2NRgPgtzB7NbXDMFrrwjwioloMvEREbjJw4EB89dVXSEpKglLpnl+3zXmO/v37AwCOHTvm+BwAlEolJkyYgAkTJmDx4sUICwvDpk2bMHHiRGg0Gpw7dw5jxoxpsM2+ffvio48+gsViuWIv75EjR6BSqdC7d+8mvUYiopbiRWtERG4yZ84clJaWYsaMGdizZw+ys7Oxdu1a3H///bDZbB57jujoaAwcOBA7duxwbPvhhx/w1ltv4eDBgzh79ixWrlwJSZLQvXt3hIaG4umnn8YTTzyBjz76CNnZ2di/fz/efvttfPTRRwCAuXPnwmAw4M4778TevXuRmZmJjz/+2Gm6t+3bt2PUqFGN6g0mInIlBl4iIjeJj4/Hzp07YbPZkJKSgj59+mD+/PkICwuDXO6aX7/NfY4HH3wQn376qeN+WFgYvv76a4wbNw49e/bEu+++i88++8zRG/vCCy/g+eefR2pqKnr27InJkyfjxx9/RHJyMgAgMjISmzZtQmVlJcaMGYNBgwbhgw8+cOrtXbVqFR566CGXvG4ioqbgSmtERG1QTU0Nunfvjs8//xzDhg1z+/OtWbMGTz31FDIyMtw2vIOI6ErYw0tE1AYFBgZi5cqVV12gwpWqqqqwYsUKhl0i8gj28BIRERGRX2MPLxERERH5NQZeIiIiIvJrDLxERERE5NcYeImIiIjIrzHwEhEREZFfY+AlIiIiIr/GwEtEREREfo2Bl4iIiIj8GgMvEREREfm1/wfOW6GBxuroigAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 800x300 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "fig, ax1, ax2 = analyzer.plots.time_bw_timeline(\n",
     "    bw_unit='gb',\n",
@@ -2537,9 +2113,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": null,
    "id": "d8998e34-ad66-4fca-a7e9-45c4f7015862",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-01-29T07:15:03.048703Z",
+     "start_time": "2024-01-29T07:15:03.048686Z"
+    }
+   },
    "outputs": [],
    "source": [
     "fig.savefig(f'{app_name}_app_io_time.pdf', format='pdf', bbox_inches='tight')"
@@ -2547,31 +2128,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": null,
    "id": "771c4a6f-88fc-4929-ab48-f87bf6de6098",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/WS2/haridev/venvs/dlio_profiler_venv/lib/python3.9/site-packages/dask/dataframe/shuffle.py:1032: FutureWarning: Series.fillna with 'method' is deprecated and will raise in a future version. Use obj.ffill() or obj.bfill() instead.\n",
-      "  mins = mins.fillna(method=\"bfill\").tolist()\n",
-      "/usr/WS2/haridev/venvs/dlio_profiler_venv/lib/python3.9/site-packages/dask/dataframe/shuffle.py:1033: FutureWarning: Series.fillna with 'method' is deprecated and will raise in a future version. Use obj.ffill() or obj.bfill() instead.\n",
-      "  maxes = maxes.fillna(method=\"bfill\").tolist()\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAtIAAAErCAYAAADzH2TmAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAABOlElEQVR4nO3deXxM5/4H8M/MZJmsk0QSEVuCWGsJtSQUlzSiaru9uKpK0Vuupbj1Q29J1RLVVteUttqg1dItqpTaY+21BVVFRQiKRCSZ7JOZ8/z+mOTIZNHMmEkmfN6v17xmznOe85zvOTNz5jvPPHOOQgghQEREREREZlHWdABERERERLURE2kiIiIiIgswkSYiIiIisgATaSIiIiIiCzCRJiIiIiKyABNpIiIiIiILMJEmIiIiIrIAE2kiIiIiIgswkSYiIiIisgATaSIiIiIiC9RoIr1v3z4MHDgQgYGBUCgU2Lhxo8n877//HpGRkahTpw4UCgVOnjxZro0XXngBTZs2hYuLC/z8/DB48GCcO3fuL9f9+++/Y9CgQdBoNHBzc0Pnzp2RkpJipS0jIiIiogddjSbSubm5aN++PWJjYyud36NHD7z++uuVttGpUyfExcXh999/x88//wwhBCIjI2EwGCpdJikpCT169EDLli2xd+9enD59GvPmzYNarb7vbSIiIiKih4NCCCFqOggAUCgUiI+Px5AhQ8rNu3z5MoKDg5GYmIgOHTrcs53Tp0+jffv2uHjxIpo2bVphnX/+859wdHTE559/boXIiYiIiOhh5FDTAVhTbm4u4uLiEBwcjIYNG1ZYR5IkbNmyBf/3f/+Hfv36ITExEcHBwZg7d26FSXyJwsJCFBYWmrRz584dedgJEREREdkXIQSys7MRGBgIpdIGAzGEnQAg4uPjK5yXnJwsAIjExMQK58fGxgo3NzcBQLRo0UJcvHix0vXcuHFDABCurq5i+fLlIjExUcTExAiFQiH27t1b6XLR0dECAG+88cYbb7zxxhtvtex29epVc9LSKnsghnZkZWUhNTUVN27cwJtvvonr16/j4MGDFY55/vPPP1G/fn2MHDkSX375pVw+aNAguLm54auvvqowvrI90llZWWjUqBGSk5Ph4eFh/gYTERERkU1lZ2cjODgYmZmZ0Gg0Vm//gRjaodFooNFoEBISgm7dusHb2xvx8fEYOXJkubq+vr5wcHBA69atTcpbtWqFAwcOVLoOZ2dnODs7lyv38fGBp6fn/W8EEREREVmVo6MjANhsGO4Ddx5pIQSEECa9x6U5OTmhc+fOOH/+vEn5hQsX0Lhx4+oIkYiIiIgeADXaI52Tk4OLFy/K08nJyTh58iR8fHzQqFEj3LlzBykpKfjzzz8BQE5+AwICEBAQgEuXLmHDhg2IjIyEn58frl27hqVLl8LFxQVPPPGE3G7Lli0RExODoUOHAgBmzZqFESNGoGfPnvjb3/6Gbdu24ccff8TevXurb+OJiIiIqFar0R7pY8eOITQ0FKGhoQCAmTNnIjQ0FPPnzwcAbNq0CaGhoRgwYAAA42nrQkNDsXLlSgCAWq3G/v378cQTT6BZs2YYMWIEPDw8cOjQIfj7+8vrOX/+PLKysuTpoUOHYuXKlVi2bBnatm2LVatW4bvvvkOPHj2qa9OJiIiIqJazmz8b1jZarRYajQZZWVkcI01ERA8cg8GAoqKimg6D6J5UKhUcHBwqHQNt63ztgfizIREREVlPTk4Orl27Bva1UW3g6uqKevXqwcnJqdrXzUSaiIiIZAaDAdeuXYOrqyv8/Px40TGyW0II6HQ6pKWlITk5GSEhIba56Mo9MJEmIiIiWVFREYQQ8PPzg4uLS02HQ3RPLi4ucHR0xJUrV6DT6Sq8hogtPXCnvyMiIqL7x55oqi2quxfaZN01tmYiIiIiolqMiTQRERERkQU4Rvo+SZIESZJqOgwiIiKrkCRJvkowz9rx4Ni4cSNmzZqF5ORkTJkyBe+88061rl+pVOL777/HkCFDrN52yWu1opzM1jkaE2kzxcbGIjY2FgaDAQCQlpaGgoKCGo6KiIjIOoqKiiBJEvR6PfR6fU2HY7ZffvkFvXv3Rr9+/fDDDz9U67rXrl2LCRMm3LPOhQsXEBQUVD0BlTJx4kQ8++yzmDJlCjw8PKz63KalpWHBggXYunUrbt26BW9vb7Rr1w7//e9/ER4eDgBISUmBt7e3TV5Ter0ekiQhPT0djo6OJvOys7Otvr7SeEEWC5Wc4DsjI4MXZCEiogdGQUEBLl++jODg4Go/A4I1TJgwAe7u7vjss89w7tw5BAYGVtu68/PzTa6k/NRTT6FNmzZ47bXX5DI/Pz+oVCoAgE6nq5ZzH+fk5MDT0xO7du3C3/72N4vbqSzeXr16QafTYcmSJWjSpAlu3bqFXbt2oU2bNhg0aND9hF4lBQUFSE5ORlBQULnXrFarhbe3t+0uoCfIIllZWQKAyMrKqulQiIiIrCY/P1+cPXtW5OfnCyGEkCRJGPLza+QmSZJZsWdnZwt3d3dx7tw5MWLECLF48WJ53siRI8Xw4cNN6ut0OlGnTh2xZs0aIYQQWq1WPP3008LV1VUEBASI5cuXi169eokXX3zRon1ZdtkxY8aIwYMHi0WLFol69eqJoKAgIYQQa9euFZ06dRLu7u6ibt26YuTIkeLWrVvycnv27BEAxM6dO0WnTp2Ei4uLCAsLE+fOnZPrnDx5UvTu3Vu4u7sLDw8P0bFjR3H06FF52dK3PXv2CCGE2L9/v+jRo4dQq9WiQYMGYurUqSInJ0dus3HjxuK1114To0ePFh4eHmLMmDHltjEjI0MAEHv37r3nvgAg4uPjhRBCREdHl4sJgIiLixNCCGEwGMSSJUtEUFCQUKvVol27duKbb76ptO2yr9nSbJ2vcWgHERERVUoUFuLKqGdqZN2N130BhRm94l9//TVatmyJFi1a4JlnnsH06dMxd+5cKBQKjBo1CsOGDUNOTg7c3d0BAD///DPy8vIwdOhQAMDMmTNx8OBBbNq0CXXr1sX8+fNx4sQJdOjQwWrbtGvXLnh6emLHjh1yWVFRERYuXIgWLVogNTUVM2fOxNixY/HTTz+ZLPvf//4Xb731Fvz8/DBx4kSMGzcOBw8eBACMGjUKoaGhWLFiBVQqFU6ePAlHR0eEh4fj/PnzaNGiBb777juEh4fDx8cHSUlJiIqKwqJFi/DZZ58hLS0NU6ZMwZQpUxAXFyev880338T8+fMRHR1d4fa4u7vD3d0dGzduRLdu3eDs7PyX++Cll17CxIkT5el169Zh/vz5ePTRRwEAMTEx+OKLL7By5UqEhIRg3759eOaZZ+Dn54devXpVfWdXAybSRERE9ED49NNP8cwzxqQ/KioKWVlZSEhIkMdMu7m5IT4+HqNHjwYAfPnllxg0aBA8PDyQnZ2NNWvW4Msvv0Tfvn0BAHFxcVYfGuLm5oZVq1aZDJEYN26c/LhJkyZ477330LlzZ5OkHwAWL14sJ5Jz5szBgAEDUFBQALVajZSUFMyaNQstW7YEAISEhMjL+fv7AwB8fHwQEBAAwJisjho1CtOnT5frv/fee+jVqxdWrFghD5Ho06cP/vOf/1S6PQ4ODli9ejWef/55rFy5Eh07dkSvXr3wz3/+E+3atatwmZLkGzCOaX/llVewZs0aPPLIIygsLMSSJUuwc+dOhIWFyfvkwIED+Oijj5hIExERUe2hcHZG43Vf1Ni6q+r8+fM4cuQI4uPjARgTvBEjRuDTTz9F79694eDggOHDh2PdunUYPXo0cnNz8cMPP2D9+vUAgEuXLqGoqAhdunSR29RoNGjRooVVt6lt27blxhkfP34cr776Kk6dOoWMjAz5TBMpKSlo3bq1XK90YlqvXj0AQGpqKho1aoSZM2diwoQJ+PzzzxEREYFhw4ahadOmlcZx6tQpnD59GuvWrZPLRPGZL5KTk9GqVSsAkHuJ7+Wpp57CgAEDsH//fvzyyy/YunUrli1bhlWrVmHs2LGVLpeSkoIhQ4bgpZdewvDhwwEAFy9eRF5eHh5//HGTujqdDqGhoX8ZS3VjIk1ERESVUigUZg2vqCmffvop9Hq9SQ+yEALOzs744IMPoNFoMGrUKPTq1QupqanYsWMHXFxcEBUVVa1xurm5mUzn5uaiX79+6NevH9atWwc/Pz+kpKSgX79+0Ol0JnVLn5Gi5MqTJUn3q6++iqeffhpbtmzB1q1bER0djfXr18vDVsrKycnBCy+8gGnTppWb16hRo0rjrYxarcbjjz+Oxx9/HPPmzcOECRMQHR1daSKdm5uLQYMGISwszOTPmDk5OQCALVu2oH79+ibLVGXYSHVjIk1ERES1ml6vx9q1a/HWW28hMjLSZN6QIUPw1VdfYeLEiQgPD0fDhg2xYcMGbN26FcOGDZOT0yZNmsDR0RFHjx6VE8msrCxcuHABPXv2tFns586dQ3p6OpYuXYqGDRsCAI4dO2ZRW82bN0fz5s0xY8YMjBw5EnFxcZUm0h07dsTZs2fRrFkzi2O/l9atW2Pjxo0VzhNC4JlnnoEkSfj8889NLkffunVrODs7IyUlxe6GcVSEiTQRERHVaps3b0ZGRgbGjx8PjUZjMu+pp57Cp59+Kv+57emnn8bKlStx4cIF7NmzR67n4eGBMWPGYNasWfDx8YG/vz+io6OhVCpNEr25c+fi+vXrWLt2rVVib9SoEZycnPD+++9j4sSJOHPmDBYuXGhWG/n5+Zg1axb+8Y9/IDg4GNeuXcPRo0fx1FNPVbrM7Nmz0a1bN0yZMgUTJkyAm5sbzp49ix07duCDDz6o8rrT09MxbNgwjBs3Du3atYOHhweOHTuGZcuWYfDgwRUu8+qrr2Lnzp3Yvn07cnJy5F5ojUYDDw8PvPTSS5gxYwYkSUKPHj2QlZWFgwcPwtPTE2PGjDFr39gaLxFOREREtdqnn36KiIiIckk0YEykjx07htOnTwMwnt3i7NmzqF+/Prp3725Sd/ny5QgLC8OTTz6JiIgIdO/eHa1atTI5N/GNGzeQkpJitdj9/PywevVqfPPNN2jdujWWLl2KN99806w2VCoV0tPT8eyzz6J58+YYPnw4+vfvjwULFlS6TLt27ZCQkIALFy7gscceQ2hoKObPn2/2nyvd3d3RtWtXvP322+jZsyceeeQRzJs3D88//3ylCXlCQgJycnIQHh6OevXqybcNGzYAABYuXIh58+YhJiYGrVq1QlRUFLZs2YLg4GCzYqsOvCCLhUouyGKzE3wTERHVgJKLW9TWC7JYU25uLurXr4+33noL48ePr+lwqBL3es3aOl/j0A4iIiIiAImJiTh37hy6dOmCrKws+U9wlQ1RIGIiTURERFTszTffxPnz5+Hk5IROnTph//798PX1remwyE4xkSYiIiICEBoaiuPHj9d0GFSLMJG+T5IkyedwJCIiqu0kSYIQQr4R2buS12pFOZmtczQm0maKjY1FbGwsDAYDACAtLQ0FBQU1HBUREZF1FBUVQZIk6PV66PX6mg6H6C+VvGbT09NNLloDANnZ2TZdN8/aYaGSf4FmZGTwrB1ERPTAKCoqQlJSEurXr8/PN6oV0tPTkZqaipCQEKhUKpN5Wq0W3t7ePGuHvVIqlVAqeTpuIiJ6MDg5OcHNzQ1paWlwdHTkZxzZLSEE8vLykJaWBm9v73K90QBs/vplIk1EREQyhUKBevXqITk5GVeuXKnpcIj+kpeXFwICAmpk3UykiYiIyISTkxNCQkKg0+lqOhSie3J0dCw3nKM6MZEmIiKicpRK5UN/ZUOiv8KBT0REREREFmAiTURERERkASbSREREREQWYCJNRERERGQBJtJERERERBZgIk1EREREZAEm0kREREREFuB5pO+TJEmQJKmmwyAiIiKiMmydozGRNlNsbCxiY2NhMBgAAGlpaSgoKKjhqIiIiIiorOzsbJu2rxBCCJuu4QGl1Wqh0WiQkZEBT0/Pmg6HiIiIiMrQarXw9vZGVlaWTfI19kjfJ6VSCaWSQ82JiIiI7I2tczRmgEREREREFmAiTURERERkASbSREREREQWYCJNRERERGQBJtJERERERBZgIk1EREREZAEm0kREREREFmAiTURERERkAbtPpA0GA+bNm4fg4GC4uLigadOmWLhwIUpfkHHs2LFQKBQmt6ioqHu2GxMTg86dO8PDwwP+/v4YMmQIzp8/b+vNISIiIqIHhN1f2fD111/HihUrsGbNGrRp0wbHjh3Dc889B41Gg2nTpsn1oqKiEBcXJ087Ozvfs92EhARMnjwZnTt3hl6vx8svv4zIyEicPXsWbm5uNtseIiIiInowmJ1IJycnY//+/bhy5Qry8vLg5+eH0NBQhIWFQa1WWz3AQ4cOYfDgwRgwYAAAICgoCF999RWOHDliUs/Z2RkBAQFVbnfbtm0m06tXr4a/vz+OHz+Onj17lqtfWFiIwsJCeVqr1QIAioqKUFRUVOX1EhEREVH1sHWOVuVEet26dXj33Xdx7Ngx1K1bF4GBgXBxccGdO3eQlJQEtVqNUaNGYfbs2WjcuLHVAgwPD8fHH3+MCxcuoHnz5jh16hQOHDiA5cuXm9Tbu3cv/P394e3tjT59+mDRokWoU6dOldeTlZUFAPDx8alwfkxMDBYsWFCufPv27XB1dTVji4iIiIioOuTl5dm0fYUoPdi4EqGhoXBycsKYMWMwcOBANGzY0GR+YWEhDh8+jPXr1+O7777Dhx9+iGHDhlklQEmS8PLLL2PZsmVQqVQwGAxYvHgx5s6dK9dZv349XF1dERwcjKSkJLz88stwd3fH4cOHoVKpqrSOQYMGITMzEwcOHKiwTkU90g0bNsTt27fh6el5/xtKRERERFal1Wrh6+uLrKwsm+RrVUqkf/75Z/Tr169KDaanp+Py5cvo1KnTfQcHGJPkWbNm4Y033kCbNm1w8uRJTJ8+HcuXL8eYMWMqXObSpUto2rQpdu7cib59+/7lOiZNmoStW7fiwIEDaNCgQZXi0mq10Gg0NntiiIiIiOj+2Dpfq9LQjqom0QBQp04ds4ZU/JVZs2Zhzpw5+Oc//wkAaNu2La5cuYKYmJhKE+kmTZrA19cXFy9e/MtEesqUKdi8eTP27dtX5SSaiIiIiOi+ztohhMCePXuQn5+P8PBweHt7WysuWV5eHpRK07P0qVQqSJJU6TLXrl1Deno66tWrV2kdIQSmTp2K+Ph47N27F8HBwVaLmYiIiIgefFU+j3RmZibGjBmDtm3b4vnnn4dWq8Vjjz2GiIgIDBw4EK1atcLp06etHuDAgQOxePFibNmyBZcvX0Z8fDyWL1+OoUOHAgBycnIwa9Ys/PLLL7h8+TJ27dqFwYMHo1mzZiY96X379sUHH3wgT0+ePBlffPEFvvzyS3h4eODmzZu4efMm8vPzrb4NRERERPTgqdIYaQCYMGEC9u3bhzFjxuDHH3+EUqmEEALvvPMOlEol/u///g/u7u748ccfrRpgdnY25s2bh/j4eKSmpiIwMBAjR47E/Pnz4eTkhPz8fAwZMgSJiYnIzMxEYGAgIiMjsXDhQtStW1duJygoCGPHjsWrr75q3HCFosL1xcXFYezYsX8ZF8dIExEREdk3W+drVU6k69evjy+//BK9evXC9evX0bBhQ+zevRu9e/cGABw5cgSDBg3CzZs3rR6kPWIiTURERGTfbJ2vVXlox61bt9C8eXMAxqRarVabnAavUaNGSEtLs3qARERERET2qMqJtCRJJudkVqlUJsMjKhsqQURERET0IDLrrB2rVq2Cu7s7AECv12P16tXw9fUFYBzLTERERET0sKjyGOmgoKAq9TonJyffd1C1AcdIExEREdk3u7ggCwBcvnzZ6isnIiIiIqqtqjxGet++fX9ZZ+rUqfcVDBERERFRbVHloR1eXl7Yu3cvOnToUOH8qVOnYs2aNdBqtdaMz26V/FSQkZHBoR1EREREdkir1cLb27vmh3ZMmDABUVFROHDgAJo1a2Yy78UXX0RcXBy2bNli9QDtTWxsLGJjY2EwGAAAaWlpKCgoqOGoiIiIiKgsW58Mo8o90gAwbtw47N69G4cOHUJgYCAAYPr06fjkk0+wefNm/O1vf7NZoPaGPdJERERE9s3WPdJmJdKSJOEf//gHzp07h/3792Px4sVYuXIlfvzxR/Tt29fqwdkznrWDiIiIyL7ZzVk7AECpVGL9+vUYMGAAWrVqhdzcXGzatOmhS6KJiIiIiKqcSL/33nvy4969e2P//v3o168fzp49i7Nnz8rzpk2bZt0IiYiIiIjsUJWHdgQHB/91YwoFLl26dN9B1QYc2kFERERk3+xmaMfDcsVCIiIiIqKqqPIFWYiIiIiI6K4qJdLr16+vcoNXr17FwYMHLQ6IiIiIiKg2qFIivWLFCrRq1QrLli3D77//Xm5+VlYWfvrpJzz99NPo2LEj0tPTrR4oEREREZE9qdIY6YSEBGzatAnvv/8+5s6dCzc3N9StWxdqtRoZGRm4efMmfH19MXbsWJw5cwZ169a1ddxERERERDXKrAuyAMDt27dx4MABXLlyBfn5+fD19UVoaChCQ0OhVD48Q6551g4iIiIi+2Y3Z+0o4evriyFDhlg9ECIiIiKi2sTsRJpMSZIESZJqOgwiIiIiKsPWORoTaTPFxsYiNjYWBoMBAJCWloaCgoIajoqIiIiIysrOzrZp+2aPkSajkjE3GRkZHCNNREREZIe0Wi28vb3tZ4w0mVIqlQ/VnyyJiIiIagtb52gWt67T6XD+/Hno9XprxkNEREREVCuYnUjn5eVh/PjxcHV1RZs2bZCSkgIAmDp1KpYuXWr1AImIiIiI7JHZifTcuXNx6tQp7N27F2q1Wi6PiIjAhg0brBocEREREZG9MnuM9MaNG7FhwwZ069YNCoVCLm/Tpg2SkpKsGhwRERERkb0yu0c6LS0N/v7+5cpzc3NNEmsiIiIiogeZ2Yn0o48+ii1btsjTJcnzqlWrEBYWZr3IiIiIiIjsmNlDO5YsWYL+/fvj7Nmz0Ov1ePfdd3H27FkcOnQICQkJtoiRiIiIiMjumN0j3aNHD5w8eRJ6vR5t27bF9u3b4e/vj8OHD6NTp062iJGIiIiIyO7wyoYWKrmyoa2ulENERERE98fW+ZrZPdJ9+vTBggULypVnZGSgT58+VgmKiIiIiMjemT1Geu/evfj111+RmJiIdevWwc3NDYDxSoccI01EREREDwuzE2kA2LlzJ1544QV069YNP/74I4KCgqwcVu0hSRIkSarpMIiIiIioDFvnaBYl0vXq1UNCQgKee+45dO7cGd988w1atWpl7djsUmxsLGJjY2EwGAAYz6tdUFBQw1ERERERUVnZ2dk2bd/sPxuqVCrcuHFDvijLokWLsGjRIsyePRuLFi2SE8wHXcng9YyMDP7ZkIiIiMgOabVaeHt72+zPhmb3SJfNu1955RW0atUKY8aMsVpQtYlSqYRSafZ/NomIiIjIxmydo5mdSCcnJ8PX19ek7KmnnkKLFi1w/PhxqwVGRERERGTPeB5pC/E80kRERET2zdb5WpV6pP/+979j9erV8PT0xN///vd71v3++++tEhgRERERkT2rUiKt0WigUCjkx0REREREDzsO7bAQh3YQERER2Te7GNpxLwkJCcjNzUVYWBi8vb2tERMRERERkd2rciL9+uuvIycnBwsXLgRgPA1e//79sX37dgCAv78/du3ahTZt2tgmUiIiIiIiO1Llk+tt2LABjzzyiDz97bffYt++fdi/fz9u376NRx99FAsWLLBqcK+++ioUCoXJrWXLliZ1Dh8+jD59+sDNzQ2enp7o2bMn8vPzK23TYDBg3rx5CA4OhouLC5o2bYqFCxeWOz82EREREdG9VLlHOjk5Ge3atZOnf/rpJ/zjH/9A9+7dARgvzDJs2DCrB9imTRvs3LlTnnZwuBvy4cOHERUVhblz5+L999+Hg4MDTp06dc+Tb7/++utYsWIF1qxZgzZt2uDYsWN47rnnoNFoMG3aNKvHT0REREQPpion0nq9Hs7OzvL04cOHMX36dHk6MDAQt2/ftmpwgDFxDggIqHDejBkzMG3aNMyZM0cua9GixT3bO3ToEAYPHowBAwYAAIKCgvDVV1/hyJEj1guaiIiIiB54VU6kmzZtin379qFJkyZISUnBhQsX0LNnT3n+tWvXUKdOHasH+McffyAwMBBqtRphYWGIiYlBo0aNkJqaiv/9738YNWoUwsPDkZSUhJYtW2Lx4sXo0aNHpe2Fh4fj448/xoULF9C8eXOcOnUKBw4cwPLly+8ZR2FhIQoLC+VprVYLACgqKkJRUVGVtkUUFUHKz4coKICUl2e8z8+HyM833uflQyo1T+h0UHp6QKXxgsrbC0qNF1ReGqi8vaH08ICClyYnMoswGIrfdwUQBfkQhYXye1LodIBSCahUxtN9OjgY32MqlfFeqQJUSihK3zuUzDPeFA4OxnuVyuQeSqV8ClEiIqo+Vc3RLFXlRHry5MmYMmUK9u/fj19++QVhYWFo3bq1PH/37t0IDQ21anBdu3bF6tWr0aJFC9y4cQMLFizAY489hjNnzuDSpUsAjOOo33zzTXTo0AFr165F3759cebMGYSEhFTY5pw5c6DVatGyZUuoVCoYDAYsXrwYo0aNumcsMTExFY4BP/Tmm/BQKKDQFUFZpINCp4NSp4NSVwRFkQ7KQh0URUVQ6nRQGAz3v1NKKBQwuLoab24l927yvVQyz9UVwsnJeuuVJOO2FG+nonhblTqdcXt1RVDqCo3lRUVQ6PUQShWEgwOEowOEygHCoXi6+CY5VFCuMq0jihOUWkMI+XlXFhbvj8JCKAt1UOoKjY91OigKjfsRCkWp7VYZ90fJPihdZnKvMt1Xpe6hUgG1MXGTJECSoJAkKPR6473BABgMUOj1xtdUyXutqKj4fVZmWl/yeiypW2Sb96C5FApITo6QnNWQnJ0hqZ2N987OkNRqSE5OxnlyuWm9Gn39Fz8P8nNR5na3TIJCMkChN0AhlSk36I11Jck432Csc3d5Yx0AEA6OxmODY8n73/HuMcTBAZKD493jiWOpY4mj4/0dM4S4u616vfFW8rhkW0qXyY8N8vYp9He3QXIsfQwzxizJ26OSy0qOgzX+vhXCeOySJAiFwrj/7Ok4IoRxH5d8/pQcY3W6Mp/BRVDodMZllMbtEAoloFTcvVcqAYUSQqkAKikTZZY1Pi7TXvEXZaFSQRTfQ6k0lheXQaGwr/34kMnLy7Np+2adR/qzzz7Djz/+iICAAERHR5sMufj3v/+Nxx9/HEOHDrVJoACQmZmJxo0bY/ny5WjVqhW6d++OuXPnYsmSJXKddu3aYcCAAYiJiamwjfXr12PWrFl444030KZNG5w8eRLTp0/H8uXLMWbMmErXXVGPdMOGDXHyyYHwcHQ0azsUzs5QqNVQuroa711coHBxKb43TitdXQEHB0jabBgyMyBlZsGQlQlDZhYkrdZ4wKvq+tRqqLyMvdnK4t5t47SX8cO9oMDYK56XB5Fv7CU36SkvdS9KDk41QaWEwtHJuP+cHKFwdDROOzkZewIdVMYyB4fiaQcoHByhcHQAVMYy4zLGD6xK6zqUquvgACEERF4epLw8SLl5xsf5eZByc437LC9ffizlF8/PyzcmhTVI4egIODrK22HSm6owHuSNvabG3taSeygVUKiKe1aVSqBkfvHjkjbuzneAQqGAMOgh9HpAr4coKoLQ6yGKSk0bDBBFRcZpvR5CX1Q8v7iuXg/oqynRVSmN7ze1C5RqNRRqZygcnQAICIMEGPQQkgAkA2CQIIqTPVGc6AuDAZAMxrql69jwOVeo1VC6u0Pp5ma8ubtB6Vp87+4OpasbFGrnu/tepzPua51Onjbe/8X8Ih1QZLwvqV/Tr2VLKRwdoXB2gsLJufi44QSFo6PxuSoqMm5zkc64z3RFxtdnTf7xXKk0xujsDIWzE5ROxTHL21B87+gIYfK6M0Doi1+jBuP7SEjFr2ODdLfcIJW6NxjnlyxX3J4JhcK4D4uPt3ePJ47yvjTeO5jOd3IyrePocPc4XVKmVN79hbbkc6agwHg8LT1d8vlTYLwvF2Nt4eAAhYPKeGx1cDD+WlU8bXxsnC9/VhXPN365E8bnRwjj9gup+PhU/NggyV8CRXFZlZdByeu9TKJfkvgXn+ihoirGOopy9UvPVygUULi6QOnmDqWba6l7N/mxotRj47HMFQoXF6v9iqfVauHr62uz80jXuguydO7cGREREfjXv/6FJk2a4PPPP8czzzwjzx8xYgQcHBywbt26Cpdv2LAh5syZg8mTJ8tlixYtwhdffIFz585VOY6SE3xfjImBxsu7+IlXQ+niCqVrcVJcnCwr5STZFUoXtfENch+EXg+DVgtDZqbxlpFhcq/PyIAhMwuGjAyIUsm/NSkcHeUXe8n2KV2LvxCojV8ElK4uxgO+Xg+psND4oaUr/vDS6SAKC40fYEXGaalQd3deyc3GP8nYnEpl3BdubsX7xLWCaRcISSreF0Xydsv38oe8Tv6wr7CeTlezSYAtlP7C4+wEpbPa+D5TuxjfS85q4+vMWW2cVpeaV66Os/F1qlYbP/RtQBT36EGvL05kDHfvDQZI+QWQcnOMX7xyjPeGnBxIObkmZVJuLgzF9UR+gU1itVjxEBb5C5qjw93kqtSXU0VxUiV/wS1bpyT5kr/EFn+RBeTjg1RYCFGog9CVelxYWG5a0pWeZ70v+3cTxdJJYZky+XHxF/vi11ZFcRqnix+Xiru2flGpSXePA8WfPWUfq9XGHvWSL7ylvhwbv0RId7+M/MV96S/Npe/lLy0GA4S+SH7M59MKlEq500Dl7lYq8S7pSLibkKvc3aFu27bS4a52f0GW6pSTk4OkpCSMHj0aQUFBCAwMxPnz503qXLhwAf3796+0jby8vHJn9VCpVJAsfOH7/fvf1X5lQ4WDAxx8fODg4/OXdaX8/LuJtpxklyTgmQBgmgSbfBG4mxAr1WrjFwE3V+Njh+p56ZgkmHIyXpx463TGDyFDqR7Q4l5Q40Gt9LSxDop7TeVeueJlUbqevtTyRXpAiOI3r2kSrCidGLu63Z1Xqp7CyanaxsYKIYwJW2XJuGTsgRB6vTyEoqIPB0ilel71ekD+8ClVR0jGniwhyR9Kcm++o6Oxl6WkJ8qhVLnD3TKFo2Nxoux0t6x0glYyRrkWUZT8hOvkVK7zxlJCr7+bXJdOunNzTMtzcyEKCo37sKSXsLgX0CQJLElwy0zLv/DIyWJF8x3vuyPA1uRjRkmyWpyI301edXcT95Lkt0wyrHRyrNbXn9Dr5djuxn33S4Q8rSsyTut0xl+JHEp+VSruzZTLVMW9nyU9nMbhXgpVSVmpeari/wGUbG9xb6gwSIC+CJJOBxQZ70uOJSi+lyo6ztyrQ6DUPBiku51PLsVfeks+g8o8Lt0RVdJJZc/HBiFJxs+P4i/Qxs+eksf6u59DekP5xwbjrwtCb1ymZFiI/D8NhcL4nBUPLSkpVyhLhuKULi/+1VChuFunePiQ/N8OheJuB0zZe3mDRJniCupV0oaQJEh5+cZOgrwynQU5OZBy8+52IpQcx4o/o6TsbEjZ2dD/1Q5XKhG0Yb25T5PV2HUi/dJLL2HgwIFo3Lgx/vzzT0RHR0OlUmHkyJFQKBSYNWsWoqOj0b59e3To0AFr1qzBuXPn8O2338pt9O3bF0OHDsWUKVMAAAMHDsTixYvRqFEjtGnTBomJiVi+fDnGjRtXU5tpUyW9xY6BgTUdikUUSiUUzs6AszPg7l7T4dg1+Q9yDg6Ai0tNh0NWonBwgEqjgUqjgW360R8sJseMWqLkS6TSza2mQynHvr822SeFUmnVL9MPG0mnM0m4TX69y801Jt8liXdeHoSQavSLlV0n0teuXcPIkSORnp4OPz8/9OjRA7/88gv8/PwAANOnT0dBQQFmzJiBO3fuoH379tixYweaNm0qt5GUlGRyWr73338f8+bNw7///W+kpqYiMDAQL7zwAubPn1/t20dEREREdymdnKD08QGq8Ku7Pah1Y6Ttha3H3BARERHR/bF1vmZWX3hRUREcHBxw5swZqwdCRERERFSbmJVIOzo6olGjRjDU5LlYiYiIiIjsgNmjs//73//i5Zdfxp07d2wRDxERERFRrWD2nw0/+OADXLx4EYGBgWjcuDHcyvzL+MSJE1YLjoiIiIjIXpmdSA8ZMsQGYRARERER1S48a4eFeNYOIiIiIvtmV2ftKJGZmYlVq1Zh7ty58ljpEydO4Pr161YNjoiIiIjIXpk9tOP06dOIiIiARqPB5cuX8fzzz8PHxwfff/89UlJSsHbtWlvEabckSbL48uJEREREZDu2ztHMTqRnzpyJsWPHYtmyZfDw8JDLn3jiCTz99NNWDc4excbGIjY2Vj4FYFpaGgoKCmo4KiIiIiIqKzs726btmz1GWqPR4MSJE2jatCk8PDxw6tQpNGnSBFeuXEGLFi0emqSyZMxNRkYGx0gTERER2SGtVgtvb2+bjZE2u0fa2dkZWq22XPmFCxfg5+dnlaBqE6VSCaXSoqHmRERERGRDts7RzG590KBBeO2111BUVAQAUCgUSElJwezZs/HUU09ZPUAiIiIiIntkdiL91ltvIScnB/7+/sjPz0evXr3QrFkzeHh4YPHixbaIkYiIiIjI7pg9tEOj0WDHjh04ePAgTp06hZycHHTs2BERERG2iI+IiIiIyC5VKZH28fHBhQsX4Ovri3HjxuHdd99F9+7d0b17d1vHR0RERERkl6o0tEOn08l/MFyzZs1Dc2YOIiIiIqLKVKlHOiwsDEOGDEGnTp0ghMC0adPg4uJSYd3PPvvMqgESEREREdmjKiXSX3zxBd5++20kJSVBoVAgKyuLvdJERERE9FAz+4IswcHBOHbsGOrUqWOrmGqFkguy2OoE30RERER0f2ydr5l91o7k5ORyZZmZmfDy8rJGPEREREREtYLZ55F+/fXXsWHDBnl6+PDh8PHxQf369XHq1CmrBkdEREREZK/M7pFeuXIl1q1bBwDYsWMHduzYgW3btuHrr7/GrFmzsH37dqsHac8kSYIkSTUdBhERERGVYesczexE+ubNm2jYsCEAYPPmzRg+fDgiIyMRFBSErl27Wj1AexMbG4vY2FgYDAYAQFpaGv94SURERGSHsrOzbdq+2Ym0t7c3rl69ioYNG2Lbtm1YtGgRAEAIISeXD7LJkydj8uTJ8uB1Pz8//tmQiIiIyA6p1Wqbtm92Iv33v/8dTz/9NEJCQpCeno7+/fsDABITE9GsWTOrB2jvlEollEqzh5oTERERkY3ZOkczO5F+++23ERQUhKtXr2LZsmVwd3cHANy4cQP//ve/rR4gEREREZE9Mvs80mTE80gTERER2Te7O480APzxxx/Ys2cPUlNTy/0bcv78+VYJjIiIiIjInpmdSH/yySeYNGkSfH19ERAQAIVCIc9TKBRMpImIiIjooWB2Ir1o0SIsXrwYs2fPtkU8RERERES1gtl/ZczIyMCwYcNsEQsRERERUa1hdiI9bNiwh+7qhUREREREZZk9tKNZs2aYN28efvnlF7Rt2xaOjo4m86dNm2a14IiIiIiI7JXZp78LDg6uvDGFApcuXbrvoGoDnv6OiIiIyL7Z3envkpOTrR4EEREREVFtw2tbExERERFZwKILsly7dg2bNm1CSkoKdDqdybzly5dbJbDaQpKkchelISIiIqKaZ+sczexEeteuXRg0aBCaNGmCc+fO4ZFHHsHly5chhEDHjh1tEaNdiY2NRWxsLAwGAwAgLS0NBQUFNRwVEREREZWVnZ1t0/bN/rNhly5d0L9/fyxYsAAeHh44deoU/P39MWrUKERFRWHSpEm2itWulAxez8jI4J8NiYiIiOyQVquFt7e3/fzZ8Pfff8dXX31lXNjBAfn5+XB3d8drr72GwYMHPzSJdAmlUgmlkkPNiYiIiOyNrXM0s1t3c3OTx0XXq1cPSUlJ8rzbt29bLzIiIiIiIjtmdo90t27dcODAAbRq1QpPPPEE/vOf/+DXX3/F999/j27dutkiRiIiIiIiu2N2Ir18+XLk5OQAABYsWICcnBxs2LABISEhD90ZO4iIiIjo4WVWIm0wGHDt2jW0a9cOgHGYx8qVK20SGBERERGRPTNrjLRKpUJkZCQyMjJsFQ8RERERUa1g9p8NH3nkEVy6dMkWsRARERER1RpmJ9KLFi3CSy+9hM2bN+PGjRvQarUmNyIiIiKih0GVE+nXXnsNubm5eOKJJ3Dq1CkMGjQIDRo0gLe3N7y9veHl5QVvb2+rBxgTE4POnTvDw8MD/v7+GDJkCM6fP29S5+bNmxg9ejQCAgLg5uaGjh074rvvvqvyOpYuXQqFQoHp06dbOXoiIiIielBV+c+GCxYswMSJE7Fnzx5bxlNOQkICJk+ejM6dO0Ov1+Pll19GZGQkzp49Czc3NwDAs88+i8zMTGzatAm+vr748ssvMXz4cBw7dgyhoaH3bP/o0aP46KOP5D9QEhERERFVRZUvEa5UKnHz5k34+/vbOqZ7SktLg7+/PxISEtCzZ08AgLu7O1asWIHRo0fL9erUqYPXX38dEyZMqLStnJwcdOzYER9++CEWLVqEDh064J133qlSHCWXCLfVJSeJiIiI6P7YOl8z6/R3CoXC6gGYKysrCwDg4+Mjl4WHh2PDhg0YMGAAvLy88PXXX6OgoAC9e/e+Z1uTJ0/GgAEDEBERgUWLFt2zbmFhIQoLC+XpkvHgRUVFKCoqsnBriIiIiMhWbJ2jmZVIN2/e/C+T6Tt37txXQPciSRKmT5+O7t2745FHHpHLv/76a4wYMQJ16tSBg4MDXF1dER8fj2bNmlXa1vr163HixAkcPXq0SuuOiYnBggULypVv374drq6u5m8MEREREdlUXl6eTds3K5FesGABNBqNrWL5S5MnT8aZM2dw4MABk/J58+YhMzMTO3fuhK+vLzZu3Ijhw4dj//79aNu2bbl2rl69ihdffBE7duyAWq2u0rrnzp2LmTNnytNarRYNGzZEZGQkh3YQERER2SFbn1Gu1oyRnjJlCn744Qfs27cPwcHBcnlSUhKaNWuGM2fOoE2bNnJ5REQEmjVrVuGVFzdu3IihQ4dCpVLJZQaDAQqFAkqlEoWFhSbzKsIx0kRERET2zW7GSNfU+GghBKZOnYr4+Hjs3bvXJIkG7nbZK5WmZ/JTqVSQJKnCNvv27Ytff/3VpOy5555Dy5YtMXv27L9MoomIiIiIqpxIV7Hj2uomT56ML7/8Ej/88AM8PDxw8+ZNAIBGo4GLiwtatmyJZs2a4YUXXsCbb76JOnXqYOPGjdixYwc2b94st9O3b18MHToUU6ZMgYeHh8kYawBwc3NDnTp1ypUTEREREVWkyhdkkSSpRoZ1rFixAllZWejduzfq1asn3zZs2AAAcHR0xE8//QQ/Pz8MHDgQ7dq1w9q1a7FmzRo88cQTcjtJSUm4fft2tcdPRERERA+mKo+RJlMcI01ERERk32ydr1W5R5qIiIiIiO5iIk1EREREZAEm0kREREREFmAiTURERERkASbSREREREQWYCJNRERERGSBKl+QhSomSVKlV1AkIiIioppj6xyNibSZYmNjERsbC4PBAABIS0tDQUFBDUdFRERERGVlZ2fbtH1ekMVCJSf4zsjI4AVZiIiIiOyQVquFt7e3zS7Iwh7p+6RUKqFUcqg5ERERkb2xdY7GDJCIiIiIyAJMpImIiIiILMBEmoiIiIjIAkykiYiIiIgswESaiIiIiMgCTKSJiIiIiCzARJqIiIiIyAJMpImIiIiILMBEmoiIiIjIAkykiYiIiIgswESaiIiIiMgCDjUdQG0nSRIkSarpMIiIiIioDFvnaEykzRQbG4vY2FgYDAYAQFpaGgoKCmo4KiIiIiIqKzs726btK4QQwqZreEBptVpoNBpkZGTA09OzpsMhIiIiojK0Wi28vb2RlZVlk3yNPdL3SalUQqnkUHMiIiIie2PrHI0ZIBERERGRBZhIExERERFZgIk0EREREZEFmEgTEREREVmAiTQRERERkQWYSBMRERERWYCJNBERERGRBZhIExERERFZgIk0EREREZEFmEgTEREREVmAlwi/T5IkQZKkmg6DiIiIiMqwdY7GRNpMsbGxiI2NhcFgAACkpaWhoKCghqMiIiIiorKys7Nt2r5CCCFsuoYHlFarhUajQUZGBjw9PWs6HCIiIiIqQ6vVwtvbG1lZWTbJ19gjfZ+USiWUSg41JyIiIrI3ts7RmAESEREREVmAiTQRERERkQWYSBMRERERWYCJNBERERGRBZhIExERERFZgIk0EREREZEFmEgTEREREVmAiTQRERERkQUemEQ6NjYWQUFBUKvV6Nq1K44cOXLP+t988w1atmwJtVqNtm3b4qeffqqmSImIiIjoQfBAJNIbNmzAzJkzER0djRMnTqB9+/bo168fUlNTK6x/6NAhjBw5EuPHj0diYiKGDBmCIUOG4MyZM9UcORERERHVVgohhKjpIO5X165d0blzZ3zwwQcAAEmS0LBhQ0ydOhVz5swpV3/EiBHIzc3F5s2b5bJu3bqhQ4cOWLlyZZXWqdVqodFobHbtdiIiIiK6P7bO1xys3mI10+l0OH78OObOnSuXKZVKRERE4PDhwxUuc/jwYcycOdOkrF+/fti4cWOl6yksLERhYaE8nZWVBQC4c+cOioqK7mMLiIiIiMgWsrOzAQC26jeu9Yn07du3YTAYULduXZPyunXr4ty5cxUuc/PmzQrr37x5s9L1xMTEYMGCBeXKg4ODLYiaiIiIiKpLeno6NBqN1dut9Yl0dZk7d65JL3ZmZiYaN26MlJQUqz8xnTt3xtGjR63aZm1sV6vVomHDhrh69arVf46pbfvCFu1y/9q+be5j27ZbG/evLdvmPq597dpy/wK1a1/Yqt2srCw0atQIPj4+Vm23RK1PpH19faFSqXDr1i2T8lu3biEgIKDCZQICAsyqDwDOzs5wdnYuV67RaKz+4lepVDZ5Q9W2dkt4enpyH9twH3P/2r5t7mPu3+pom/u4drYL2Gb/ArVvX9hyHyuVtjm/Rq0/a4eTkxM6deqEXbt2yWWSJGHXrl0ICwurcJmwsDCT+gCwY8eOSutXt8mTJ7NdG6tt+6K27ePauB+4j2tnu7ZSG19r3Me1s11bqm37ojbu4wfirB0bNmzAmDFj8NFHH6FLly5455138PXXX+PcuXOoW7cunn32WdSvXx8xMTEAjKe/69WrF5YuXYoBAwZg/fr1WLJkCU6cOIFHHnmkSuvkWTtsj/vYtrh/bY/72La4f22P+9i2uH9tj2ftqIIRI0YgLS0N8+fPx82bN9GhQwds27ZN/kNhSkqKSZd+eHg4vvzyS7zyyit4+eWXERISgo0bN1Y5iQaMQz2io6MrHO5B1sF9bFvcv7bHfWxb3L+2x31sW9y/tmfrffxA9EgTEREREVW3Wj9GmoiIiIioJjCRJiIiIiKyABNpIiIiIiILMJEmIiIiIrIAE2kLxcbGIigoCGq1Gl27dsWRI0dqOqRaYd++fRg4cCACAwOhUCiwceNGk/lCCMyfPx/16tWDi4sLIiIi8Mcff5jUuXDhAgYPHgxfX194enqiR48e2LNnTzVuhf2KiYlB586d4eHhAX9/fwwZMgTnz583qfPxxx+jd+/e8PT0hEKhQGZmpsn8vXv3QqFQVHiz1ZXeapMVK1agXbt28gUUwsLCsHXrVgDAnTt3MHXqVLRo0QIuLi5o1KgRpk2bhqysrHLtrF69Gu3atYNarYa/v3+tPH9qdVi6dCkUCgWmT58ul73wwgto2rQpXFxc4Ofnh8GDB+PcuXMVLp+eno4GDRpU+Fp/WL366qvl3tstW7YsV08Igf79+5c7VqenpyMqKgqBgYFwdnZGw4YNMWXKFGi12mrcCvt2/fp1PPPMM6hTpw5cXFzQtm1bHDt2TJ4/duzYcs9BVFSUPP/y5csYP348goOD4eLigqZNmyI6Oho6na4mNsfuBAUFVfgZVfo4evjwYfTp0wdubm7w9PREz549kZ+fL89fvHgxwsPD4erqCi8vL4tjYSJtgQ0bNmDmzJmIjo7GiRMn0L59e/Tr1w+pqak1HZrdy83NRfv27REbG1vh/GXLluG9997DypUr8b///Q9ubm7o168fCgoK5DpPPvkk9Ho9du/ejePHj6N9+/Z48skncfPmzeraDLuVkJCAyZMn45dffsGOHTtQVFSEyMhI5ObmynXy8vIQFRWFl19+ucI2wsPDcePGDZPbhAkTEBwcjEcffbS6NsVuNWjQAEuXLsXx48dx7Ngx9OnTB4MHD8Zvv/2GP//8E3/++SfefPNNnDlzBqtXr8a2bdswfvx4kzaWL1+O//73v5gzZw5+++037Ny5E/369auhLbJfR48exUcffYR27dqZlHfq1AlxcXH4/fff8fPPP0MIgcjISBgMhnJtjB8/vtzyBLRp08bkPX7gwIFydd555x0oFIpy5UqlEoMHD8amTZtw4cIFrF69Gjt37sTEiROrI3S7l5GRge7du8PR0RFbt27F2bNn8dZbb8Hb29ukXlRUlMlz8NVXX8nzzp07B0mS8NFHH+G3337D22+/jZUrV1Z63H7YHD161GTf7dixAwAwbNgwAMYkOioqCpGRkThy5AiOHj2KKVOmmJwKWafTYdiwYZg0adL9BSPIbF26dBGTJ0+Wpw0GgwgMDBQxMTE1GFXtA0DEx8fL05IkiYCAAPHGG2/IZZmZmcLZ2Vl89dVXQggh0tLSBACxb98+uY5WqxUAxI4dO6ot9toiNTVVABAJCQnl5u3Zs0cAEBkZGfdsQ6fTCT8/P/Haa6/ZKMraz9vbW6xatarCeV9//bVwcnISRUVFQggh7ty5I1xcXMTOnTurM8RaJzs7W4SEhIgdO3aIXr16iRdffLHSuqdOnRIAxMWLF03KP/zwQ9GrVy+xa9euKr3WHxbR0dGiffv296yTmJgo6tevL27cuFHuWF2Rd999VzRo0MB6QdZis2fPFj169LhnnTFjxojBgweb1e6yZctEcHDwfUT24HrxxRdF06ZNhSRJQgghunbtKl555ZUqLRsXFyc0Go3F62aPtJl0Oh2OHz+OiIgIuUypVCIiIgKHDx+uwchqv+TkZNy8edNk32o0GnTt2lXet3Xq1EGLFi2wdu1a5ObmQq/X46OPPoK/vz86depUU6HbrZIhBT4+Pha3sWnTJqSnp+O5556zVlgPDIPBgPXr1yM3NxdhYWEV1im5mpaDg/H6Vzt27IAkSbh+/TpatWqFBg0aYPjw4bh69Wp1hm73Jk+ejAEDBpgcDyqSm5uLuLg4BAcHo2HDhnL52bNn8dprr2Ht2rUmvVBk9McffyAwMBBNmjTBqFGjkJKSIs/Ly8vD008/jdjYWAQEBPxlW3/++Se+//579OrVy5Yh1xqbNm3Co48+imHDhsHf3x+hoaH45JNPytXbu3cv/P390aJFC0yaNAnp6en3bDcrK+u+juUPKp1Ohy+++ALjxo2DQqFAamoq/ve//8Hf3x/h4eGoW7cuevXqVeGvLtbAo4uZbt++DYPBIF81sUTdunU5tOA+ley/e+1bhUKBnTt3IjExER4eHlCr1Vi+fDm2bdtW7mezh50kSZg+fTq6d+9u1lU7y/r000/Rr18/NGjQwIrR1W6//vor3N3d4ezsjIkTJyI+Ph6tW7cuV+/27dtYuHAh/vWvf8llly5dgiRJWLJkCd555x18++23uHPnDh5//HGOfyy2fv16nDhxAjExMZXW+fDDD+Hu7g53d3ds3boVO3bsgJOTEwCgsLAQI0eOxBtvvIFGjRpVV9i1RteuXeVhRytWrEBycjIee+wxZGdnAwBmzJiB8PBwDB48+J7tjBw5Eq6urqhfvz48PT2xatWq6gjf7l26dAkrVqxASEgIfv75Z0yaNAnTpk3DmjVr5DpRUVFYu3Ytdu3ahddffx0JCQno379/hcOTAODixYt4//338cILL1TXZtQaGzduRGZmJsaOHQvAuP8B438Bnn/+eWzbtg0dO3ZE3759y/3nyios7st+SF2/fl0AEIcOHTIpnzVrlujSpUsNRVU7oczPhQcPHhQAxJ9//mlSb9iwYWL48OFCCOPwj0GDBon+/fuLAwcOiOPHj4tJkyaJ+vXrl1vuYTdx4kTRuHFjcfXq1QrnV2Vox9WrV4VSqRTffvutjaKsnQoLC8Uff/whjh07JubMmSN8fX3Fb7/9ZlInKytLdOnSRURFRQmdTieXL168WAAQP//8s1yWmpoqlEql2LZtW7Vtg71KSUkR/v7+4tSpU3JZRUM7MjMzxYULF0RCQoIYOHCg6Nixo8jPzxdCCDFjxgwxYsQIuW5VhzE9rDIyMoSnp6dYtWqV+OGHH0SzZs1Edna2PL/ssbrEjRs3xO+//y5++OEH0bp1azFp0qRqjNp+OTo6irCwMJOyqVOnim7dulW6TFJSkgBQ4ZCva9euiaZNm4rx48dbPdYHQWRkpHjyySfl6ZJcYu7cuSb12rZtK+bMmVNueQ7tqGa+vr5QqVS4deuWSfmtW7eq9BMYVa5k/91r3+7evRubN2/G+vXr0b17d3Ts2BEffvghXFxcTL7tP+ymTJmCzZs3Y8+ePffVkxwXF4c6depg0KBBVoyu9nNyckKzZs3QqVMnxMTEoH379nj33Xfl+dnZ2YiKioKHhwfi4+Ph6Ogoz6tXrx4AmPRg+/n5wdfX1+Tn9YfV8ePHkZqaio4dO8LBwQEODg5ISEjAe++9BwcHB7nHTqPRICQkBD179sS3336Lc+fOIT4+HoDxOPHNN9/Iy/ft2xeA8fgdHR1dY9tmr7y8vNC8eXNcvHgRu3fvRlJSEry8vOT9BwBPPfUUevfubbJcQEAAWrZsiUGDBuGjjz7CihUrcOPGjRrYAvtSr169cr9QtWrV6p7v7yZNmsDX1xcXL140Kf/zzz/xt7/9DeHh4fj4449tEm9tduXKFezcuRMTJkyQyyo6xgJ//RxYiom0mZycnNCpUyfs2rVLLpMkCbt27ap0jCRVTXBwMAICAkz2rVarxf/+9z953+bl5QFAuTGPSqUSkiRVX7B2SgiBKVOmID4+Hrt370ZwcPB9tRUXF4dnn33WJBGk8iRJQmFhIQDjazYyMhJOTk7YtGkT1Gq1Sd3u3bsDgMlpCe/cuYPbt2+jcePG1Re0nerbty9+/fVXnDx5Ur49+uijGDVqFE6ePAmVSlVuGSEEhBDyc/Ddd9/h1KlT8vIlQw7279/P0wxWICcnB0lJSahXrx7mzJmD06dPm+x/AHj77bcRFxdXaRslx9+S5+Bh1r1793KnHb1w4cI939/Xrl1Denq6nAQCxlPo9e7dWz5LDcf6lxcXFwd/f38MGDBALgsKCkJgYKDZz4HFLO7LfoitX79eODs7i9WrV4uzZ8+Kf/3rX8LLy0vcvHmzpkOze9nZ2SIxMVEkJiYKAGL58uUiMTFRXLlyRQghxNKlS4WXl5f44YcfxOnTp8XgwYNFcHCw/JNtWlqaqFOnjvj73/8uTp48Kc6fPy9eeukl4ejoKE6ePFmTm2YXJk2aJDQajdi7d6+4ceOGfMvLy5Pr3LhxQyQmJopPPvlEPgNKYmKiSE9PN2lr586dAoD4/fffq3sz7NqcOXNEQkKCSE5OFqdPnxZz5swRCoVCbN++XWRlZYmuXbuKtm3biosXL5o8B3q9Xm5j8ODBok2bNuLgwYPi119/FU8++aRo3bq1yRAQuqv00I6kpCSxZMkScezYMXHlyhVx8OBBMXDgQOHj4yNu3bpV4fIc2mHqP//5j9i7d69ITk4WBw8eFBEREcLX11ekpqZWWB9lhnZs2bJFfPbZZ+LXX38VycnJYvPmzaJVq1aie/fu1bQF9u3IkSPCwcFBLF68WPzxxx9i3bp1wtXVVXzxxRdCCOPn4EsvvSQOHz4skpOTxc6dO0XHjh1FSEiIKCgoEEIYh3M0a9ZM9O3bV1y7ds3kWEJGBoNBNGrUSMyePbvcvLffflt4enqKb775Rvzxxx/ilVdeEWq12uTMPleuXBGJiYliwYIFwt3dXc5NSg9rqgom0hZ6//33RaNGjYSTk5Po0qWL+OWXX2o6pFqh5AOt7G3MmDFCCOMY6Hnz5om6desKZ2dn0bdvX3H+/HmTNo4ePSoiIyOFj4+P8PDwEN26dRM//fRTDWyN/alo3wIQcXFxcp3o6Oi/rCOEECNHjhTh4eHVuwG1wLhx40Tjxo2Fk5OT8PPzE3379hXbt28XQlT++gYgkpOT5TaysrLEuHHjhJeXl/Dx8RFDhw4VKSkpNbRF9q90In39+nXRv39/4e/vLxwdHUWDBg3E008/Lc6dO1fp8kykTY0YMULUq1dPODk5ifr164sRI0aUO3VgaWUT6d27d4uwsDCh0WiEWq0WISEhYvbs2dy/pfz444/ikUceEc7OzqJly5bi448/lufl5eWJyMhI4efnJxwdHUXjxo3F888/b9IZFxcXV+mxhIx+/vlnAaBcjlAiJiZGNGjQQLi6uoqwsDCxf/9+k/ljxoypcP/u2bPHrDgUQghh/X5uIiIiIqIHGwfcEBERERFZgIk0EREREZEFmEgTEREREVmAiTQRERERkQWYSBMRERERWYCJNBERERGRBZhIExERERFZgIk0EREREZEFmEgTEVWjsWPHYsiQITZfT+/evTF9+nR5OigoCO+8847N1wsAo0ePxpIlS6plXXPmzMHUqVOrZV1ERGXxyoZERFaiUCjuOT86OhozZsyAEAJeXl42jaV3797o0KGDnDynpaXBzc0Nrq6uNl3vqVOn0KdPH1y5cgXu7u42XRcA3L59G02aNMHJkyfRpEkTm6+PiKg0h5oOgIjoQXHjxg358YYNGzB//nycP39eLnN3d6+W5LIifn5+1bKe999/H8OGDau27fT19UW/fv2wYsUKvPHGG9WyTiKiEhzaQURkJQEBAfJNo9FAoVCYlLm7u5cb2tG7d29MnToV06dPh7e3N+rWrYtPPvkEubm5eO655+Dh4YFmzZph69atJus6c+YM+vfvD3d3d9StWxejR4/G7du3K42t7NAOhUKBVatWYejQoXB1dUVISAg2bdp0X+swGAz49ttvMXDgQJPyDz/8ECEhIVCr1ahbty7+8Y9/yPMkSUJMTAyCg4Ph4uKC9u3b49tvvzVZ/rfffsOTTz4JT09PeHh44LHHHkNSUpI8f+DAgVi/fn2lcRER2QoTaSKiGrZmzRr4+vriyJEjmDp1KiZNmoRhw4YhPDwcJ06cQGRkJEaPHo28vDwAQGZmJvr06YPQ0FAcO3YM27Ztw61btzB8+HCz1rtgwQIMHz4cp0+fxhNPPIFRo0bhzp07Fq/j9OnTyMrKwqOPPiqXHTt2DNOmTcNrr72G8+fPY9u2bejZs6c8PyYmBmvXrsXKlSvx22+/YcaMGXjmmWeQkJAAALh+/Tp69uwJZ2dn7N69G8ePH8e4ceOg1+vlNrp06YJr167h8uXLZm0/EdF9E0REZHVxcXFCo9GUKx8zZowYPHiwPN2rVy/Ro0cPeVqv1ws3NzcxevRouezGjRsCgDh8+LAQQoiFCxeKyMhIk3avXr0qAIjz58/L7b744ovy/MaNG4u3335bngYgXnnlFXk6JydHABBbt26t8jrKio+PFyqVSkiSJJd99913wtPTU2i12nL1CwoKhKurqzh06JBJ+fjx48XIkSOFEELMnTtXBAcHC51OV+E6hRAiKytLABB79+6ttA4RkS1wjDQRUQ1r166d/FilUqFOnTpo27atXFa3bl0AQGpqKgDjH/r27NlT4TjkpKQkNG/e3Oz1urm5wdPT877WkZ+fD2dnZ5M/XT7++ONo3LgxmjRpgqioKERFRcnDSS5evIi8vDw8/vjjJu3odDqEhoYCAE6ePInHHnsMjo6OlW6Hi4sLAMg99kRE1YWJNBFRDSubJCoUCpOyksRUkiQAQE5ODgYOHIjXX3+9XFv16tW7r/Xezzp8fX2Rl5cHnU4HJycnAICHhwdOnDiBvXv3Yvv27Zg/fz5effVVHD16FDk5OQCALVu2oH79+iZtOTs7A7ibJN9LyXCU6vpDJRFRCSbSRES1TMeOHfHdd98hKCgIDg62OYxbso4OHToAAM6ePSs/BgAHBwdEREQgIiIC0dHR8PLywu7du/H444/D2dkZKSkp6NWrV4VttmvXDmvWrEFRUVGlvdJnzpyBo6Mj2rRpY9Y2EhHdL/7ZkIiolpk8eTLu3LmDkSNH4ujRo0hKSsLPP/+M5557DgaDocbW4efnh44dO+LAgQNy2ebNm/Hee+/h5MmTuHLlCtauXQtJktCiRQt4eHjgpZdewowZM7BmzRokJSXhxIkTeP/997FmzRoAwJQpU6DVavHPf/4Tx44dwx9//IHPP//c5LSC+/fvx2OPPVal3msiImtiIk1EVMsEBgbi4MGDMBgMiIyMRNu2bTF9+nR4eXlBqbTOYd3SdUyYMAHr1q2Tp728vPD999+jT58+aNWqFVauXImvvvpK7j1euHAh5s2bh5iYGLRq1QpRUVHYsmULgoODAQB16tTB7t27kZOTg169eqFTp0745JNPTHqn169fj+eff94q201EZA5e2ZCIiKwmPz8fLVq0wIYNGxAWFmbz9W3duhX/+c9/cPr0aZsNcyEiqgx7pImIyGpcXFywdu3ae164xZpyc3MRFxfHJJqIagR7pImIiIiILMAeaSIiIiIiCzCRJiIiIiKyABNpIiIiIiILMJEmIiIiIrIAE2kiIiIiIgswkSYiIiIisgATaSIiIiIiCzCRJiIiIiKyABNpIiIiIiIL/D84axJiy3XThgAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 800x300 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-01-29T07:15:03.051149Z",
+     "start_time": "2024-01-29T07:15:03.051131Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "fig, ax = analyzer.plots.xfer_size_timeline(\n",
     "    figsize=(8, 3),\n",
@@ -2582,9 +2147,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": null,
    "id": "d8f5b274-5727-479f-838c-dca3abd094f3",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-01-29T07:15:03.052828Z",
+     "start_time": "2024-01-29T07:15:03.052812Z"
+    }
+   },
    "outputs": [],
    "source": [
     "fig.savefig(f'{app_name}_xfer_size.pdf', format='pdf', bbox_inches='tight')"
@@ -2592,85 +2162,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "id": "9284c27d-598a-419d-a667-c8816ef3fb71",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "name\n",
-       "__fxstat64        NaN\n",
-       "__xstat64         NaN\n",
-       "close             NaN\n",
-       "lseek64           NaN\n",
-       "open64            NaN\n",
-       "opendir           NaN\n",
-       "read          0.05467\n",
-       "Name: size, dtype: double[pyarrow]"
-      ]
-     },
-     "execution_count": 43,
-     "metadata": {},
-     "output_type": "execute_result"
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2024-01-29T07:14:37.890Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "analyzer.events.query(\"cat == 'POSIX'\").groupby(\"name\")[\"size\"].mean().compute() / (1024**2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "id": "e52cb7e7-5d51-4126-888b-ee847222b988",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "name\n",
-       "__fxstat64     14.238569\n",
-       "__xstat64       0.361658\n",
-       "close          11.435908\n",
-       "lseek64         0.184910\n",
-       "open64         13.368323\n",
-       "opendir         1.125259\n",
-       "read          533.845061\n",
-       "Name: io_time, dtype: double[pyarrow]"
-      ]
-     },
-     "execution_count": 44,
-     "metadata": {},
-     "output_type": "execute_result"
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2024-01-29T07:14:37.890Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "analyzer.events.query(\"cat == 'POSIX'\").groupby([\"trange\",\"pid\",\"tid\",\"name\"])[\"io_time\"].sum().groupby([\"trange\",\"name\"]).max().groupby(\"name\").sum().compute() / 1e6"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "id": "f446524b-6ebb-496f-b595-9f0456fce540",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "io_time       min          0\n",
-       "              max    3614661\n",
-       "compute_time  min        255\n",
-       "              max    3313428\n",
-       "app_io_time   min         26\n",
-       "              max    9089266\n",
-       "dtype: uint64[pyarrow]"
-      ]
-     },
-     "execution_count": 45,
-     "metadata": {},
-     "output_type": "execute_result"
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2024-01-29T07:14:37.891Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "val = analyzer.events.groupby([\"trange\"]).agg({\"io_time\":[min,max],\"compute_time\":[min,max],\"app_io_time\":[min,max]}).sum().compute()\n",
     "val"
@@ -2678,21 +2205,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "id": "251dad2f-2e57-4473-bdf2-0a3ab1c4813e",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "9089266"
-      ]
-     },
-     "execution_count": 46,
-     "metadata": {},
-     "output_type": "execute_result"
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2024-01-29T07:14:37.892Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "val = analyzer.events[\"app_io_time\"].max().compute()\n",
     "val"
@@ -2700,21 +2220,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "id": "58dfba53-d7e2-4370-a446-e57de17d17d5",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "761.167636"
-      ]
-     },
-     "execution_count": 47,
-     "metadata": {},
-     "output_type": "execute_result"
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2024-01-29T07:14:37.893Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "import dask\n",
     "val1, val2 = dask.compute(analyzer.events[\"ts\"].min() /1e6 , analyzer.events[\"ts\"].max()/1e6)\n",
@@ -2723,123 +2236,70 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "id": "556446aa-52a0-4bd0-b650-ab6a9c4ed68c",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0    x3006c0s13b0n0\n",
-       "Name: hostname, dtype: string"
-      ]
-     },
-     "execution_count": 48,
-     "metadata": {},
-     "output_type": "execute_result"
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2024-01-29T07:14:37.894Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "analyzer.events[\"hostname\"].unique().compute()[:2]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "id": "42c8fafb-8354-466e-a12b-7d5e41e17c31",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "4.01724"
-      ]
-     },
-     "execution_count": 49,
-     "metadata": {},
-     "output_type": "execute_result"
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2024-01-29T07:14:37.895Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "analyzer.events.query(\"cat == 'POSIX'\").groupby([\"trange\",\"name\"])[\"dur\"].max().sum().compute() / 1e6"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "id": "fce6590b-20e9-4dff-9cde-7bdc4c9d714a",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.0"
-      ]
-     },
-     "execution_count": 50,
-     "metadata": {},
-     "output_type": "execute_result"
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2024-01-29T07:14:37.896Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "analyzer.events.query(\"name == 'open'\").groupby(\"trange\")[\"dur\"].max().sum().compute() / 1e6"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "id": "53cfa467-4b5c-4a2f-bff3-196dd3d92225",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "cat                      name                       \n",
-       "POSIX                    __fxstat64                       444448241\n",
-       "                         __xstat64                          1041137\n",
-       "                         close                            342150487\n",
-       "                         lseek64                            5377747\n",
-       "                         open64                           417437820\n",
-       "                         opendir                            3807348\n",
-       "                         read                           16581944325\n",
-       "IO                       real_IO.iter                     311363925\n",
-       "                         real_IO.yield                   2708610270\n",
-       "communication-except-io  cpu-gpu-transfer                  37165103\n",
-       "compute                  model-compute-backward-prop      444288066\n",
-       "                         model-compute-forward-prop        50921978\n",
-       "Name: dur, dtype: uint64[pyarrow]"
-      ]
-     },
-     "execution_count": 51,
-     "metadata": {},
-     "output_type": "execute_result"
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2024-01-29T07:14:37.897Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "analyzer.events.groupby([\"cat\",\"name\"])[\"dur\"].sum().compute()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "id": "80672c5c-5a66-4d22-88b6-c97102ff5563",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(0.9911281578947368,\n",
-       " 0.26911763157894736,\n",
-       " 0.28428078947368424,\n",
-       " 0.04696078947368421,\n",
-       " 0.371635)"
-      ]
-     },
-     "execution_count": 52,
-     "metadata": {},
-     "output_type": "execute_result"
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2024-01-29T07:14:37.899Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "3766287/3.8/1e6, 1022647/3.8/1e6, 1080267/3.8/1e6, 178451/3.8/1e6, (1259124+153089)/3.8/1e6"
    ]

--- a/tests/integration/dlio_benchmark/setup-env.sh
+++ b/tests/integration/dlio_benchmark/setup-env.sh
@@ -4,7 +4,7 @@ module load python/3.9.12
 module load openmpi/4.1.2
 
 # Configurations
-export DLIO_WORKLOAD=unet3d_base # unet3d_base dyad_unet3d dyad_unet3d_small
+export DLIO_WORKLOAD=dyad_unet3d # unet3d_base dyad_unet3d dyad_unet3d_small
 export NUM_NODES=2
 export PPN=8
 export BROKERS_PER_NODE=1
@@ -14,6 +14,7 @@ export DYAD_INSTALL_PREFIX=/usr/workspace/haridev/dyad/env/spack/.spack-env/view
 export DYAD_KVS_NAMESPACE=dyad
 export DYAD_DTL_MODE=UCX
 export DYAD_PATH=/l/ssd/haridev/dyad
+export DYAD_PATH=/dev/shm/haridev/dyad
 export GITHUB_WORKSPACE=/usr/workspace/haridev/dyad
 export SPACK_DIR=/usr/workspace/haridev/spack-new
 export SPACK_ENV=/usr/workspace/haridev/dyad/env/spack
@@ -32,7 +33,7 @@ export DLIO_PROFILER_LOG_LEVEL=ERROR
 export DLIO_PROFILER_BIND_SIGNALS=0
 export MV2_BCAST_HWLOC_TOPOLOGY=0
 
-
+mkdir -p ${DYAD_PATH}
 mkdir -p ${DLIO_PROFILER_LOG_FILE}
 # Activate Environments
 . ${SPACK_DIR}/share/spack/setup-env.sh

--- a/tests/integration/dlio_benchmark/setup-env.sh
+++ b/tests/integration/dlio_benchmark/setup-env.sh
@@ -33,7 +33,7 @@ export DLIO_PROFILER_LOG_LEVEL=ERROR
 export DLIO_PROFILER_BIND_SIGNALS=0
 export MV2_BCAST_HWLOC_TOPOLOGY=0
 
-mkdir -p ${DYAD_PATH}
+mkdir -m 775 -p ${DYAD_PATH}
 mkdir -p ${DLIO_PROFILER_LOG_FILE}
 # Activate Environments
 . ${SPACK_DIR}/share/spack/setup-env.sh


### PR DESCRIPTION
In case of shared storage, we should not use KVS to synchronize Producer and Consumer. Instead, we first use FS locks to do the sync, if that fails (say consumer got the lock first), we fall back to the case of KVS for sync. 

This allows us to optimize our KVS calls by calling it only in case, locks looks the order battle ;).

Note, if use streams, there is no portable way to do locks. Therefore, this PR will use KVS only for that case.

- [x] Test it with collocation test from Ian.