### PR TITLE
Allow lib64 as the dyad library installation path in test scripts

### DIFF
--- a/.github/prod-cons/dyad_consumer.sh
+++ b/.github/prod-cons/dyad_consumer.sh
@@ -6,8 +6,17 @@ source ${this_script_dir}/prod_cons_argparse.sh
 
 mkdir -m 775 -p ${DYAD_PATH_CONSUMER}
 
+if [ -d ${DYAD_INSTALL_PREFIX}/lib64 ] ; then
+    DYAD_INSTALL_LIBDIR=${DYAD_INSTALL_PREFIX}/lib64
+elif [ -d ${DYAD_INSTALL_PREFIX}/lib ] ; then
+    DYAD_INSTALL_LIBDIR=${DYAD_INSTALL_PREFIX}/lib
+else
+    echo "Cannot find DYAD LIB DIR"
+    exit 1
+fi
+
 if [[ "$mode" == "${valid_modes[0]}" ]]; then
-    LD_PRELOAD=${DYAD_INSTALL_PREFIX}/lib/libdyad_wrapper.so ${GITHUB_WORKSPACE}/docs/demos/ecp_feb_2023/c_cons 10 ${DYAD_PATH_CONSUMER}
+    LD_PRELOAD=${DYAD_INSTALL_LIBDIR}/libdyad_wrapper.so ${GITHUB_WORKSPACE}/docs/demos/ecp_feb_2023/c_cons 10 ${DYAD_PATH_CONSUMER}
 elif [[ "$mode" == "${valid_modes[1]}" ]]; then
     ${GITHUB_WORKSPACE}/docs/demos/ecp_feb_2023/cpp_cons 10 ${DYAD_PATH_CONSUMER}
 elif [[ "$mode" == "${valid_modes[2]}" ]]; then

--- a/.github/prod-cons/dyad_producer.sh
+++ b/.github/prod-cons/dyad_producer.sh
@@ -7,18 +7,27 @@ source $this_script_dir/prod_cons_argparse.sh
 mkdir -m 775 -p ${DYAD_PATH_PRODUCER}
 echo "Loading DYAD module"
 
-echo flux module load ${DYAD_INSTALL_PREFIX}/lib/dyad.so --mode="${DYAD_DTL_MODE}" ${DYAD_PATH_PRODUCER}
-flux module load ${DYAD_INSTALL_PREFIX}/lib/dyad.so --mode="${DYAD_DTL_MODE}" ${DYAD_PATH_PRODUCER}
+if [ -d ${DYAD_INSTALL_PREFIX}/lib64 ] ; then
+    DYAD_INSTALL_LIBDIR=${DYAD_INSTALL_PREFIX}/lib64
+elif [ -d ${DYAD_INSTALL_PREFIX}/lib ] ; then
+    DYAD_INSTALL_LIBDIR=${DYAD_INSTALL_PREFIX}/lib
+else
+    echo "Cannot find DYAD LIB DIR"
+    exit 1
+fi
+
+echo flux module load ${DYAD_INSTALL_LIBDIR}/dyad.so --mode="${DYAD_DTL_MODE}" ${DYAD_PATH_PRODUCER}
+flux module load ${DYAD_INSTALL_LIBDIR}/dyad.so --mode="${DYAD_DTL_MODE}" ${DYAD_PATH_PRODUCER}
 
 if [[ "$mode" == "${valid_modes[0]}" ]]; then
-    echo ${GITHUB_WORKSPACE}/docs/demos/ecp_feb_2023/c_prod 10 $DYAD_PATH_PRODUCER
-    LD_PRELOAD=${DYAD_INSTALL_PREFIX}/lib/libdyad_wrapper.so ${GITHUB_WORKSPACE}/docs/demos/ecp_feb_2023/c_prod 10 $DYAD_PATH_PRODUCER
+    echo ${GITHUB_WORKSPACE}/docs/demos/ecp_feb_2023/c_prod 10 ${DYAD_PATH_PRODUCER}
+    LD_PRELOAD=${DYAD_INSTALL_LIBDIR}/libdyad_wrapper.so ${GITHUB_WORKSPACE}/docs/demos/ecp_feb_2023/c_prod 10 ${DYAD_PATH_PRODUCER}
 elif [[ "$mode" == "${valid_modes[1]}" ]]; then
-    echo ${GITHUB_WORKSPACE}/docs/demos/ecp_feb_2023/cpp_prod 10 $DYAD_PATH_PRODUCER
-    ${GITHUB_WORKSPACE}/docs/demos/ecp_feb_2023/cpp_prod 10 $DYAD_PATH_PRODUCER
+    echo ${GITHUB_WORKSPACE}/docs/demos/ecp_feb_2023/cpp_prod 10 ${DYAD_PATH_PRODUCER}
+    ${GITHUB_WORKSPACE}/docs/demos/ecp_feb_2023/cpp_prod 10 ${DYAD_PATH_PRODUCER}
 elif [[ "$mode" == "${valid_modes[2]}" ]]; then
-    echo python3 ${GITHUB_WORKSPACE}/tests/pydyad_spsc/producer.py $DYAD_PATH_PRODUCER 10 50
-    python3 ${GITHUB_WORKSPACE}/tests/pydyad_spsc/producer.py $DYAD_PATH_PRODUCER 10 50
+    echo python3 ${GITHUB_WORKSPACE}/tests/pydyad_spsc/producer.py ${DYAD_PATH_PRODUCER} 10 50
+    python3 ${GITHUB_WORKSPACE}/tests/pydyad_spsc/producer.py ${DYAD_PATH_PRODUCER} 10 50
 else
     echo "Invalid prod test mode: $mode"
     exit 1

--- a/.github/prod-cons/prod_cons_argparse.sh
+++ b/.github/prod-cons/prod_cons_argparse.sh
@@ -18,7 +18,7 @@ for vm in "${valid_modes[@]}"; do
         mode_is_valid=0
     fi
 done
-echo "Need valid_modes: $mode_is_valid"
+echo "mode_is_valid: $mode_is_valid"
 
 if [[ $mode_is_valid -eq 0 ]]; then
     echo "Invalid arg mode: $mode"

--- a/docs/demos/ecp_feb_2023/Makefile
+++ b/docs/demos/ecp_feb_2023/Makefile
@@ -1,4 +1,4 @@
-DYAD_LIB_PATH = $(DYAD_INSTALL_PREFIX)/lib
+DYAD_INSTALL_LIBDIR = $(shell if [ -d $${DYAD_INSTALL_PREFIX}/lib64 ] ; then echo $${DYAD_INSTALL_PREFIX}/lib64; elif [ -d $${DYAD_INSTALL_PREFIX}/lib ] ; then echo $${DYAD_INSTALL_PREFIX}/lib; fi)
 DYAD_INCLUDE_PATH = $(DYAD_INSTALL_PREFIX)/include
 #UCX_PATH = /p/gpfs1/ice4hpc/install
 #UCXLIBS = -L$(UCX_PATH)/lib -Wl,-rpath=$(UCX_PATH)/lib -lucs -lucp
@@ -6,7 +6,7 @@ DYAD_INCLUDE_PATH = $(DYAD_INSTALL_PREFIX)/include
 CFLAGS_LOC = -g -std=c11 -DDYAD_HAS_CONFIG=1 $(CFLAGS)
 CPPFLAGS_LOC = -g -O3 -I. $(CPPFLAGS)
 CXXFLAGS_LOC = -g -std=c++11 -DDYAD_HAS_CONFIG=1 -I$(DYAD_INCLUDE_PATH) $(CXXFLAGS)
-CXXLIBS_LOC = -L$(DYAD_LIB_PATH) -Wl,-rpath=$(DYAD_LIB_PATH) -ldyad_fstream $(CXXLIBS) $(UCXLIBS)
+CXXLIBS_LOC = -L$(DYAD_INSTALL_LIBDIR) -Wl,-rpath=$(DYAD_INSTALL_LIBDIR) -ldyad_fstream $(CXXLIBS) $(UCXLIBS)
 
 all: c_prod c_cons cpp_prod cpp_cons
 


### PR DESCRIPTION
Currently, dyad library path is hard-coded as 'lib' in test scripts.
Allow 'lib64' as the dyad library installation path.
