### PR TITLE
Make dftracer an optional dependency in pydyad

### DIFF
--- a/.github/workflows/compile_test.yaml
+++ b/.github/workflows/compile_test.yaml
@@ -78,7 +78,7 @@ jobs:
                               sqlite3
           pip3 --version && python3 --version
           gcc --version
-          sudo pip3 install jsonschema cffi ply pyyaml
+          sudo pip3 install jsonschema cffi ply pyyaml numpy
           sudo chmod 777 /usr -R
       - name: Install Spack
         run: |

--- a/pydyad/pydyad/bindings.py
+++ b/pydyad/pydyad/bindings.py
@@ -3,9 +3,18 @@ from ctypes.util import find_library
 import enum
 from pathlib import Path
 import warnings
-from dftracer.python import dftracer, dft_fn
-
-dft_log = dft_fn("DYAD_PY")
+try:
+    from dftracer.python import dftracer, dft_fn
+    dft_log = dft_fn("DYAD_PY")
+except ImportError:
+    class _NoopLog:
+        def log(self, fn):
+            return fn
+    class _NoopDftracer:
+        def initialize_log(self, **kwargs):
+            return None
+    dftracer = _NoopDftracer()
+    dft_log = _NoopLog()
 
 DYAD_LIB_DIR = None
 

--- a/pydyad/pydyad/context.py
+++ b/pydyad/pydyad/context.py
@@ -4,8 +4,14 @@ from contextlib import contextmanager
 import io
 from pathlib import Path
 
-from dftracer.python import dft_fn 
-dft_log = dft_fn("DYAD_PY")
+try:
+    from dftracer.python import dft_fn
+    dft_log = dft_fn("DYAD_PY")
+except ImportError:
+    class _NoopLog:
+        def log(self, fn):
+            return fn
+    dft_log = _NoopLog()
 DYAD_IO = None
 
 


### PR DESCRIPTION
dftracer is a profiling library that may not be installed in all environments. Wrap the import in a try/except in both bindings.py and context.py and provide no-op stubs so pydyad works without it.