### PR TITLE
Fixes for large file

### DIFF
--- a/src/dyad/client/dyad_client.c
+++ b/src/dyad/client/dyad_client.c
@@ -618,6 +618,7 @@ dyad_rc_t dyad_get_metadata (dyad_ctx_t *restrict ctx,
 
     if (fname_len == 0ul) {
         rc = DYAD_RC_BADFIO;
+        DYAD_LOG_ERROR (ctx, "Filename length is zero");
         goto get_metadata_done;
     }
     if (ctx->relative_to_managed_path

--- a/src/dyad/client/dyad_client.c
+++ b/src/dyad/client/dyad_client.c
@@ -516,20 +516,30 @@ DYAD_CORE_FUNC_MODS dyad_rc_t dyad_cons_store (const dyad_ctx_t *restrict ctx,
     } else {
         ssize_t written_data = 0;
         ssize_t granularity = DYAD_POSIX_TRANSFER_GRANULARITY;
-        DYAD_LOG_DEBUG (ctx, " writing file %s with bytes %zd is big. Writing in granularity %zd", file_path, data_len, granularity);
-        while(written_data < data_len) {
-            ssize_t written_size = (data_len - written_data) > granularity ? granularity : (data_len - written_data);
+        DYAD_LOG_DEBUG (ctx,
+                        " writing file %s with bytes %zd is big. Writing in granularity %zd",
+                        file_path,
+                        data_len,
+                        granularity);
+        while (written_data < data_len) {
+            ssize_t written_size =
+                (data_len - written_data) > granularity ? granularity : (data_len - written_data);
             written_len = write (fd, file_data + written_data, written_size);
-            DYAD_LOG_DEBUG (ctx, " writing file %s with bytes %zd of %zd", file_path, written_size, written_len);
+            DYAD_LOG_DEBUG (ctx,
+                            " writing file %s with bytes %zd of %zd",
+                            file_path,
+                            written_size,
+                            written_len);
             if (written_len <= 0) {
                 DYAD_LOG_ERROR (ctx,
-                    "Failed to write file \"%s\" only read %zd of %zd of %zd. with code %d:%s.",
-                    file_path,
-                    written_len,
-                    written_size, 
-                    data_len, 
-                    errno, 
-                    strerror(errno));
+                                "Failed to write file \"%s\" only read %zd of %zd of %zd. with "
+                                "code %d:%s.",
+                                file_path,
+                                written_len,
+                                written_size,
+                                data_len,
+                                errno,
+                                strerror (errno));
                 goto pull_done;
             }
             written_data += written_len;

--- a/src/dyad/client/dyad_client.c
+++ b/src/dyad/client/dyad_client.c
@@ -616,8 +616,6 @@ dyad_rc_t dyad_get_metadata (dyad_ctx_t *restrict ctx,
     const size_t fname_len = strlen (fname);
     char upath[PATH_MAX + 1] = {'\0'};
 
-    // DYAD_LOG_INFO (ctx, "Obtaining file path relative to consumer directory: %s", upath);
-
     if (fname_len == 0ul) {
         rc = DYAD_RC_BADFIO;
         goto get_metadata_done;
@@ -639,6 +637,7 @@ dyad_rc_t dyad_get_metadata (dyad_ctx_t *restrict ctx,
         rc = DYAD_RC_UNTRACKED;
         goto get_metadata_done;
     }
+    DYAD_LOG_INFO (ctx, "Obtaining file path relative to consumer directory: %s", upath);
     ctx->reenter = false;
     DYAD_C_FUNCTION_UPDATE_STR ("upath", upath);
 

--- a/src/dyad/common/dyad_structures_int.h
+++ b/src/dyad/common/dyad_structures_int.h
@@ -61,7 +61,7 @@ struct dyad_ctx {
 };
 typedef void *ucx_ep_cache_h;
 
-#define DYAD_POSIX_TRANSFER_GRANULARITY 1024L*1024L*1024L
+#define DYAD_POSIX_TRANSFER_GRANULARITY 1024L * 1024L * 1024L
 
 #ifdef __cplusplus
 }

--- a/src/dyad/common/dyad_structures_int.h
+++ b/src/dyad/common/dyad_structures_int.h
@@ -61,6 +61,8 @@ struct dyad_ctx {
 };
 typedef void *ucx_ep_cache_h;
 
+#define DYAD_POSIX_TRANSFER_GRANULARITY 1024L*1024L*1024L
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/dyad/dtl/ucx_dtl.c
+++ b/src/dyad/dtl/ucx_dtl.c
@@ -418,7 +418,8 @@ static inline ucs_status_ptr_t ucx_recv_no_wait (const dyad_ctx_t* ctx,
         memcpy (&temp, dtl_handle->net_buf, sizeof (temp));
         ucp_worker_progress (ctx->dtl_handle->private_dtl.ucx_dtl_handle->ucx_worker);
         nanosleep ((const struct timespec[]){{0, 10000L}}, NULL);
-        if (is_first == 1) DYAD_LOG_DEBUG (ctx, "Consumer Waiting for worker to finsih all work");
+        if (is_first == 1)
+            DYAD_LOG_DEBUG (ctx, "Consumer Waiting for worker to finsih all work");
         is_first = 0;
     } while (temp == 0l);
 #endif  // DYAD_ENABLE_UCX_RMA

--- a/src/dyad/dtl/ucx_dtl.c
+++ b/src/dyad/dtl/ucx_dtl.c
@@ -20,7 +20,7 @@
 
 extern const base64_maps_t base64_maps_rfc4648;
 
-#define UCX_MAX_TRANSFER_SIZE (1024 * 1024 * 1024)
+#define UCX_MAX_TRANSFER_SIZE (4 * 1024L * 1024L * 1024L)
 
 // Tag mask for UCX Tag send/recv
 #define DYAD_UCX_TAG_MASK UINT64_MAX
@@ -413,11 +413,13 @@ static inline ucs_status_ptr_t ucx_recv_no_wait (const dyad_ctx_t* ctx,
 #else   // DYAD_ENABLE_UCX_RMA
     dyad_dtl_ucx_t* dtl_handle = ctx->dtl_handle->private_dtl.ucx_dtl_handle;
     ssize_t temp = 0l;
+    int is_first = 1;
     do {
         memcpy (&temp, dtl_handle->net_buf, sizeof (temp));
         ucp_worker_progress (ctx->dtl_handle->private_dtl.ucx_dtl_handle->ucx_worker);
         nanosleep ((const struct timespec[]){{0, 10000L}}, NULL);
-        DYAD_LOG_DEBUG (ctx, "Consumer Waiting for worker to finsih all work");
+        if (is_first == 1) DYAD_LOG_DEBUG (ctx, "Consumer Waiting for worker to finsih all work");
+        is_first = 0;
     } while (temp == 0l);
 #endif  // DYAD_ENABLE_UCX_RMA
     DYAD_LOG_DEBUG (ctx, "Consumer finsihed all work");

--- a/src/dyad/dtl/ucx_ep_cache.cpp
+++ b/src/dyad/dtl/ucx_ep_cache.cpp
@@ -24,9 +24,8 @@
 using key_type = uint64_t;
 using cache_type = std::unordered_map<key_type, ucp_ep_h>;
 
-static void __attribute__ ((unused)) dyad_ucx_ep_err_handler (void *arg,
-                                                              ucp_ep_h ep,
-                                                              ucs_status_t status)
+static void __attribute__ ((unused))
+dyad_ucx_ep_err_handler (void *arg, ucp_ep_h ep, ucs_status_t status)
 {
     DYAD_C_FUNCTION_START ();
     dyad_ctx_t __attribute__ ((unused)) *ctx = (dyad_ctx_t *)arg;

--- a/src/dyad/dtl/ucx_ep_cache.cpp
+++ b/src/dyad/dtl/ucx_ep_cache.cpp
@@ -24,8 +24,9 @@
 using key_type = uint64_t;
 using cache_type = std::unordered_map<key_type, ucp_ep_h>;
 
-static void __attribute__ ((unused))
-dyad_ucx_ep_err_handler (void *arg, ucp_ep_h ep, ucs_status_t status)
+static void __attribute__ ((unused)) dyad_ucx_ep_err_handler (void *arg,
+                                                              ucp_ep_h ep,
+                                                              ucs_status_t status)
 {
     DYAD_C_FUNCTION_START ();
     dyad_ctx_t __attribute__ ((unused)) *ctx = (dyad_ctx_t *)arg;

--- a/src/dyad/modules/dyad.c
+++ b/src/dyad/modules/dyad.c
@@ -211,19 +211,25 @@ dyad_fetch_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_t *msg, 
         } else {
             ssize_t read_data = 0;
             int granularity = DYAD_POSIX_TRANSFER_GRANULARITY;
-            while(read_data < file_size) {
-                ssize_t read_size = (file_size - read_data) > granularity ? granularity : (file_size - read_data);
+            while (read_data < file_size) {
+                ssize_t read_size =
+                    (file_size - read_data) > granularity ? granularity : (file_size - read_data);
                 inlen = read (fd, inbuf + sizeof (file_size) + read_data, read_size);
-                DYAD_LOG_DEBUG (mod_ctx->ctx, "DYAD_MOD: reading file %s with bytes %zd of %zd", fullpath, read_size, inlen);
+                DYAD_LOG_DEBUG (mod_ctx->ctx,
+                                "DYAD_MOD: reading file %s with bytes %zd of %zd",
+                                fullpath,
+                                read_size,
+                                inlen);
                 if (inlen <= 0) {
                     DYAD_LOG_ERROR (mod_ctx->ctx,
-                        "DYAD_MOD: Failed to load file \"%s\" only read %zd of %zd of %zd. with code %d:%s.",
-                        fullpath,
-                        inlen,
-                        read_size, 
-                        file_size, 
-                        errno, 
-                        strerror(errno));
+                                    "DYAD_MOD: Failed to load file \"%s\" only read %zd of %zd of "
+                                    "%zd. with code %d:%s.",
+                                    fullpath,
+                                    inlen,
+                                    read_size,
+                                    file_size,
+                                    errno,
+                                    strerror (errno));
                     goto fetch_error;
                 }
                 read_data += inlen;
@@ -236,29 +242,36 @@ dyad_fetch_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_t *msg, 
         } else {
             ssize_t read_data = 0;
             ssize_t granularity = DYAD_POSIX_TRANSFER_GRANULARITY;
-            while(read_data < file_size) {
-                ssize_t read_size = (file_size - read_data) > granularity ? granularity : (file_size - read_data);
+            while (read_data < file_size) {
+                ssize_t read_size =
+                    (file_size - read_data) > granularity ? granularity : (file_size - read_data);
                 inlen = read (fd, inbuf + read_data, read_size);
                 if (inlen < 0) {
                     DYAD_LOG_ERROR (mod_ctx->ctx,
-                        "DYAD_MOD: Failed to load file \"%s\" only read %zd of %zd. with code %d:%s.",
-                        fullpath,
-                        inlen,
-                        file_size, errno, strerror(errno));
+                                    "DYAD_MOD: Failed to load file \"%s\" only read %zd of %zd. "
+                                    "with code %d:%s.",
+                                    fullpath,
+                                    inlen,
+                                    file_size,
+                                    errno,
+                                    strerror (errno));
                     goto fetch_error;
                 }
                 read_data += inlen;
             }
             inlen = read_data;
         }
-        
+
 #endif
         if (inlen != file_size) {
             DYAD_LOG_ERROR (mod_ctx->ctx,
-                            "DYAD_MOD: Failed to load file \"%s\" only read %zd of %zd. with code %d:%s.",
+                            "DYAD_MOD: Failed to load file \"%s\" only read %zd of %zd. with code "
+                            "%d:%s.",
                             fullpath,
                             inlen,
-                            file_size, errno, strerror(errno));
+                            file_size,
+                            errno,
+                            strerror (errno));
             goto fetch_error;
         }
 #ifdef DYAD_ENABLE_UCX_RMA

--- a/src/dyad/modules/dyad.c
+++ b/src/dyad/modules/dyad.c
@@ -206,16 +206,59 @@ dyad_fetch_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_t *msg, 
 #endif
     if (file_size > 0l) {
 #ifdef DYAD_ENABLE_UCX_RMA
-        inlen = read (fd, inbuf + sizeof (file_size), file_size);
+        if (file_size < DYAD_POSIX_TRANSFER_GRANULARITY) {
+            inlen = read (fd, inbuf + sizeof (file_size), file_size);
+        } else {
+            ssize_t read_data = 0;
+            int granularity = DYAD_POSIX_TRANSFER_GRANULARITY;
+            while(read_data < file_size) {
+                ssize_t read_size = (file_size - read_data) > granularity ? granularity : (file_size - read_data);
+                inlen = read (fd, inbuf + sizeof (file_size) + read_data, read_size);
+                DYAD_LOG_DEBUG (mod_ctx->ctx, "DYAD_MOD: reading file %s with bytes %zd of %zd", fullpath, read_size, inlen);
+                if (inlen <= 0) {
+                    DYAD_LOG_ERROR (mod_ctx->ctx,
+                        "DYAD_MOD: Failed to load file \"%s\" only read %zd of %zd of %zd. with code %d:%s.",
+                        fullpath,
+                        inlen,
+                        read_size, 
+                        file_size, 
+                        errno, 
+                        strerror(errno));
+                    goto fetch_error;
+                }
+                read_data += inlen;
+            }
+            inlen = read_data;
+        }
 #else
-        inlen = read (fd, inbuf, file_size);
+        if (file_size < DYAD_POSIX_TRANSFER_GRANULARITY) {
+            inlen = read (fd, inbuf, file_size);
+        } else {
+            ssize_t read_data = 0;
+            ssize_t granularity = DYAD_POSIX_TRANSFER_GRANULARITY;
+            while(read_data < file_size) {
+                ssize_t read_size = (file_size - read_data) > granularity ? granularity : (file_size - read_data);
+                inlen = read (fd, inbuf + read_data, read_size);
+                if (inlen < 0) {
+                    DYAD_LOG_ERROR (mod_ctx->ctx,
+                        "DYAD_MOD: Failed to load file \"%s\" only read %zd of %zd. with code %d:%s.",
+                        fullpath,
+                        inlen,
+                        file_size, errno, strerror(errno));
+                    goto fetch_error;
+                }
+                read_data += inlen;
+            }
+            inlen = read_data;
+        }
+        
 #endif
         if (inlen != file_size) {
             DYAD_LOG_ERROR (mod_ctx->ctx,
-                            "DYAD_MOD: Failed to load file \"%s\" only read %zd of %zd.",
+                            "DYAD_MOD: Failed to load file \"%s\" only read %zd of %zd. with code %d:%s.",
                             fullpath,
                             inlen,
-                            file_size);
+                            file_size, errno, strerror(errno));
             goto fetch_error;
         }
 #ifdef DYAD_ENABLE_UCX_RMA

--- a/src/dyad/utils/utils.c
+++ b/src/dyad/utils/utils.c
@@ -580,12 +580,12 @@ dyad_rc_t dyad_release_flock (const dyad_ctx_t* __restrict__ ctx,
     DYAD_C_FUNCTION_START ();
     DYAD_C_FUNCTION_UPDATE_INT ("fd", fd);
     dyad_rc_t rc = DYAD_RC_OK;
-    DYAD_LOG_INFO (ctx,
-                   "[node %u rank %u pid %d] Releases a lock on fd %d\n",
-                   ctx->node_idx,
-                   ctx->rank,
-                   ctx->pid,
-                   fd);
+    // DYAD_LOG_INFO (ctx,
+    //                "[node %u rank %u pid %d] Releases a lock on fd %d\n",
+    //                ctx->node_idx,
+    //                ctx->rank,
+    //                ctx->pid,
+    //                fd);
     if (!lock) {
         rc = DYAD_RC_BADFIO;
         goto release_flock_end;
@@ -596,12 +596,12 @@ dyad_rc_t dyad_release_flock (const dyad_ctx_t* __restrict__ ctx,
         rc = DYAD_RC_BADFIO;
         goto release_flock_end;
     }
-    DYAD_LOG_INFO (ctx,
-                   "[node %u rank %u pid %d] lock lifted from fd %d\n",
-                   ctx->node_idx,
-                   ctx->rank,
-                   ctx->pid,
-                   fd);
+    // DYAD_LOG_INFO (ctx,
+    //                "[node %u rank %u pid %d] lock lifted from fd %d\n",
+    //                ctx->node_idx,
+    //                ctx->rank,
+    //                ctx->pid,
+    //                fd);
     rc = DYAD_RC_OK;
 release_flock_end:;
     DYAD_C_FUNCTION_END ();


### PR DESCRIPTION
Hyojin's app uses large files which needs to use granularity to make sure POSIX does not fail.

Also reducing some prints which are excessive.