### PR TITLE
Improve consume performance by avoiding fsync.

### DIFF
--- a/src/dyad/core/dyad_core.c
+++ b/src/dyad/core/dyad_core.c
@@ -958,7 +958,7 @@ dyad_rc_t dyad_consume (dyad_ctx_t* ctx, const char* fname)
     DYAD_C_FUNCTION_START();
     DYAD_C_FUNCTION_UPDATE_STR ("fname", fname);
     dyad_rc_t rc = DYAD_RC_OK;
-    int fd = -1;
+    int lock_fd = -1, io_fd = -1;
     ssize_t file_size = -1;
     char* file_data = NULL;
     size_t data_len = 0ul;
@@ -979,21 +979,20 @@ dyad_rc_t dyad_consume (dyad_ctx_t* ctx, const char* fname)
     // Set reenter to false to avoid recursively performing
     // DYAD operations
     ctx->reenter = false;
-    fd = open (fname, O_RDWR | O_CREAT, 0666);
-    DYAD_C_FUNCTION_UPDATE_INT ("fd", fd);
-    if (fd == -1) {
+    lock_fd = open (fname, O_RDWR | O_CREAT, 0666);
+    if (lock_fd == -1) {
         DYAD_LOG_ERROR (ctx, "Cannot create file (%s) for dyad_consume!\n", fname);
         rc = DYAD_RC_BADFIO;
         goto consume_close;
     }
-    rc = dyad_excl_flock (ctx, fd, &exclusive_lock);
+    rc = dyad_excl_flock (ctx, lock_fd, &exclusive_lock);
     if (DYAD_IS_ERROR (rc)) {
-        dyad_release_flock (ctx, fd, &exclusive_lock);
+        dyad_release_flock (ctx, lock_fd, &exclusive_lock);
         goto consume_close;
     }
-    file_size = get_file_size (fd);
+    file_size = get_file_size (lock_fd);
     if (ctx->shared_storage) {
-        dyad_release_flock (ctx, fd, &exclusive_lock);
+        dyad_release_flock (ctx, lock_fd, &exclusive_lock);
         if (!ctx->use_fs_locks || file_size <= 0) {
             // as file size was zero that means consumer won the lock first so has to wait for kvs.
             // or we cannot use file lock based synchronization as it does not work with the
@@ -1002,8 +1001,8 @@ dyad_rc_t dyad_consume (dyad_ctx_t* ctx, const char* fname)
         }
     } else {
         if (file_size <= 0) {
-            DYAD_LOG_INFO (ctx, "[node %u rank %u pid %d] File (%s with fd %d) is not fetched yet", \
-                       ctx->node_idx, ctx->rank, ctx->pid, fname, fd);
+            DYAD_LOG_INFO (ctx, "[node %u rank %u pid %d] File (%s with lock_fd %d) is not fetched yet", \
+                       ctx->node_idx, ctx->rank, ctx->pid, fname, lock_fd);
             // Call dyad_fetch to get (and possibly wait on)
             // data from the Flux KVS
             rc = dyad_fetch (ctx, fname, &mdata);
@@ -1011,7 +1010,7 @@ dyad_rc_t dyad_consume (dyad_ctx_t* ctx, const char* fname)
             // and return the corresponding DYAD return code
             if (DYAD_IS_ERROR (rc)) {
                 DYAD_LOG_ERROR (ctx, "dyad_fetch failed!\n");
-                dyad_release_flock (ctx, fd, &exclusive_lock);
+                dyad_release_flock (ctx, lock_fd, &exclusive_lock);
                 goto consume_close;
             }
             // If dyad_fetch was successful, but resp is still NULL,
@@ -1021,7 +1020,7 @@ dyad_rc_t dyad_consume (dyad_ctx_t* ctx, const char* fname)
             if (mdata == NULL) {
                 DYAD_LOG_INFO (ctx, "File '%s' is local!\n", fname);
                 rc = DYAD_RC_OK;
-                dyad_release_flock (ctx, fd, &exclusive_lock);
+                dyad_release_flock (ctx, lock_fd, &exclusive_lock);
                 goto consume_close;
             }
 
@@ -1030,41 +1029,45 @@ dyad_rc_t dyad_consume (dyad_ctx_t* ctx, const char* fname)
             rc = dyad_get_data (ctx, mdata, &file_data, &data_len);
             if (DYAD_IS_ERROR (rc)) {
                 DYAD_LOG_ERROR (ctx, "dyad_get_data failed!\n");
-                dyad_release_flock (ctx, fd, &exclusive_lock);
+                dyad_release_flock (ctx, lock_fd, &exclusive_lock);
                 goto consume_done;
             }
             DYAD_C_FUNCTION_UPDATE_INT ("data_len", data_len);
-
+            io_fd = open (fname, O_WRONLY);
+            DYAD_C_FUNCTION_UPDATE_INT ("io_fd", io_fd);
+            if (io_fd == -1) {
+                DYAD_LOG_ERROR (ctx, "Cannot open file (%s) in write mode for dyad_consume!\n", fname);
+                rc = DYAD_RC_BADFIO;
+                goto consume_close;
+            }
             // Call dyad_pull to fetch the data from the producer's
             // Flux broker
-            rc = dyad_cons_store (ctx, mdata, fd, data_len, file_data);
+            rc = dyad_cons_store (ctx, mdata, io_fd, data_len, file_data);
             // Regardless if there was an error in dyad_pull,
             // free the KVS response object
             if (mdata != NULL) {
                 dyad_free_metadata (&mdata);
             }
+            if (close (io_fd) != 0) {
+                rc = DYAD_RC_BADFIO;
+                dyad_release_flock (ctx, lock_fd, &exclusive_lock);
+                goto consume_done;
+            }
             // If an error occured in dyad_pull, log it
             // and return the corresponding DYAD return code
             if (DYAD_IS_ERROR (rc)) {
                 DYAD_LOG_ERROR (ctx, "dyad_cons_store failed!\n");
-                dyad_release_flock (ctx, fd, &exclusive_lock);
+                dyad_release_flock (ctx, lock_fd, &exclusive_lock);
                 goto consume_done;
             };
-            fsync (fd);
         }
-        dyad_release_flock (ctx, fd, &exclusive_lock);
+        dyad_release_flock (ctx, lock_fd, &exclusive_lock);
     }
-
-
-
     DYAD_C_FUNCTION_UPDATE_INT ("file_size", file_size);
-
-    if (close (fd) != 0) {
-        rc = DYAD_RC_BADFIO;
-        goto consume_done;
-    }
-    rc = DYAD_RC_OK;
 consume_done:;
+    if (close (lock_fd) != 0) {
+        rc = DYAD_RC_BADFIO;
+    }
     if (file_data != NULL) {
         ctx->dtl_handle->return_buffer (ctx, (void**)&file_data);
     }


### PR DESCRIPTION
We have two fd one for locking and one for io which we close so we dont have to do fsync.

Closes #98 