### PR TITLE
Doc: exclude venv in case that it is located under docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,9 @@ libltdl/
 /config/lt~obsolete.m4
 
 # docs intermediate files
-/doc/man*/*.xml
-/doc/_build
+/docs/man*/*.xml
+/docs/_build
+/docs/doxygen
 
 # Object files
 *.o
@@ -123,6 +124,10 @@ docs/demos/ecp_feb_2023/c_cons
 docs/demos/ecp_feb_2023/cpp_cons
 docs/demos/ecp_feb_2023/c_prod
 docs/demos/ecp_feb_2023/cpp_prod
+docs/demos/SCA26/c_cons
+docs/demos/SCA26/cpp_cons
+docs/demos/SCA26/c_prod
+docs/demos/SCA26/cpp_prod
 tests/integration/dlio_benchmark/logs
 scripts/checkpoints
 scripts/logs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,10 +10,11 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-    # You can also specify other tool versions:
-    # nodejs: "19"
-    # rust: "1.64"
-    # golang: "1.19"
+  apt_packages:
+    - doxygen
+  jobs:
+    pre_build:
+      - cd docs && doxygen Doxyfile
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/docs/api/stream.rst
+++ b/docs/api/stream.rst
@@ -15,10 +15,10 @@ Input stream
    :project: dyad
    :members:
 
-.. doxygentypedef:: ifstream_dyad
+.. doxygentypedef:: dyad::ifstream_dyad
    :project: dyad
 
-.. doxygentypedef:: wifstream_dyad
+.. doxygentypedef:: dyad::wifstream_dyad
    :project: dyad
 
 Output stream
@@ -28,10 +28,10 @@ Output stream
    :project: dyad
    :members:
 
-.. doxygentypedef:: ofstream_dyad
+.. doxygentypedef:: dyad::ofstream_dyad
    :project: dyad
 
-.. doxygentypedef:: wofstream_dyad
+.. doxygentypedef:: dyad::wofstream_dyad
    :project: dyad
 
 Bidirectional stream
@@ -41,8 +41,8 @@ Bidirectional stream
    :project: dyad
    :members:
 
-.. doxygentypedef:: fstream_dyad
+.. doxygentypedef:: dyad::fstream_dyad
    :project: dyad
 
-.. doxygentypedef:: wfstream_dyad
+.. doxygentypedef:: dyad::wfstream_dyad
    :project: dyad

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', '_fragments', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', '_fragments', 'Thumbs.db', '.DS_Store', 'venv', '.venv']
 
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
Let sphinx ignore `venv` or `.venv` folders under `docs` in case that user puts it under there.