### PR TITLE
Doc: add rst control to render blocked logo table on readthedoc

### DIFF
--- a/docs/docutils.conf
+++ b/docs/docutils.conf
@@ -1,0 +1,3 @@
+[restructuredtext parser]
+raw_enabled: 1
+file_insertion_enabled: 1


### PR DESCRIPTION
readthedoc seems to block raw html used to draw logo table regardless of configurations set in conf.py
ReadTheDocs controls raw_enabled at the docutils level, not the Sphinx level. So, `docutils.rst` added.