### PR TITLE
reduce the number of realpath calls

### DIFF
--- a/cmake/configure_files/dyad_config.hpp.in
+++ b/cmake/configure_files/dyad_config.hpp.in
@@ -59,4 +59,8 @@
   #define VA_OPT_SUPPORTED VA_OPT_SUPPORTED_I(?)
 #endif
 
+#if !defined (DYAD_HASH_SEED) || (DYAD_HASH_SEED <= 0)
+#define DYAD_SEED 104723u
+#endif
+
 #endif /* DYAD_CONFIG_H */

--- a/include/dyad/stream/dyad_stream_api.hpp
+++ b/include/dyad/stream/dyad_stream_api.hpp
@@ -32,17 +32,6 @@
 
 namespace dyad
 {
-#if 0
-inline bool cmp_prefix (const char*  __restrict__ prefix,
-                        const char*  __restrict__ full,
-                        const char*  __restrict__ delim,
-                        size_t*  __restrict__ u_len);
-
-inline bool cmp_canonical_path_prefix (const char* __restrict__ prefix,
-                                       const char* __restrict__ path,
-                                       char* __restrict__ upath,
-                                       const size_t upath_capacity);
-#endif
 
 #if (__cplusplus >= 201703L) && __has_include(<filesystem>)
 // Enable if _Path is a filesystem::path or experimental::filesystem::path

--- a/pydyad/pydyad/bindings.py
+++ b/pydyad/pydyad/bindings.py
@@ -39,6 +39,8 @@ class DyadCtxWrapper(ctypes.Structure):
         ("kvs_namespace", ctypes.c_char_p),
         ("prod_managed_path", ctypes.c_char_p),
         ("cons_managed_path", ctypes.c_char_p),
+        ("prod_real_path", ctypes.c_char_p),
+        ("cons_real_path", ctypes.c_char_p),
     ]
 
 

--- a/pydyad/pydyad/bindings.py
+++ b/pydyad/pydyad/bindings.py
@@ -41,6 +41,14 @@ class DyadCtxWrapper(ctypes.Structure):
         ("cons_managed_path", ctypes.c_char_p),
         ("prod_real_path", ctypes.c_char_p),
         ("cons_real_path", ctypes.c_char_p),
+        ("prod_managed_len", ctypes.c_uint32),
+        ("cons_managed_len", ctypes.c_uint32),
+        ("prod_real_len", ctypes.c_uint32),
+        ("cons_real_len", ctypes.c_uint32),
+        ("prod_managed_hash", ctypes.c_uint32),
+        ("cons_managed_hash", ctypes.c_uint32),
+        ("prod_real_hash", ctypes.c_uint32),
+        ("cons_real_hash", ctypes.c_uint32),
     ]
 
 

--- a/src/dyad/common/dyad_logging.h
+++ b/src/dyad/common/dyad_logging.h
@@ -5,6 +5,8 @@
 #else
 #error "no config"
 #endif
+
+#include <dyad/common/dyad_structures.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -64,13 +66,13 @@ extern "C" {
   #else  // DYAD_UTIL_LOGGER
     #include <flux/core.h>
     #ifdef DYAD_LOGGER_LEVEL_DEBUG
-      #define DYAD_LOG_DEBUG(dyad_ctx, ...) flux_log ((dyad_ctx)->h, LOG_DEBUG, __VA_ARGS__);
+      #define DYAD_LOG_DEBUG(dyad_ctx, ...) flux_log ((flux_t*)(((dyad_ctx_t*) dyad_ctx)->h), LOG_DEBUG, __VA_ARGS__);
     #else
       #define DYAD_LOG_DEBUG(dyad_ctx, ...) DYAD_NOOP_MACRO
     #endif
 
     #ifdef DYAD_LOGGER_LEVEL_INFO
-      #define DYAD_LOG_INFO(dyad_ctx, ...) flux_log ((dyad_ctx)->h, LOG_INFO, __VA_ARGS__);
+      #define DYAD_LOG_INFO(dyad_ctx, ...) flux_log ((flux_t*)(((dyad_ctx_t*) dyad_ctx)->h), LOG_INFO, __VA_ARGS__);
     #else
       #define DYAD_LOG_INFO(dyad_ctx, ...) DYAD_NOOP_MACRO
     #endif
@@ -82,7 +84,7 @@ extern "C" {
     #endif
 
     #ifdef DYAD_LOGGER_LEVEL_ERROR
-      #define DYAD_LOG_ERROR(dyad_ctx, ...) flux_log_error ((dyad_ctx)->h, __VA_ARGS__);
+      #define DYAD_LOG_ERROR(dyad_ctx, ...) flux_log_error ((flux_t*)(((dyad_ctx_t*) dyad_ctx)->h), __VA_ARGS__);
     #else
       #define DYAD_LOG_ERROR(dyad_ctx, ...) DYAD_NOOP_MACRO
     #endif

--- a/src/dyad/common/dyad_structures.h
+++ b/src/dyad/common/dyad_structures.h
@@ -6,7 +6,14 @@
 #else
 #error "no config"
 #endif
-#include <flux/core.h>
+
+#ifdef __cplusplus
+#include <cstdint>
+#else
+#include <stdbool.h>
+#include <stdint.h>
+#endif
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -17,7 +24,7 @@ extern "C" {
  */
 struct dyad_ctx {
     // Internal
-    flux_t* h;                      // the Flux handle for DYAD
+    void* h;                      // the Flux handle for DYAD
     struct dyad_dtl* dtl_handle;    // Opaque handle to DTL info
     const char* fname;              // Used to track which file is getting processed.
     bool use_fs_locks;              // Used to track if fs locks should be used.
@@ -40,6 +47,14 @@ struct dyad_ctx {
     char* cons_managed_path;        // consumer path managed by DYAD
     char* prod_real_path;           // producer managed real path
     char* cons_real_path;           // consumer managed real path
+    uint32_t prod_managed_len;         // length of producer path managed by DYAD
+    uint32_t cons_managed_len;         // length of consumer path managed by DYAD
+    uint32_t prod_real_len;            // length of producer managed real path
+    uint32_t cons_real_len;            // length of consumer managed real path
+    uint32_t prod_managed_hash;        // hash of producer path managed by DYAD
+    uint32_t cons_managed_hash;        // hash of consumer path managed by DYAD
+    uint32_t prod_real_hash;           // hash of producer managed real path
+    uint32_t cons_real_hash;           // hash of consumer managed real path
 };
 typedef struct dyad_ctx dyad_ctx_t;
 typedef void* ucx_ep_cache_h;

--- a/src/dyad/common/dyad_structures.h
+++ b/src/dyad/common/dyad_structures.h
@@ -38,6 +38,8 @@ struct dyad_ctx {
     char* kvs_namespace;            // Flux KVS namespace for DYAD
     char* prod_managed_path;        // producer path managed by DYAD
     char* cons_managed_path;        // consumer path managed by DYAD
+    char* prod_real_path;           // producer managed real path
+    char* cons_real_path;           // consumer managed real path
 };
 typedef struct dyad_ctx dyad_ctx_t;
 typedef void* ucx_ep_cache_h;

--- a/src/dyad/core/dyad_core.c
+++ b/src/dyad/core/dyad_core.c
@@ -51,7 +51,9 @@ const struct dyad_ctx dyad_ctx_default = {
     -1,     // pid
     NULL,   // kvs_namespace
     NULL,   // prod_managed_path
-    NULL    // cons_managed_path
+    NULL,   // cons_managed_path
+    NULL,   // prod_real_path
+    NULL    // cons_real_path
 };
 
 static int gen_path_key (const char* str,
@@ -194,7 +196,9 @@ DYAD_CORE_FUNC_MODS dyad_rc_t dyad_commit (dyad_ctx_t* restrict ctx, const char*
     // Extract the path to the file specified by fname relative to the
     // producer-managed path
     // This relative path will be stored in upath
-    if (!cmp_canonical_path_prefix (ctx->prod_managed_path, fname, upath, PATH_MAX)) {
+    if (!cmp_canonical_path_prefix (ctx->prod_managed_path, ctx->prod_real_path,
+                                    fname, upath, PATH_MAX))
+    {
         DYAD_LOG_INFO (ctx, "%s is not in the Producer's managed path", fname);
         rc = DYAD_RC_OK;
         goto commit_done;
@@ -324,7 +328,9 @@ DYAD_CORE_FUNC_MODS dyad_rc_t dyad_fetch_metadata (const dyad_ctx_t* restrict ct
     // Extract the path to the file specified by fname relative to the
     // consumer-managed path
     // This relative path will be stored in upath
-    if (!cmp_canonical_path_prefix (ctx->cons_managed_path, fname, upath, PATH_MAX)) {
+    if (!cmp_canonical_path_prefix (ctx->cons_managed_path, ctx->cons_real_path,
+                                    fname, upath, PATH_MAX))
+    {
         DYAD_LOG_INFO (ctx, "%s is not in the Consumer's managed path\n", fname);
         rc = DYAD_RC_OK;
         goto fetch_done;
@@ -647,11 +653,16 @@ dyad_rc_t dyad_init (bool debug,
     if (prod_managed_path == NULL) {
         (*ctx)->prod_managed_path = NULL;
     } else {
+        char prod_real_path[PATH_MAX+1] = {'\0'};
+        realpath (prod_managed_path, prod_real_path);
         const size_t prod_path_len = strlen (prod_managed_path);
+        const size_t prod_realpath_len = strlen (prod_real_path);
         (*ctx)->prod_managed_path = (char*)malloc (prod_path_len + 1);
-        if ((*ctx)->prod_managed_path == NULL) {
-            DYAD_LOG_ERROR ((*ctx), "Could not allocate buffer for " \
-                                    "Producer managed path!\n");
+        if ((*ctx)->prod_managed_path == NULL ||
+            prod_realpath_len == 0ul || (*ctx)->prod_real_path == NULL) {
+            DYAD_LOG_ERROR ((*ctx),
+                          "Could not allocate buffer for Producer managed "
+                          "path!\n");
             free ((*ctx)->kvs_namespace);
             free (*ctx);
             *ctx = NULL;
@@ -659,6 +670,7 @@ dyad_rc_t dyad_init (bool debug,
             goto init_region_finish;
         }
         strncpy ((*ctx)->prod_managed_path, prod_managed_path, prod_path_len + 1);
+        strncpy ((*ctx)->prod_real_path, prod_real_path, prod_realpath_len + 1);
     }
     // If the consumer-managed path is provided, copy it into
     // the dyad_ctx_t object
@@ -666,11 +678,16 @@ dyad_rc_t dyad_init (bool debug,
     if (cons_managed_path == NULL) {
         (*ctx)->cons_managed_path = NULL;
     } else {
+        char cons_real_path[PATH_MAX+1] = {'\0'};
+        realpath (cons_managed_path, cons_real_path);
         const size_t cons_path_len = strlen (cons_managed_path);
+        const size_t cons_realpath_len = strlen (cons_real_path);
         (*ctx)->cons_managed_path = (char*)malloc (cons_path_len + 1);
-        if ((*ctx)->cons_managed_path == NULL) {
-            DYAD_LOG_ERROR ((*ctx), \
-                          "Could not allocate buffer for Consumer managed " \
+        (*ctx)->cons_real_path = (char*)malloc (cons_realpath_len + 1);
+        if ((*ctx)->cons_managed_path == NULL ||
+            cons_realpath_len == 0ul || (*ctx)->cons_real_path == NULL) {
+            DYAD_LOG_ERROR ((*ctx),
+                          "Could not allocate buffer for Consumer managed "
                           "path!\n");
             free ((*ctx)->kvs_namespace);
             free ((*ctx)->prod_managed_path);
@@ -680,6 +697,7 @@ dyad_rc_t dyad_init (bool debug,
             goto init_region_finish;
         }
         strncpy ((*ctx)->cons_managed_path, cons_managed_path, cons_path_len + 1);
+        strncpy ((*ctx)->cons_real_path, cons_real_path, cons_realpath_len + 1);
     }
 
     DYAD_C_FUNCTION_UPDATE_STR ("prod_managed_path", (*ctx)->prod_managed_path);
@@ -926,7 +944,9 @@ dyad_rc_t dyad_get_metadata (dyad_ctx_t* ctx,
     // producer-managed path
     // This relative path will be stored in upath
     DYAD_LOG_INFO (ctx, "Obtaining file path relative to consumer directory: %s", upath);
-    if (!cmp_canonical_path_prefix (ctx->cons_managed_path, fname, upath, PATH_MAX)) {
+    if (!cmp_canonical_path_prefix (ctx->cons_managed_path, ctx->cons_real_path,
+                                    fname, upath, PATH_MAX))
+    {
         DYAD_LOG_INFO (ctx, "%s is not in the Consumer's managed path\n", fname);
         rc = DYAD_RC_UNTRACKED;
         goto get_metadata_done;
@@ -1201,9 +1221,17 @@ dyad_rc_t dyad_finalize (dyad_ctx_t** ctx)
         free ((*ctx)->prod_managed_path);
         (*ctx)->prod_managed_path = NULL;
     }
+    if ((*ctx)->prod_real_path != NULL) {
+        free ((*ctx)->prod_real_path);
+        (*ctx)->prod_real_path = NULL;
+    }
     if ((*ctx)->cons_managed_path != NULL) {
         free ((*ctx)->cons_managed_path);
         (*ctx)->cons_managed_path = NULL;
+    }
+    if ((*ctx)->cons_real_path != NULL) {
+        free ((*ctx)->cons_real_path);
+        (*ctx)->cons_real_path = NULL;
     }
     free (*ctx);
     *ctx = NULL;

--- a/src/dyad/core/dyad_core.h
+++ b/src/dyad/core/dyad_core.h
@@ -7,12 +7,12 @@
 #error "no config"
 #endif
 
+#include <flux/core.h>
 #include <dyad/common/dyad_rc.h>
 #include <dyad/common/dyad_structures.h>
 #include <dyad/common/dyad_dtl.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <flux/core.h>
 
 #ifdef __cplusplus
 #include <cstdio>

--- a/src/dyad/dtl/flux_dtl.c
+++ b/src/dyad/dtl/flux_dtl.c
@@ -21,7 +21,7 @@ dyad_rc_t dyad_dtl_flux_init (const dyad_ctx_t* ctx,
         rc = DYAD_RC_SYSFAIL;
         goto dtl_flux_init_region_finish;
     }
-    ctx->dtl_handle->private_dtl.flux_dtl_handle->h = ctx->h;
+    ctx->dtl_handle->private_dtl.flux_dtl_handle->h = (flux_t*) ctx->h;
     ctx->dtl_handle->private_dtl.flux_dtl_handle->comm_mode = comm_mode;
     ctx->dtl_handle->private_dtl.flux_dtl_handle->debug = debug;
     ctx->dtl_handle->private_dtl.flux_dtl_handle->f = NULL;

--- a/src/dyad/dtl/ucx_dtl.c
+++ b/src/dyad/dtl/ucx_dtl.c
@@ -275,7 +275,7 @@ static inline ucs_status_ptr_t ucx_send_no_wait (const dyad_ctx_t* ctx, bool is_
         stat_ptr = (void*)UCS_ERR_NOT_CONNECTED;
         goto ucx_send_no_wait_done;
     }
-    DYAD_LOG_INFO (ctx, "written data buf of length %d", buflen);
+    DYAD_LOG_INFO (ctx, "written data buf of length %lu", buflen);
 #endif
 ucx_send_no_wait_done:;
     DYAD_C_FUNCTION_END();
@@ -523,7 +523,7 @@ dyad_rc_t dyad_dtl_ucx_init (const dyad_ctx_t* ctx,
     dtl_handle = ctx->dtl_handle->private_dtl.ucx_dtl_handle;
     // Allocation/Freeing of the Flux handle should be
     // handled by the DYAD context
-    dtl_handle->h = ctx->h;
+    dtl_handle->h = (flux_t*) ctx->h;
     dtl_handle->comm_mode = comm_mode;
     dtl_handle->debug = debug;
     dtl_handle->ucx_ctx = NULL;

--- a/src/dyad/dtl/ucx_ep_cache.cpp
+++ b/src/dyad/dtl/ucx_ep_cache.cpp
@@ -4,9 +4,9 @@
 #error "no config"
 #endif
 
+#include <dyad/dtl/ucx_ep_cache.h>
 #include <dyad/common/dyad_profiler.h>
 #include <dyad/common/dyad_logging.h>
-#include <dyad/dtl/ucx_ep_cache.h>
 #include <dyad/common/dyad_structures.h>
 
 #include <functional>
@@ -17,10 +17,10 @@
 using key_type = uint64_t;
 using cache_type = std::unordered_map<key_type, ucp_ep_h>;
 
-static void dyad_ucx_ep_err_handler (void* arg, ucp_ep_h ep, ucs_status_t status)
+static void __attribute__((unused)) dyad_ucx_ep_err_handler (void* arg, ucp_ep_h ep, ucs_status_t status)
 {
     DYAD_C_FUNCTION_START();
-    dyad_ctx_t *ctx = (dyad_ctx_t*)arg;
+    dyad_ctx_t __attribute__((unused)) *ctx = (dyad_ctx_t*)arg;
     DYAD_LOG_ERROR (ctx, "An error occured on the UCP endpoint (status = %d)", status);
     DYAD_C_FUNCTION_END();
 }

--- a/src/dyad/dtl/ucx_ep_cache.h
+++ b/src/dyad/dtl/ucx_ep_cache.h
@@ -7,11 +7,11 @@
 #error "no config"
 #endif
 
+#include <flux/core.h>
 #include <dyad/common/dyad_rc.h>
 #include <dyad/common/dyad_structures.h>
-#include <ucp/api/ucp.h>
-#include <flux/core.h>
 #include <dyad/dtl/ucx_dtl.h>
+#include <ucp/api/ucp.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/dyad/modules/CMakeLists.txt
+++ b/src/dyad/modules/CMakeLists.txt
@@ -1,5 +1,14 @@
 set(DYAD_MODULE_SRC ${CMAKE_CURRENT_SOURCE_DIR}/dyad.c)
-set(DYAD_MODULE_PRIVATE_HEADERS)
+set(DYAD_MODULE_PRIVATE_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/../core/dyad_core.h
+                                ${CMAKE_CURRENT_SOURCE_DIR}/../common/dyad_envs.h
+                                ${CMAKE_CURRENT_SOURCE_DIR}/../common/dyad_dtl.h
+                                ${CMAKE_CURRENT_SOURCE_DIR}/../common/dyad_rc.h
+                                ${CMAKE_CURRENT_SOURCE_DIR}/../common/dyad_logging.h
+                                ${CMAKE_CURRENT_SOURCE_DIR}/../common/dyad_structures.h
+                                ${CMAKE_CURRENT_SOURCE_DIR}/../common/dyad_profiler.h
+                                ${CMAKE_CURRENT_SOURCE_DIR}/../dtl/dyad_dtl_api.h
+                                ${CMAKE_CURRENT_SOURCE_DIR}/../utils/read_all.h
+                                ${CMAKE_CURRENT_SOURCE_DIR}/../utils/utils.h)
 set(DYAD_MODULE_PUBLIC_HEADERS)
 
 add_library(${PROJECT_NAME} SHARED ${DYAD_MODULE_SRC}
@@ -18,7 +27,12 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ${JANSSON_INCLUDE_DIRS})
 target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ${FluxCore_INCLUDE_DIRS})
 
-add_executable(test_opt_parse test_opt_parse.c)
+add_executable(test_opt_parse test_opt_parse.c
+               ${CMAKE_CURRENT_SOURCE_DIR}/../common/dyad_envs.h
+               ${CMAKE_CURRENT_SOURCE_DIR}/../common/dyad_dtl.h
+               ${CMAKE_CURRENT_SOURCE_DIR}/../common/dyad_rc.h
+               ${CMAKE_CURRENT_SOURCE_DIR}/../common/dyad_logging.h
+               ${CMAKE_CURRENT_SOURCE_DIR}/../common/dyad_structures.h)
 target_compile_definitions(test_opt_parse PUBLIC DYAD_HAS_CONFIG)
 target_include_directories(test_opt_parse PUBLIC
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>

--- a/src/dyad/modules/dyad.c
+++ b/src/dyad/modules/dyad.c
@@ -14,6 +14,7 @@
 #error "no config"
 #endif
 
+#include <dyad/core/dyad_core.h>
 #include <dyad/common/dyad_envs.h>
 #include <dyad/common/dyad_dtl.h>
 #include <dyad/common/dyad_rc.h>
@@ -21,7 +22,6 @@
 #include <dyad/common/dyad_logging.h>
 #include <dyad/common/dyad_profiler.h>
 #include <dyad/dtl/dyad_dtl_api.h>
-#include <dyad/core/dyad_core.h>
 #include <dyad/utils/read_all.h>
 #include <dyad/utils/utils.h>
 

--- a/src/dyad/modules/test_opt_parse.c
+++ b/src/dyad/modules/test_opt_parse.c
@@ -11,8 +11,8 @@
 #include <dyad/common/dyad_dtl.h>
 #include <dyad/common/dyad_rc.h>
 #include <dyad/common/dyad_logging.h>
+#include <dyad/common/dyad_structures.h>
 #include <inttypes.h>
-typedef void dyad_ctx_t;
 
 #if defined(__cplusplus)
 #include <cerrno>

--- a/src/dyad/utils/CMakeLists.txt
+++ b/src/dyad/utils/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(${PROJECT_NAME}_utils SHARED ${DYAD_UTILS_SRC}
 set_target_properties(${PROJECT_NAME}_utils PROPERTIES CMAKE_INSTALL_RPATH
                       "${CMAKE_INSTALL_PREFIX}/${DYAD_LIBDIR}")
 target_link_libraries(${PROJECT_NAME}_utils PUBLIC flux::core ${PROJECT_NAME}_base64)
+
 if(DYAD_LOGGER STREQUAL "CPP_LOGGER")
     target_link_libraries(${PROJECT_NAME}_utils PRIVATE ${CPP_LOGGER_LIBRARIES})
 endif()
@@ -30,6 +31,17 @@ target_include_directories(${PROJECT_NAME}_utils PUBLIC
 add_library(${PROJECT_NAME}_murmur3 SHARED ${DYAD_MURMUR3_SRC})
 set_target_properties(${PROJECT_NAME}_murmur3 PROPERTIES CMAKE_INSTALL_RPATH
                       "${CMAKE_INSTALL_PREFIX}/${DYAD_LIBDIR}")
+
+add_executable(test_cmp_canonical_path_prefix test_cmp_canonical_path_prefix.c)
+target_compile_definitions(test_cmp_canonical_path_prefix PUBLIC DYAD_HAS_CONFIG)
+target_link_libraries(test_cmp_canonical_path_prefix PUBLIC ${PROJECT_NAME}_utils)
+if(DYAD_LOGGER STREQUAL "CPP_LOGGER")
+    target_link_libraries(test_cmp_canonical_path_prefix PRIVATE ${CPP_LOGGER_LIBRARIES})
+endif()
+if(DYAD_PROFILER STREQUAL "DLIO_PROFILER")
+    target_link_libraries(test_cmp_canonical_path_prefix PRIVATE ${DLIO_PROFILER_LIBRARIES})
+endif()
+
 
 if (TARGET DYAD_C_FLAGS_werror)
   target_link_libraries(${PROJECT_NAME}_utils PRIVATE DYAD_C_FLAGS_werror)

--- a/src/dyad/utils/CMakeLists.txt
+++ b/src/dyad/utils/CMakeLists.txt
@@ -14,7 +14,9 @@ add_library(${PROJECT_NAME}_utils SHARED ${DYAD_UTILS_SRC}
             ${DYAD_UTILS_PRIVATE_HEADERS} ${DYAD_UTILS_PUBLIC_HEADERS})
 set_target_properties(${PROJECT_NAME}_utils PROPERTIES CMAKE_INSTALL_RPATH
                       "${CMAKE_INSTALL_PREFIX}/${DYAD_LIBDIR}")
-target_link_libraries(${PROJECT_NAME}_utils PUBLIC flux::core ${PROJECT_NAME}_base64)
+target_link_libraries(${PROJECT_NAME}_utils PUBLIC
+                      ${PROJECT_NAME}_base64
+                      ${PROJECT_NAME}_murmur3)
 
 if(DYAD_LOGGER STREQUAL "CPP_LOGGER")
     target_link_libraries(${PROJECT_NAME}_utils PRIVATE ${CPP_LOGGER_LIBRARIES})

--- a/src/dyad/utils/test_cmp_canonical_path_prefix.c
+++ b/src/dyad/utils/test_cmp_canonical_path_prefix.c
@@ -1,0 +1,40 @@
+#if defined(DYAD_HAS_CONFIG)
+#include <dyad/dyad_config.hpp>
+#else
+#error "no config"
+#endif
+
+#include <dyad/utils/utils.h>
+#include <stdlib.h>
+#include <limits.h>
+
+int main (int argc, char** argv)
+{
+    char* prefix = NULL;
+    char* can_prefix = NULL;
+    char* path = NULL;
+    bool ret = false;
+    char upath[PATH_MAX] = {'\0'};
+
+    if (argc < 3 || 4 < argc) {
+        printf ("Usage: %s prefix path [canonical_prefix]\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+    if (argc >= 3) {
+        prefix = argv[1];
+        path = argv[2];
+    }
+    if (argc == 4) {
+        can_prefix = argv[3];
+    }
+
+    ret = cmp_canonical_path_prefix (prefix, can_prefix, path, upath, PATH_MAX);
+    if (!ret) {
+        printf ("path '%s' does not include prefix '%s' ('%s')\n", path, prefix, can_prefix);
+        return EXIT_FAILURE;
+    }
+    printf ("path '%s' include prefix '%s' ('%s')\n", path, prefix, can_prefix);
+    printf ("%s under %s\n", upath, prefix);
+
+    return EXIT_SUCCESS;
+}

--- a/src/dyad/utils/test_cmp_canonical_path_prefix.c
+++ b/src/dyad/utils/test_cmp_canonical_path_prefix.c
@@ -7,6 +7,8 @@
 #include <dyad/utils/utils.h>
 #include <stdlib.h>
 #include <limits.h>
+#include <stdint.h>
+#include <string.h>
 
 int main (int argc, char** argv)
 {
@@ -28,13 +30,21 @@ int main (int argc, char** argv)
         can_prefix = argv[3];
     }
 
-    ret = cmp_canonical_path_prefix (prefix, can_prefix, path, upath, PATH_MAX);
+    const size_t prefix_len = strlen (prefix);
+    const size_t can_prefix_len = can_prefix? strlen (can_prefix) : 0u;;
+    uint32_t prefix_hash = hash_str (prefix, DYAD_SEED);
+    uint32_t can_prefix_hash = hash_str (can_prefix, DYAD_SEED);
+
+    ret = cmp_canonical_path_prefix (prefix, can_prefix,
+                                     prefix_len, can_prefix_len,
+                                     prefix_hash, can_prefix_hash,
+                                     path, upath, PATH_MAX);
     if (!ret) {
         printf ("path '%s' does not include prefix '%s' ('%s')\n", path, prefix, can_prefix);
         return EXIT_FAILURE;
     }
-    printf ("path '%s' include prefix '%s' ('%s')\n", path, prefix, can_prefix);
-    printf ("%s under %s\n", upath, prefix);
+    printf ("path '%s' include prefix '%s' (canonical form: '%s')\n", path, prefix, can_prefix);
+    printf ("'%s' is under '%s'\n", upath, prefix);
 
     return EXIT_SUCCESS;
 }

--- a/src/dyad/utils/utils.c
+++ b/src/dyad/utils/utils.c
@@ -25,11 +25,13 @@
 
 #include <dyad/common/dyad_logging.h>
 #include <dyad/common/dyad_profiler.h>
+#include <dyad/utils/murmur3.h>
 
 #include <fcntl.h>      // open
 #include <libgen.h>     // basename dirname
 #include <sys/stat.h>   // open
 #include <sys/types.h>  // open
+#include <sys/file.h>
 #include <unistd.h>     // readlink
 
 #if defined(__cplusplus)
@@ -40,6 +42,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <cstdint>
 // #include <cstdbool> // c++11
 #else
 #include <errno.h>
@@ -50,23 +53,41 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <stdint.h>
 #endif
 
-static __thread bool debug_dyad_utils = false;
 
-void enable_debug_dyad_utils (void)
+/// If hashing is not possible, returns 0. Otherwise, returns a non-zero hash value.
+uint32_t hash_str (const char* str, const uint32_t seed)
 {
-    debug_dyad_utils = true;
+    if (!str) return 0u;
+    const size_t len = strlen (str);
+    if (len == 0ul) return 0u;
+
+    uint32_t hash[4] = {0u};  // Output for the hash
+    MurmurHash3_x64_128 (str, strlen (str), seed, hash);
+    return (hash[0] ^ hash[1] ^ hash[2] ^ hash[3]) + 1;
 }
 
-void disable_debug_dyad_utils (void)
+/** If hashing is not possible, returns 0. Otherwise, returns a non-zero hash value.
+ *  This does not check if the length of string is correct, but simply use it */
+uint32_t hash_path_prefix (const char* str, const uint32_t seed,
+                           const size_t len)
 {
-    debug_dyad_utils = false;
-}
+    char strbuf [PATH_MAX+1] = {'\0'};
+    uint32_t hash[4] = {0u};  // Output for the first hash with len1
 
-bool check_debug_dyad_utils (void)
-{
-    return debug_dyad_utils;
+    if (!str || len == 0ul) {
+        return 0u;
+    }
+
+    memcpy (strbuf, str, (len > PATH_MAX)? PATH_MAX : len);
+    const size_t buf_len = strlen (strbuf);
+    if (buf_len != len) {
+        return 0u;
+    }
+    MurmurHash3_x64_128 (str, buf_len, seed, hash);
+    return (hash[0] ^ hash[1] ^ hash[2] ^ hash[3]) + 1;
 }
 
 /**
@@ -124,43 +145,31 @@ char* concat_str (char* __restrict__ str,
 }
 
 /**
- * Copies the last upath_len characters of the path into upath
- */
-bool extract_user_path (const char* __restrict__ path,
-                        char* __restrict__ upath,
-                        const size_t upath_len)
-{
-    if ((upath_len > PATH_MAX) || (upath == NULL)) {
-        return false;
-    }
-
-    if (!(((upath + PATH_MAX) <= path) || ((path + PATH_MAX) <= upath))) {
-        return false;  // buffers overlap
-    }
-
-    size_t upath_pos = strlen (path) - upath_len;
-    strncpy (upath, path + upath_pos, upath_len);
-    upath[upath_len] = '\0';
-
-    return true;
-}
-
-/**
  * Compares a path (full) against a path prefix considering the path
  * delimiter. Then, returns the length of the user added path string
  * that follows the path prefix via the last argument.
  */
-bool cmp_prefix (const char* __restrict__ prefix,
-                 const char* __restrict__ full,
-                 const char* __restrict__ delim,
-                 size_t* __restrict__ u_len)
+bool extract_user_path (const char* __restrict__ prefix,
+                        const char* __restrict__ full,
+                        const char* __restrict__ delim,
+                        char* __restrict__ upath,
+                        const size_t upath_capacity)
 {
+    size_t prefix_len = strlen (prefix);
+    const size_t full_len = strlen (full);
+    const size_t delim_len = ((delim == NULL) ? 0ul : strlen (delim));
+    size_t u_len = 0ul;
+
+    if (upath == NULL) {
+        return false;
+    }
+
     {
-        const char* const u_len_end = ((const char*)u_len) + sizeof (size_t);
+        const char* const upath_end = upath + upath_capacity;
         bool no_overlap =
-            ((prefix + strlen (prefix) <= (char*)u_len) || (u_len_end <= prefix))
-            && ((full + strlen (full) <= (char*)u_len) || (u_len_end <= full))
-            && ((delim + strlen (delim) <= (char*)u_len) || (u_len_end <= delim));
+             ((prefix + prefix_len <= upath) || (upath_end <= prefix))
+            && ((full + full_len <= upath)   || (upath_end <= full))
+            && ((delim + delim_len <= upath) || (upath_end <= delim));
 
         if (!no_overlap) {
             DYAD_LOG_DEBUG (NULL, "DYAD UTIL: buffers overlap.\n");
@@ -168,25 +177,14 @@ bool cmp_prefix (const char* __restrict__ prefix,
         }
     }
 
-    const size_t full_len = strlen (full);
-    const size_t delim_len = ((delim == NULL) ? 0ul : strlen (delim));
-    size_t prefix_len = strlen (prefix);
-    if (full_len > PATH_MAX || delim_len > PATH_MAX || prefix_len > PATH_MAX) {
-        DYAD_LOG_DEBUG (NULL, "DYAD UTIL: path length cannot be larger than PATH_MAX\n");
+    // Check if the full path begins with the prefix string
+    if (strncmp (prefix, full, prefix_len) != 0) {
         return false;
     }
 
-    if (delim_len == 0ul) {  // no delimiter is defined
-        if (strncmp (prefix, full, prefix_len) != 0) {
-            return false;
-        }
-        if (u_len != NULL) {
-            // Without a path delimiter used, the length of the substring that
-            // follows the prefix (user path) is the total length of the full
-            // string minus that of the prefix string.
-            *u_len = full_len - prefix_len;
-        }
-        return true;
+    if (full_len > PATH_MAX || delim_len > PATH_MAX || prefix_len > PATH_MAX) {
+        DYAD_LOG_DEBUG (NULL, "DYAD UTIL: path length cannot be larger than PATH_MAX\n");
+        return false;
     }
 
     if (prefix_len >= delim_len) {
@@ -196,77 +194,67 @@ bool cmp_prefix (const char* __restrict__ prefix,
         }
     }
 
-    // Check if the full path begins with the prefix string
-    if (strncmp (prefix, full, prefix_len) != 0) {
-        return false;
-    }
-
-    if (full_len == prefix_len) {
+    if (full_len <= prefix_len + delim_len) {
         // The full path string is exactly the same as the prefix string.
-        if (u_len != NULL) {
-            *u_len = 0ul;
-        }
-        return true;
-    } else if (full_len < prefix_len + delim_len) {
         return false;
     }
 
-    if (u_len != NULL) {
-        *u_len = full_len - prefix_len - delim_len;
-    }
-
-    // Finally, make sure that the user path begins with the delimiter.
+    // Finally, make sure that the the delimiter is at the right position.
     // This check correctly identifies, for example, "prefix_path2/user_path" as
     // a mismatch when "prefix_path/user_path" is a match.
-    return (strncmp (full + prefix_len, delim, delim_len) == 0);
+    if (strncmp (full + prefix_len, delim, delim_len) != 0) {
+        return false;
+    }
+
+    u_len = full_len - prefix_len - delim_len;
+    if (u_len + 1 > upath_capacity) {
+        return false;
+    }
+
+    memcpy (upath, full + full_len - u_len, u_len);
+
+    return true;
 }
 
+/**
+ * This function checks if the 'path' string provided has the prefix that matches
+ * the dyad manage path ('prefix') or the canonical version of it ('can_prefix').
+ * Then, it returns true if it matches or false otherwise. It also checks with the
+ * canonical version of the 'path' if it does not match as is. The portion of the
+ * path string without the prefix is written to `upath` buffer. 'upath_capacity'
+ * indicates the capacity of the buffer.
+ * This does not check if the length of prefix string and can_prefix string
+ * actually match the ones provided. It is also assume that the internal hashing
+ * relies on the same hash algorithm and the seed as used to compute the hash
+ * arguments provided.
+ */
 bool cmp_canonical_path_prefix (const char* __restrict__ prefix,
-                                const char* __restrict__ canprefix,
+                                const char* __restrict__ can_prefix,
+                                const uint32_t prefix_len,
+                                const uint32_t can_prefix_len,
+                                const uint32_t prefix_hash,
+                                const uint32_t can_prefix_hash,
                                 const char* __restrict__ path,
                                 char* __restrict__ upath,
                                 const size_t upath_capacity)
 {
-    {
-        const char* const upath_end = upath + upath_capacity;
-        bool no_overlap = ((prefix + strlen (prefix) <= upath) || (upath_end <= prefix))
-                          && ((path + strlen (path) <= upath) || (upath_end <= path));
-
-        if (!no_overlap) {
-            DYAD_LOG_DEBUG (NULL, "DYAD UTIL: buffers overlap\n");
-            return false;
-        }
-    }
-
-    size_t upath_len = 0ul;
-
-    if (cmp_prefix (prefix, path, DYAD_PATH_DELIM, &upath_len)) {
-        extract_user_path (path, upath, upath_len);
-        if (upath_len + 1 > upath_capacity) {
-            return false;
-        }
-        return true;
-    }
-
     // Only works when there are no multiple absolute paths via hardlinks
-    char can_prefix[PATH_MAX] = {'\0'};  // canonical form of the managed path
     char can_path[PATH_MAX] = {'\0'};    // canonical form of the given path
 
-    // The path prefix needs to translate to a real path
-    if (!canprefix && !realpath (prefix, can_prefix)) {
-        DYAD_LOG_DEBUG (NULL,"DYAD UTIL: error in realpath for %s\n", prefix);
-        DYAD_LOG_DEBUG (NULL, "DYAD UTIL: %s\n", strerror (errno));
-        return false;
+    const uint32_t path_hash1 = hash_path_prefix (path, DYAD_SEED, prefix_len);
+
+    if ((path_hash1 == prefix_hash) &&
+        extract_user_path (prefix, path, DYAD_PATH_DELIM, upath, upath_capacity)) {
+        return true;
     }
 
-    const char* _can_prefix = canprefix? canprefix : can_prefix;
-
-    if (cmp_prefix (_can_prefix, path, DYAD_PATH_DELIM, &upath_len)) {
-        extract_user_path (path, upath, upath_len);
-        if (upath_len + 1 > upath_capacity) {
-            return false;
+    if (can_prefix_len > 0u) {
+        const uint32_t path_hash2 = hash_path_prefix (path, DYAD_SEED, can_prefix_len);
+        if (path_hash2 == can_prefix_hash) {
+            if (extract_user_path (can_prefix, path, DYAD_PATH_DELIM, upath, upath_capacity)) {
+                return true;
+            }
         }
-        return true;
     }
 
     // See if the prefix of the path in question matches that of either the
@@ -276,17 +264,22 @@ bool cmp_canonical_path_prefix (const char* __restrict__ prefix,
         return false;
     }
 
-    // For a real path, see if the prefix of either the path or its canonical
-    // form matches the managed path.
-    if (!cmp_prefix (_can_prefix, can_path, DYAD_PATH_DELIM, &upath_len)) {
-        return false;
-    }
-    if (upath_len + 1 > upath_capacity) {
-        return false;
-    }
-    extract_user_path (can_path, upath, upath_len);
+    const uint32_t can_path_hash1 = hash_path_prefix (can_path, DYAD_SEED, prefix_len);
 
-    return true;
+    if ((can_path_hash1 == prefix_hash) &&
+        extract_user_path (prefix, can_path, DYAD_PATH_DELIM, upath, upath_capacity)) {
+        return true;
+    }
+
+    if (can_prefix_len > 0u) {
+        const uint32_t can_path_hash2 = hash_path_prefix (can_path, DYAD_SEED, can_prefix_len);
+        if ((can_path_hash2 == can_prefix_hash) &&
+            extract_user_path (can_prefix, can_path, DYAD_PATH_DELIM, upath, upath_capacity)) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 /**
@@ -457,7 +450,8 @@ ssize_t get_file_size (int fd)
     return file_size;
 }
 
-dyad_rc_t dyad_excl_flock (const dyad_ctx_t* ctx, int fd, struct flock* lock)
+dyad_rc_t dyad_excl_flock (const dyad_ctx_t* __restrict__ ctx, int fd,
+                           struct flock* __restrict__ lock)
 {
     dyad_rc_t rc = DYAD_RC_OK;
     DYAD_C_FUNCTION_START();
@@ -486,7 +480,8 @@ excl_flock_end:;
     return rc;
 }
 
-dyad_rc_t dyad_shared_flock (const dyad_ctx_t* ctx, int fd, struct flock* lock)
+dyad_rc_t dyad_shared_flock (const dyad_ctx_t* __restrict__ ctx, int fd,
+                             struct flock* __restrict__ lock)
 {
     DYAD_C_FUNCTION_START();
     DYAD_C_FUNCTION_UPDATE_INT ("fd", fd);
@@ -515,7 +510,8 @@ shared_flock_end:;
     return rc;
 }
 
-dyad_rc_t dyad_release_flock (const dyad_ctx_t* ctx, int fd, struct flock* lock)
+dyad_rc_t dyad_release_flock (const dyad_ctx_t* __restrict__ ctx, int fd,
+                              struct flock* __restrict__ lock)
 {
     DYAD_C_FUNCTION_START();
     DYAD_C_FUNCTION_UPDATE_INT ("fd", fd);

--- a/src/dyad/utils/utils.c
+++ b/src/dyad/utils/utils.c
@@ -259,7 +259,7 @@ bool cmp_canonical_path_prefix (const char* __restrict__ prefix,
         return false;
     }
 
-    char* _can_prefix = canprefix? canprefix : can_prefix;
+    const char* _can_prefix = canprefix? canprefix : can_prefix;
 
     if (cmp_prefix (_can_prefix, path, DYAD_PATH_DELIM, &upath_len)) {
         extract_user_path (path, upath, upath_len);

--- a/src/dyad/utils/utils.h
+++ b/src/dyad/utils/utils.h
@@ -65,6 +65,7 @@ bool cmp_prefix (const char* __restrict__ prefix,
                  size_t* __restrict__ u_len);
 
 bool cmp_canonical_path_prefix (const char* __restrict__ prefix,
+                                const char* __restrict__ can_prefix,
                                 const char* __restrict__ path,
                                 char* __restrict__ upath,
                                 const size_t upath_capacity);

--- a/src/dyad/utils/utils.h
+++ b/src/dyad/utils/utils.h
@@ -27,13 +27,15 @@
 // #include <cstdbool> // c++11
 #include <cstddef>
 #include <cstdio>
+#include <cstdint>
 #else
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <stdint.h>
 #endif  // defined(__cplusplus)
-#include <sys/file.h>
-#include <sys/stat.h>
+
+#include <fcntl.h>
 #include <dyad/common/dyad_structures.h>
 #include <dyad/common/dyad_rc.h>
 
@@ -50,22 +52,31 @@ void enable_debug_dyad_utils (void);
 void disable_debug_dyad_utils (void);
 bool check_debug_dyad_utils (void);
 
+/** Return the hash value computed for the entire string with a given seed
+ *  The return value 0 means that the string was not valid or the length was 0. */
+uint32_t hash_str (const char* str, const uint32_t seed);
+/** Return the hash value computed for the path string up to len characters
+ *  with a given seed.
+ *  The return value 0 means that the string was not valid or the length was 0. */
+uint32_t hash_path_prefix (const char* str, const uint32_t seed, const size_t len);
+
 char* concat_str (char* __restrict__ str,
                   const char* __restrict__ to_append,
                   const char* __restrict__ connector,
                   size_t str_capacity);
 
-bool extract_user_path (const char* __restrict__ path,
+bool extract_user_path (const char* __restrict__ prefix,
+                        const char* __restrict__ full,
+                        const char* __restrict__ delim,
                         char* __restrict__ upath,
-                        const size_t upath_len);
-
-bool cmp_prefix (const char* __restrict__ prefix,
-                 const char* __restrict__ full,
-                 const char* __restrict__ delim,
-                 size_t* __restrict__ u_len);
+                        const size_t upath_capacity);
 
 bool cmp_canonical_path_prefix (const char* __restrict__ prefix,
                                 const char* __restrict__ can_prefix,
+                                const uint32_t prefix_len,
+                                const uint32_t can_prefix_len,
+                                const uint32_t prefix_hash,
+                                const uint32_t can_prefix_hash,
                                 const char* __restrict__ path,
                                 char* __restrict__ upath,
                                 const size_t upath_capacity);
@@ -88,9 +99,12 @@ bool get_stat (const char* path, unsigned int max_retry, long ns_sleep);
 
 ssize_t get_file_size (int fd);
 
-dyad_rc_t dyad_excl_flock (const dyad_ctx_t* ctx, int fd, struct flock* lock);
-dyad_rc_t dyad_shared_flock (const dyad_ctx_t* ctx, int fd, struct flock* lock);
-dyad_rc_t dyad_release_flock (const dyad_ctx_t* ctx, int fd, struct flock* lock);
+dyad_rc_t dyad_excl_flock (const dyad_ctx_t* __restrict__ ctx, int fd,
+                           struct flock* __restrict__ lock);
+dyad_rc_t dyad_shared_flock (const dyad_ctx_t* __restrict__ ctx, int fd,
+                             struct flock* __restrict__ lock);
+dyad_rc_t dyad_release_flock (const dyad_ctx_t* __restrict__ ctx, int fd,
+                              struct flock* __restrict__ lock);
 
 #if DYAD_SYNC_DIR
 /**

--- a/src/dyad/wrapper/wrapper.c
+++ b/src/dyad/wrapper/wrapper.c
@@ -40,13 +40,11 @@ using namespace std;  // std::clock ()
 #endif  // defined(__cplusplus)
 
 #include <dlfcn.h>
-#include <dyad/utils/utils.h>
 #include <fcntl.h>
 #include <libgen.h>  // dirname
 #include <unistd.h>
 
 #include <dyad/utils/utils.h>
-// #include "wrapper.h"
 #include <dyad/common/dyad_envs.h>
 #include <dyad/common/dyad_logging.h>
 #include <dyad/common/dyad_profiler.h>
@@ -111,8 +109,10 @@ void dyad_wrapper_init (void)
 
     if (DYAD_IS_ERROR (rc)) {
         fprintf (stderr, "Failed to initialize DYAD (code = %d)", rc);
-        ctx->initialized = false;
-        ctx->reenter = false;
+        if (ctx != NULL) {
+            ctx->initialized = false;
+            ctx->reenter = false;
+        }
         DYAD_C_FUNCTION_END();
         return;
     }


### PR DESCRIPTION
1. Cache the result of realpath call in ctx
2. use the cached realpath in calling `cmp_canonical_path_prefix()`
3. reorder the comparisons between managed path prefix and path
This PR dependes on PR #91 