### PR TITLE
improve hash distribution with short strings

### DIFF
--- a/src/dyad/core/dyad_core.c
+++ b/src/dyad/core/dyad_core.c
@@ -49,6 +49,7 @@ static int gen_path_key (const char* restrict str,
     size_t cx = 0ul;
     int n = 0;
     size_t str_len = strlen (str);
+    const char* str_long = str;
 
     if (str == NULL || path_key == NULL || len == 0ul || str_len == 0ul) {
         DYAD_C_FUNCTION_END();
@@ -56,26 +57,15 @@ static int gen_path_key (const char* restrict str,
     }
     path_key[0] = '\0';
 
-    const char* str_long = str;
-
-#if 1
-    // Strings shorter than 128 bytes collide. Especially, the hash value seems
-    // to depend on the length of such a string.
-    // For such a short string, we concatenate it as many times as needed to make
-    // it longer than 128 bytes.
+    // Just append the string so that it can be as large as 128 bytes.
     if (str_len < 128ul) {
-        char buf[PATH_MAX+1] = {'\0'};
+        char buf[256] = {'\0'};
         memcpy (buf, str, str_len);
-        char* str_pos = buf + str_len;
-        const char* const str_min = buf + 128ul;
-        while (str_pos < str_min) {
-            memcpy (str_pos, str, str_len);
-            str_pos += str_len;
-        };
-        str_len = str_pos - buf;
+        memset (buf + str_len, '@', 128ul - str_len);
+        buf[128u] = '\0';
+        str_len = 128ul;
         str_long = buf;
     }
-#endif
 
     for (uint32_t d = 0u; d < depth; d++) {
         seed += seeds[d % 10];

--- a/src/dyad/utils/CMakeLists.txt
+++ b/src/dyad/utils/CMakeLists.txt
@@ -39,6 +39,11 @@ add_executable(test_cmp_canonical_path_prefix test_cmp_canonical_path_prefix.c
                ${CMAKE_CURRENT_SOURCE_DIR}/../common/dyad_structures.h)
 target_compile_definitions(test_cmp_canonical_path_prefix PUBLIC DYAD_HAS_CONFIG)
 target_link_libraries(test_cmp_canonical_path_prefix PUBLIC ${PROJECT_NAME}_utils)
+
+add_executable(test_murmur3 test_murmur3.c)
+target_compile_definitions(test_murmur3 PUBLIC DYAD_HAS_CONFIG)
+target_link_libraries(test_murmur3 PUBLIC ${PROJECT_NAME}_murmur3)
+
 if(DYAD_LOGGER STREQUAL "CPP_LOGGER")
     target_link_libraries(test_cmp_canonical_path_prefix PRIVATE ${CPP_LOGGER_LIBRARIES})
 endif()
@@ -49,6 +54,9 @@ endif()
 
 if (TARGET DYAD_C_FLAGS_werror)
   target_link_libraries(${PROJECT_NAME}_utils PRIVATE DYAD_C_FLAGS_werror)
+  target_link_libraries(${PROJECT_NAME}_murmur3 PRIVATE DYAD_C_FLAGS_werror)
+  target_link_libraries(test_murmur3 PRIVATE DYAD_C_FLAGS_werror)
+  target_link_libraries(test_cmp_canonical_path_prefix PRIVATE DYAD_C_FLAGS_werror)
 endif ()
 
 install(

--- a/src/dyad/utils/test_murmur3.c
+++ b/src/dyad/utils/test_murmur3.c
@@ -18,29 +18,21 @@ static int gen_path_key (const char* restrict str,
     size_t cx = 0ul;
     int n = 0;
     size_t str_len = strlen (str);
+    const char* str_long = str;
 
     if (str == NULL || path_key == NULL || len == 0ul || str_len == 0ul) {
         return -1;
     }
     path_key[0] = '\0';
 
-    const char* str_long = str;
-
 #if 1
-    // Strings shorter than 128 bytes collide. Especially, the hash value seems
-    // to depend on the length of such a string.
-    // For such a short string, we concatenate it as many times as needed to make
-    // it longer than 128 bytes.
+    // Just append the string so that it can be as large as 128 bytes.
     if (str_len < 128ul) {
-        char buf[PATH_MAX+1] = {'\0'};
+        char buf[256] = {'\0'};
         memcpy (buf, str, str_len);
-        char* str_pos = buf + str_len;
-        const char* const str_min = buf + 128ul;
-        while (str_pos < str_min) {
-            memcpy (str_pos, str, str_len);
-            str_pos += str_len;
-        };
-        str_len = str_pos - buf;
+        memset (buf + str_len, '@', 128ul - str_len);
+        buf[128u] = '\0';
+        str_len = 128ul;
         str_long = buf;
     }
 #endif

--- a/src/dyad/utils/test_murmur3.c
+++ b/src/dyad/utils/test_murmur3.c
@@ -1,0 +1,84 @@
+#include "dyad/utils/murmur3.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <limits.h>
+
+static int gen_path_key (const char* restrict str,
+                         char* restrict path_key,
+                         const size_t len,
+                         const uint32_t depth,
+                         const uint32_t width)
+{
+    static const uint32_t seeds[10] =
+        {104677u, 104681u, 104683u, 104693u, 104701u, 104707u, 104711u, 104717u, 104723u, 104729u};
+
+    uint32_t seed = 57u;
+    uint32_t hash[4] = {0u};  // Output for the hash
+    size_t cx = 0ul;
+    int n = 0;
+    size_t str_len = strlen (str);
+
+    if (str == NULL || path_key == NULL || len == 0ul || str_len == 0ul) {
+        return -1;
+    }
+    path_key[0] = '\0';
+
+    const char* str_long = str;
+
+#if 1
+    // Strings shorter than 128 bytes collide. Especially, the hash value seems
+    // to depend on the length of such a string.
+    // For such a short string, we concatenate it as many times as needed to make
+    // it longer than 128 bytes.
+    if (str_len < 128ul) {
+        char buf[PATH_MAX+1] = {'\0'};
+        memcpy (buf, str, str_len);
+        char* str_pos = buf + str_len;
+        const char* const str_min = buf + 128ul;
+        while (str_pos < str_min) {
+            memcpy (str_pos, str, str_len);
+            str_pos += str_len;
+        };
+        str_len = str_pos - buf;
+        str_long = buf;
+    }
+#endif
+
+    for (uint32_t d = 0u; d < depth; d++) {
+        seed += seeds[d % 10];
+        MurmurHash3_x64_128 (str_long, str_len, seed, hash);
+        uint32_t bin = (hash[0] ^ hash[1] ^ hash[2] ^ hash[3]) % width;
+        n = snprintf (path_key + cx, len - cx, "%x.", bin);
+        //n = snprintf (path_key + cx, len - cx, "%x%x%x%x.", hash[0], hash[1], hash[2], hash[3]);
+        cx += n;
+        if (cx >= len || n < 0) {
+            return -1;
+        }
+    }
+    n = snprintf (path_key + cx, len - cx, "%s", str);
+    if (cx + n >= len || n < 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+
+int main (int argc, char** argv)
+{
+    if (argc < 4) {
+        printf ("Usage: %s depth width str1 [str2 [str3 ...]]\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    int depth = atoi (argv[1]);
+    int width = atoi (argv[2]);
+    for (int i = 3; i < argc; i++) {
+        char path_key [PATH_MAX + 1] = {'\0'};
+        gen_path_key (argv[i], path_key, PATH_MAX, depth, width);
+        printf("%s\t%s\n", argv[i], path_key);
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Strings shorter than 128 bytes collide possible due to the implementation details of `MurmurHash3_x64_128()`. Especially, the hash value seems to depend on the length of such a string.
For such a short string, we concatenate it as many times as needed to make it longer than 128 bytes.
Added a test to show hash results.

For example, before this fix,  `test_murmur3 3 1024 data1.txt data2.txt data3.txt 123456.txt 1data5.txt data91.txt` showed the following results
```
data1.txt	199.ca.3e.data1.txt
data2.txt	199.ca.3e.data2.txt
data3.txt	199.ca.3e.data3.txt
123456.txt	37e.c8.89.123456.txt
1data5.txt	37e.c8.89.1data5.txt
data91.txt	37e.c8.89.data91.txt
```
After the fix, the below is the new results.
```
data1.txt	2cd.1cd.3cc.data1.txt
data2.txt	11f.2cb.5a.data2.txt
data3.txt	22b.28f.11d.data3.txt
123456.txt	db.272.14.123456.txt
1data5.txt	8a.1ce.f8.1data5.txt
data91.txt	219.32f.47.data91.txt
```