### PR TITLE
reenter logic fix

### DIFF
--- a/src/dyad/common/dyad_logging.h
+++ b/src/dyad/common/dyad_logging.h
@@ -64,13 +64,13 @@ extern "C" {
   #else  // DYAD_UTIL_LOGGER
     #include <flux/core.h>
     #ifdef DYAD_LOGGER_LEVEL_DEBUG
-      #define DYAD_LOG_DEBUG(dyad_ctx, ...) flux_log ((dyad_ctx)->h, LOG_DEBUG, __VA_ARGS__);
+      #define DYAD_LOG_DEBUG(dyad_ctx, ...) flux_log (((dyad_ctx_t*) dyad_ctx)->h, LOG_DEBUG, __VA_ARGS__);
     #else
       #define DYAD_LOG_DEBUG(dyad_ctx, ...) DYAD_NOOP_MACRO
     #endif
 
     #ifdef DYAD_LOGGER_LEVEL_INFO
-      #define DYAD_LOG_INFO(dyad_ctx, ...) flux_log ((dyad_ctx)->h, LOG_INFO, __VA_ARGS__);
+      #define DYAD_LOG_INFO(dyad_ctx, ...) flux_log (((dyad_ctx_t*) dyad_ctx)->h, LOG_INFO, __VA_ARGS__);
     #else
       #define DYAD_LOG_INFO(dyad_ctx, ...) DYAD_NOOP_MACRO
     #endif
@@ -82,7 +82,7 @@ extern "C" {
     #endif
 
     #ifdef DYAD_LOGGER_LEVEL_ERROR
-      #define DYAD_LOG_ERROR(dyad_ctx, ...) flux_log_error ((dyad_ctx)->h, __VA_ARGS__);
+      #define DYAD_LOG_ERROR(dyad_ctx, ...) flux_log_error (((dyad_ctx_t*) dyad_ctx)->h, __VA_ARGS__);
     #else
       #define DYAD_LOG_ERROR(dyad_ctx, ...) DYAD_NOOP_MACRO
     #endif

--- a/src/dyad/core/dyad_core.c
+++ b/src/dyad/core/dyad_core.c
@@ -309,7 +309,7 @@ kvs_read_end:;
 
 
 
-DYAD_CORE_FUNC_MODS dyad_rc_t dyad_fetch_metadata (const dyad_ctx_t* restrict ctx,
+DYAD_CORE_FUNC_MODS dyad_rc_t dyad_fetch_metadata (dyad_ctx_t* restrict ctx,
                                                    const char* restrict fname,
                                                    dyad_metadata_t** restrict mdata)
 {
@@ -329,6 +329,8 @@ DYAD_CORE_FUNC_MODS dyad_rc_t dyad_fetch_metadata (const dyad_ctx_t* restrict ct
         rc = DYAD_RC_OK;
         goto fetch_done;
     }
+    // Set reenter to false to avoid recursively performing DYAD operations
+    ctx->reenter = false;
     DYAD_LOG_INFO (ctx, "Obtained file path relative to consumer directory: %s\n", upath);
     DYAD_C_FUNCTION_UPDATE_STR ("upath", upath);
     // Generate the KVS key from the file path relative to
@@ -686,7 +688,6 @@ dyad_rc_t dyad_init (bool debug,
     DYAD_C_FUNCTION_UPDATE_STR ("cons_managed_path", (*ctx)->cons_managed_path);
     // Initialization is now complete!
     // Set reenter and initialized to indicate this.
-    (*ctx)->reenter = true;
     (*ctx)->initialized = true;
     (*ctx)->use_fs_locks = true; // This is default value except for streams which dont have a fp.
     // TODO Print logging info
@@ -702,6 +703,7 @@ dyad_rc_t dyad_init (bool debug,
     DYAD_LOG_STDERR_REDIRECT (log_file_name);
   #endif // DYAD_LOGGER_NO_LOG
 init_region_finish:;
+    (*ctx)->reenter = true;
     DYAD_C_FUNCTION_END();
     return rc;
 }
@@ -986,9 +988,6 @@ dyad_rc_t dyad_consume (dyad_ctx_t* ctx, const char* fname)
         rc = DYAD_RC_BADMANAGEDPATH;
         goto consume_close;
     }
-    // Set reenter to false to avoid recursively performing
-    // DYAD operations
-    ctx->reenter = false;
     lock_fd = open (fname, O_RDWR | O_CREAT, 0666);
     if (lock_fd == -1) {
         DYAD_LOG_ERROR (ctx, "Cannot create file (%s) for dyad_consume!\n", fname);
@@ -1120,8 +1119,7 @@ dyad_rc_t dyad_consume_w_metadata (dyad_ctx_t* ctx, const char* fname,
         rc = DYAD_RC_BADMANAGEDPATH;
         goto consume_close;
     }
-    // Set reenter to false to avoid recursively performing
-    // DYAD operations
+    // Set reenter to false to avoid recursively performing DYAD operations
     ctx->reenter = false;
     fd = open (fname, O_RDWR | O_CREAT, 0666);
     DYAD_C_FUNCTION_UPDATE_INT ("fd", fd);

--- a/src/dyad/dtl/ucx_dtl.c
+++ b/src/dyad/dtl/ucx_dtl.c
@@ -67,7 +67,7 @@ static void dyad_send_callback (void* req, ucs_status_t status)
 #endif
 {
     DYAD_C_FUNCTION_START();
-    DYAD_LOG_INFO (ctx, "Calling send callback");
+    DYAD_LOG_STDOUT ("Calling send callback");
     dyad_ucx_request_t* real_req = (dyad_ucx_request_t*)req;
     real_req->completed = 1;
     DYAD_C_FUNCTION_END();
@@ -275,7 +275,7 @@ static inline ucs_status_ptr_t ucx_send_no_wait (const dyad_ctx_t* ctx, bool is_
         stat_ptr = (void*)UCS_ERR_NOT_CONNECTED;
         goto ucx_send_no_wait_done;
     }
-    DYAD_LOG_INFO (ctx, "written data buf of length %d", buflen);
+    DYAD_LOG_INFO (ctx, "written data buf of length %lu", buflen);
 #endif
 ucx_send_no_wait_done:;
     DYAD_C_FUNCTION_END();

--- a/src/dyad/modules/dyad.c
+++ b/src/dyad/modules/dyad.c
@@ -340,7 +340,7 @@ static int opt_parse (dyad_ctx_t* ctx, const unsigned broker_rank,
     *dtl_mode = DYAD_DTL_END;
 
     int argc = 0;
-    char* argv[PATH_MAX] = {'\0'};
+    char* argv[PATH_MAX] = {NULL};
 
     if ((argc = _argc + 1) > PATH_MAX) {
         DYAD_LOG_DEBUG (ctx, "DYAD_MOD: too many options.\n");


### PR DESCRIPTION
We do not want DYAD interception in the middle of interception as it is not needed and only adds overhead.
If we block re-entrance into DYAD region to early, a legitimate access to a file under a managed directory can also be not intercepted. If block too late, then we incur needless cost for irrelevant accesses.
The right position to start blocking re-entrance is when we know the file is under a managed directory.

This is a little tricky for python API because dyad_get_metadata is separated from consume call.