### PR TITLE
Documentation on DYAD_MARGO_PROTO examples, added dftracer's silent d…

### DIFF
--- a/docs/demos/SCA26/batch/workflow.sh
+++ b/docs/demos/SCA26/batch/workflow.sh
@@ -46,18 +46,18 @@ flux exec -r all flux module load ${DYAD_INSTALL_LIBDIR}/dyad.so #--mode="${DYAD
 for i_task in `seq 1 $n_tasks`
 do
     echo "Submitting Consumer job"
-    flux submit --nodes 1 --exclusive -t 10 \
-                --env=DYAD_KVS_NAMESPACE=${DYAD_KVS_NAMESPACE} \
-                --env=DYAD_DTL_MODE=${DYAD_DTL_MODE} \
+    flux submit --nodes 1 --exclusive -t 1 \
                 --env=DYAD_INSTALL_LIBDIR=${DYAD_INSTALL_LIBDIR} \
+                --output=out-cons-${i_task}.txt \
+                --error=err-cons-${i_task}.txt \
                 ${script_dir}/task_cons.sh ${i_task} ${mode}
     CONS_IDs="${CONS_IDs} $(flux job last)"
 
     echo "Submitting Producer job"
-    flux submit --nodes 1 --exclusive -t 10 \
-                --env=DYAD_KVS_NAMESPACE=${DYAD_KVS_NAMESPACE} \
-                --env=DYAD_DTL_MODE=${DYAD_DTL_MODE} \
+    flux submit --nodes 1 --exclusive -t 1 \
                 --env=DYAD_INSTALL_LIBDIR=${DYAD_INSTALL_LIBDIR} \
+                --output=out-prod-${i_task}.txt \
+                --error=err-prod-${i_task}.txt \
                 ${script_dir}/task_prod.sh ${i_task} ${mode}
     PROD_IDs="${PROD_IDs} $(flux job last)"
 done

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -157,9 +157,19 @@ There are several custom CMake options available to configure a DYAD build:
 
 .. note::
 
-   **mochi-margo** enables seamless adoption of various DTL types. Currently, DYAD
-   relies on it only for **libfabric**, but we plan to fully leverage the diverse
-   options it provides in the near future.
+   **mochi-margo** enables seamless adoption of various DTL types. When installed
+   via spack, it supports **libfabric** by default, but not UCX. To enable UCX with
+   Margo, Mercury (on which Margo depends) must be built with UCX support enabled.
+   One way to achieve this is to use a Spack environment.
+
+   .. code-block:: bash
+
+      spack env create dyad_margo
+      spack env activate dyad_margo
+      spack add mercury +ofi +ucx +sm
+      spack add mochi-margo
+      spack concretize --force
+      spack install
 
    To enable a specific DTL type, DYAD requires the environment variable
    ``DYAD_DTL_MODE`` to be set accordingly. At present, three values are
@@ -172,6 +182,7 @@ There are several custom CMake options available to configure a DYAD build:
    - When built with ``DYAD_ENABLE_UCX_DATA=ON``, data transfer is synchronous
      using UCX. In other words, the choice between synchronous and RMA-based UCX
      is mutually exclusive at compile time.
+   - For details on choosing a network protocol with MARGO, see :doc:`runtime_configuration`.
 
    However, the selection between ``MARGO``, ``UCX``, and ``FLUX_RPC`` can be
    made dynamically at launch time. Ensure that ``DYAD_DTL_MODE`` is set

--- a/docs/runtime_configuration.rst
+++ b/docs/runtime_configuration.rst
@@ -6,61 +6,77 @@ At launch time, DYAD allows users to customize its behavior and make better use
 of the environment through various environment variables. The list of these 
 variables is shown below.
 
-+--------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
-| Name                           | Type            | Required?    | Default  | Description                                                     |
-+================================+=================+==============+==========+=================================================================+
-| :code:`DYAD_KVS_NAMESPACE`     | String          | Yes          | N/A      | The Flux KVS namespace that DYAD will use to record or look     |
-|                                |                 |              |          |                                                                 |
-|                                |                 |              |          | for file information                                            |
-+--------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
-| :code:`DYAD_PATH_PRODUCER`     | Directory Path  | Yes [#two]_  | N/A      | The producer-managed path of the application                    |
-+--------------------------------+                 +              +          +-----------------------------------------------------------------+
-| :code:`DYAD_PATH_CONSUMER`     |                 |              |          | The consumer-managed path of the application                    |
-+--------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
-| :code:`DYAD_DTL_MODE`          | String          | No           | FLUX_RPC | Choose data transfer method among MARGO, UCX, FLUX_RPC          |
-+--------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
-| :code:`DYAD_MARGO_PROTO`       | String [#thr]_  | No           | ofi\+tcp | Specify network protocol when :code:`DYAD_DTL_MODE=MARGO`       |
-+--------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
-| :code:`DYAD_PATH_RELATIVE`     | 0 or 1          | No           | 0        | The presence of this variable in the environment indicates that |
-|                                |                 |              |          |                                                                 |
-|                                |                 |              |          | DYAD treats relative paths as relative to the managed directory |
-+--------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
-| :code:`DYAD_SHARED_STORAGE`    | 0 or 1          | No           | 0        | 1: only per-file access synchronization for consumer            |
-|                                |                 |              |          |                                                                 |
-|                                |                 |              |          | but no transfer or the overhead associated with it              |
-+--------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
-| :code:`DYAD_ASYNC_PUBLISH`     | 0 or 1          | No           | 0        | Enable asynchronous metadata publishing by producers.           |
-+--------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
-| :code:`DYAD_SERVICE_MUX`       | integer >= 1    | No           | 1        | Number of Flux brokers sharing node-local storage.              |
-+--------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
-| :code:`DYAD_KEY_DEPTH` [#for]_ | Integer         | No           | 3        | The number of levels in Flux's hierarchical KVS to use          |
-|                                |                 |              |          |                                                                 |
-|                                |                 |              |          | within DYAD's namespace                                         |
-+--------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
-| :code:`DYAD_KEY_BINS` [#for]_  | Integer         | No           | 1024     | The maximum number of unique hash values per level in Flux’s    |
-|                                |                 |              |          |                                                                 |
-|                                |                 |              |          | hierarchical KVS within DYAD’s namespace.                       |
-+--------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
++------------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
+| Name                               | Type            | Required?    | Default  | Description                                                     |
++====================================+=================+==============+==========+=================================================================+
+| :code:`DYAD_KVS_NAMESPACE`         | String          | Yes          | N/A      | The Flux KVS namespace that DYAD will use to record or look     |
+|                                    |                 |              |          |                                                                 |
+|                                    |                 |              |          | for file information                                            |
++------------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
+| :code:`DYAD_PATH_PRODUCER`         | Directory Path  | Yes [#two]_  | N/A      | The producer-managed path of the application                    |
++------------------------------------+                 +              +          +-----------------------------------------------------------------+
+| :code:`DYAD_PATH_CONSUMER`         |                 |              |          | The consumer-managed path of the application                    |
++------------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
+| :code:`DYAD_DTL_MODE`              | String          | No           | FLUX_RPC | Choose data transfer method among MARGO, UCX, FLUX_RPC          |
++------------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
+| :code:`DYAD_MARGO_PROTO` [#thr]_   | String          | No           | ofi\+tcp | Specify network protocol when :code:`DYAD_DTL_MODE=MARGO`       |
++------------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
+| :code:`DYAD_PATH_RELATIVE`         | 0 or 1          | No           | 0        | The presence of this variable in the environment indicates that |
+|                                    |                 |              |          |                                                                 |
+|                                    |                 |              |          | DYAD treats relative paths as relative to the managed directory |
++------------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
+| :code:`DYAD_SHARED_STORAGE`        | 0 or 1          | No           | 0        | 1: only per-file access synchronization for consumer            |
+|                                    |                 |              |          |                                                                 |
+|                                    |                 |              |          | but no transfer or the overhead associated with it              |
++------------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
+| :code:`DYAD_ASYNC_PUBLISH`         | 0 or 1          | No           | 0        | Enable asynchronous metadata publishing by producers.           |
++------------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
+| :code:`DYAD_SERVICE_MUX`           | integer >= 1    | No           | 1        | Number of Flux brokers sharing node-local storage.              |
++------------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
+| :code:`DYAD_KEY_DEPTH` [#for]_     | Integer         | No           | 3        | The number of levels in Flux's hierarchical KVS to use          |
+|                                    |                 |              |          |                                                                 |
+|                                    |                 |              |          | within DYAD's namespace                                         |
++------------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
+| :code:`DYAD_KEY_BINS` [#for]_      | Integer         | No           | 1024     | The maximum number of unique hash values per level in Flux's    |
+|                                    |                 |              |          |                                                                 |
+|                                    |                 |              |          | hierarchical KVS within DYAD's namespace.                       |
++------------------------------------+-----------------+--------------+----------+-----------------------------------------------------------------+
 
 .. [#two] For DYAD to do anything, at least one of :code:`DYAD_PATH_PRODUCER` or :code:`DYAD_PATH_CONSUMER` must be provided.
    Applications will still work if neither are provided, but DYAD will not do anything.
 
-.. [#thr] When built with the cmake option :code:`DYAD_ENABLE_MARGO_DATA=ON` and run with the env variable :code:`DYAD_DTL_MODE=MARGO`, :code:`DYAD_MARGO_PROTO` specifies the network protocol.
-   Example values include:
-
-   .. code-block:: none
-      ofi+tcp     – portable TCP/IP via libfabric (default)
-      ofi+verbs   – InfiniBand via libfabric
-      ofi+cxi     – HPE Slingshot (Cray EX) via libfabric
-      sm          – shared memory (single-node testing)
-      na+sm       – shared memory (newer Margo)
-      ucx         - auto (all);              let UCX pick, safe default for ucx
-      ucx+tcp     - TCP/IP;                  portable, works everywhere
-      ucx+rc_v    - InfiniBand RC (verbs);   low-latency IB
-      ucx+rc_mlx5 - InfiniBand RC (mlx5 optimized); Mellanox HCAs
-      ucx+ud_v    - InfiniBand UD (verbs);   scalable IB, less reliability overhead
-      ucx+dc_mlx5 - InfiniBand DC (mlx5);    large-scale IB (Frontier, Sierra)
-      ucx+cma     - Cross-Memory Attach;     intra-node shared memory (Linux)
-      ucx+sysv    - SysV shared memory;      intra-node only
+.. [#thr] When built with the cmake option :code:`DYAD_ENABLE_MARGO_DATA=ON` and run
+   with the env variable :code:`DYAD_DTL_MODE=MARGO`, :code:`DYAD_MARGO_PROTO`
+   specifies the network protocol. See the table below for example values.
 
 .. [#for] The Flux KVS supports organized categorization of data through hierarchical `key structuring <https://flux-framework.readthedocs.io/projects/flux-core/en/latest/man1/flux-kvs.html>`_. DYAD leverages this capability to optimize hash lookup performance by increasing the likelihood of early search termination when no matching entry exists in the store. The search key is hashed across multiple levels using different seeds. A match is confirmed only if corresponding entries are found at all levels, with an exact key-string match at the final level.
+
+**Examples of valid values for DYAD_MARGO_PROTO:**
+
++---------------------+--------------------------------------------------------+
+| Value               | Description                                            |
++=====================+========================================================+
+| ``ofi+tcp``         | Portable TCP/IP via libfabric (default)                |
++---------------------+--------------------------------------------------------+
+| ``ofi+verbs``       | InfiniBand via libfabric                               |
++---------------------+--------------------------------------------------------+
+| ``ofi+cxi``         | HPE Slingshot (Cray EX) via libfabric                  |
++---------------------+--------------------------------------------------------+
+| ``na+sm``           | Shared memory (current Margo; use ``sm`` for older)    |
++---------------------+--------------------------------------------------------+
+| ``ucx``             | Auto; let UCX pick, safe default                       |
++---------------------+--------------------------------------------------------+
+| ``ucx+tcp``         | TCP/IP, portable                                       |
++---------------------+--------------------------------------------------------+
+| ``ucx+rc_v``        | InfiniBand RC (verbs), low-latency IB                  |
++---------------------+--------------------------------------------------------+
+| ``ucx+rc_mlx5``     | InfiniBand RC (mlx5), Mellanox HCAs                    |
++---------------------+--------------------------------------------------------+
+| ``ucx+ud_v``        | InfiniBand UD (verbs), scalable IB                     |
++---------------------+--------------------------------------------------------+
+| ``ucx+dc_mlx5``     | InfiniBand DC (mlx5), large-scale IB (Frontier, Sierra)|
++---------------------+--------------------------------------------------------+
+| ``ucx+cma``         | Cross-Memory Attach, intra-node shared memory (Linux)  |
++---------------------+--------------------------------------------------------+
+| ``ucx+sysv``        | SysV shared memory, intra-node only                    |
++---------------------+--------------------------------------------------------+

--- a/pydyad/setup.cfg
+++ b/pydyad/setup.cfg
@@ -9,4 +9,5 @@ python_requires = >=3.7
 install_requires =
     numpy
     h5py
+    typing-extensions
     dftracer==2.0.2


### PR DESCRIPTION
- Fixed RST documentation on `DYAD_MARGO_PROTO` examples.
- Added dftracer's silent dependency on `typing-extensions` to pydyad requirements
- Updated a tutorial example to add stdout and stderr redirection for jobs.