### PR TITLE
Move the DLIO test after Python API test

### DIFF
--- a/.github/workflows/compile_test.yaml
+++ b/.github/workflows/compile_test.yaml
@@ -274,19 +274,6 @@ jobs:
           export LDFLAGS="-L${DYAD_INSTALL_PREFIX}/lib"
           cd ${GITHUB_WORKSPACE}/docs/demos/ecp_feb_2023
           make all
-      - name: Test DYAD with DLIO benchmark
-        timeout-minutes: 10
-        run: |
-          mkdir -p $DYAD_PATH
-          source ${DYAD_INSTALL_PREFIX}/bin/activate
-          . ${SPACK_DIR}/share/spack/setup-env.sh
-          export PATH=${PATH}:${DYAD_INSTALL_PREFIX}/bin:${DYAD_INSTALL_PREFIX}/sbin
-          export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${DYAD_INSTALL_PREFIX}/lib
-          export PYTHONPATH=${GITHUB_WORKSPACE}/tests/integration/dlio_benchmark:${GITHUB_WORKSPACE}/pydyad:$PYTHONPATH
-          pip install -v -r ${GITHUB_WORKSPACE}/tests/integration/dlio_benchmark/requirements.txt
-          echo "Starting flux brokers"
-          cd ${GITHUB_WORKSPACE}/tests/integration/dlio_benchmark
-          flux start --test-size=2 /bin/bash ./script.sh ${GITHUB_WORKSPACE} ${DYAD_INSTALL_PREFIX}
       - name: Test DYAD with separate FS c
         timeout-minutes: 1
         run: |
@@ -315,4 +302,17 @@ jobs:
           export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${DYAD_INSTALL_PREFIX}/lib
           echo "Starting flux brokers"
           flux start --test-size=2 /bin/bash ${GITHUB_WORKSPACE}/.github/prod-cons/dyad_prod_cons_test.sh "python"
+      - name: Test DYAD with DLIO benchmark
+        timeout-minutes: 10
+        run: |
+          mkdir -p $DYAD_PATH
+          source ${DYAD_INSTALL_PREFIX}/bin/activate
+          . ${SPACK_DIR}/share/spack/setup-env.sh
+          export PATH=${PATH}:${DYAD_INSTALL_PREFIX}/bin:${DYAD_INSTALL_PREFIX}/sbin
+          export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${DYAD_INSTALL_PREFIX}/lib
+          export PYTHONPATH=${GITHUB_WORKSPACE}/tests/integration/dlio_benchmark:${GITHUB_WORKSPACE}/pydyad:$PYTHONPATH
+          pip install -v -r ${GITHUB_WORKSPACE}/tests/integration/dlio_benchmark/requirements.txt
+          echo "Starting flux brokers"
+          cd ${GITHUB_WORKSPACE}/tests/integration/dlio_benchmark
+          flux start --test-size=2 /bin/bash ./script.sh ${GITHUB_WORKSPACE} ${DYAD_INSTALL_PREFIX}
 


### PR DESCRIPTION
DLIO test requires Python API.
So, it makes sense to move it after Python API test.
We will also be able to see the test result with c core first.