### PR TITLE
bug fix: fix out-of-scope access and pydyad test with PYTHONPATH

### DIFF
--- a/.github/workflows/compile_test.yaml
+++ b/.github/workflows/compile_test.yaml
@@ -300,6 +300,7 @@ jobs:
           spack load flux-core
           export PATH=${PATH}:${DYAD_INSTALL_PREFIX}/bin:${DYAD_INSTALL_PREFIX}/sbin
           export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${DYAD_INSTALL_PREFIX}/lib
+          export PYTHONPATH=${GITHUB_WORKSPACE}/pydyad:${PYTHONPATH}
           echo "Starting flux brokers"
           flux start --test-size=2 /bin/bash ${GITHUB_WORKSPACE}/.github/prod-cons/dyad_prod_cons_test.sh "python"
       #- name: Test DYAD with DLIO benchmark

--- a/src/dyad/client/dyad_client.c
+++ b/src/dyad/client/dyad_client.c
@@ -41,24 +41,25 @@ DYAD_DLL_EXPORTED int gen_path_key (const char *restrict str,
 
     uint32_t seed = 57u;
     uint32_t hash[4] = {0u};  // Output for the hash
+    char buf[256] = {'\0'};
     size_t cx = 0ul;
     int n = 0;
+    const char *str_long = str;
+    size_t str_len = strlen (str);
+
     if (str == NULL || path_key == NULL || len == 0ul) {
         DYAD_C_FUNCTION_END ();
         return -1;
     }
-    size_t str_len = strlen (str);
     if (str_len == 0ul) {
         DYAD_C_FUNCTION_END ();
         return -1;
     }
-    const char *str_long = str;
 
     path_key[0] = '\0';
 
     // Just append the string so that it can be as large as 128 bytes.
     if (str_len < 128ul) {
-        char buf[256] = {'\0'};
         memcpy (buf, str, str_len);
         memset (buf + str_len, '@', 128ul - str_len);
         buf[128u] = '\0';

--- a/src/dyad/utils/test_murmur3.c
+++ b/src/dyad/utils/test_murmur3.c
@@ -16,6 +16,7 @@ static int gen_path_key (const char* restrict str,
 
     uint32_t seed = 57u;
     uint32_t hash[4] = {0u};  // Output for the hash
+    char buf[256] = {'\0'};
     size_t cx = 0ul;
     int n = 0;
     size_t str_len = strlen (str);
@@ -29,7 +30,6 @@ static int gen_path_key (const char* restrict str,
 #if 1
     // Just append the string so that it can be as large as 128 bytes.
     if (str_len < 128ul) {
-        char buf[256] = {'\0'};
         memcpy (buf, str, str_len);
         memset (buf + str_len, '@', 128ul - str_len);
         buf[128u] = '\0';


### PR DESCRIPTION
Two bugs fixed.
1) pydyad test fails because it cannot load pydyad module. Fixed it by adding pydyad path to PYTHONPATH
2) out-of-scope access. buf[] is defined within a scope and its pointer is assigned to a variable accessed out of the scope. Fixed it by moving the variable to the upper scope.